### PR TITLE
Fix refresh for publishingInfoList

### DIFF
--- a/nuxeo-features/nuxeo-platform-publisher/nuxeo-platform-publisher-web/src/main/resources/web/nuxeo.war/incl/tabs/document_publish_template.xhtml
+++ b/nuxeo-features/nuxeo-platform-publisher/nuxeo-platform-publisher-web/src/main/resources/web/nuxeo.war/incl/tabs/document_publish_template.xhtml
@@ -91,7 +91,7 @@
       <a4j:outputPanel id="publishingInfoList" layout="block">
 
         <nxu:dataTable value="#{publishedDocuments}"
-          rendered="#{publishActions.currentPublicationTreeForPublishing != null and !empty publishedDocuments}"
+          rendered="#{publishActions.currentPublicationTreeForPublishing != null and !empty publishActions.publishedDocuments}"
           var="publishedDocument" preserveSort="true"
           preserveDataModel="false" rowClasses="dataRowEven,dataRowOdd"
           sortable="false" styleClass="dataList">


### PR DESCRIPTION
Tested on 5.8-HF31

Explanation: The "a4j: outputPanel" with id "publishingInfoList" does not refresh when you would select a publicationTree
