### PR TITLE
Deps exclusions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3066,6 +3066,10 @@
         <artifactId>shindig-gadgets</artifactId>
         <version>${shindig.version}</version>
         <exclusions>
+          <exclusion>
+            <groupId>com.google.code.guice</groupId>
+            <artifactId>guice</artifactId>
+          </exclusion>
           <!-- exclude bad versions 1.O.b2 -->
           <exclusion>
             <groupId>xml-apis</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -2158,6 +2158,12 @@
         <groupId>com.sun.xsom</groupId>
         <artifactId>xsom</artifactId>
         <version>20081112</version>
+        <exclusions>
+          <exclusion>
+            <groupId>relaxngDatatype</groupId>
+            <artifactId>relaxngDatatype</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
       <dependency>
         <groupId>com.sun.xml</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -3147,6 +3147,10 @@
             <groupId>com.google.code.guice</groupId>
             <artifactId>guice</artifactId>
           </exclusion>
+          <exclusion>
+            <groupId>xpp3</groupId>
+            <artifactId>xpp3_min</artifactId>
+          </exclusion>
         </exclusions>
       </dependency>
       <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -2496,6 +2496,17 @@
         <groupId>com.thoughtworks.xstream</groupId>
         <artifactId>xstream</artifactId>
         <version>1.3.1</version>
+        <exclusions>
+          <exclusion>
+            <groupId>xpp3</groupId>
+            <artifactId>xpp3_min</artifactId>
+          </exclusion> 
+        </exclusions>
+      </dependency>
+      <dependency>
+        <groupId>xpp3</groupId>
+        <artifactId>xpp3</artifactId>
+        <version>1.1.4c</version>
       </dependency>
       <dependency>
         <groupId>cglib</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -2082,11 +2082,23 @@
         <groupId>net.sf.jxls</groupId>
         <artifactId>jxls-core</artifactId>
         <version>${jxls.version}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-jexl</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
       <dependency>
         <groupId>net.sf.jxls</groupId>
         <artifactId>jxls-reader</artifactId>
         <version>${jxls.version}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-jexl</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
 
       <!-- docx report -->


### PR DESCRIPTION
This cleans up the dependency tree by excluding some dependencies with different versions.
See: https://jira.nuxeo.com/browse/TA-34