### PR TITLE
Fix NXP-17813 configuration service

### DIFF
--- a/nuxeo-common/src/main/java/org/nuxeo/common/utils/DefaultProperties.java
+++ b/nuxeo-common/src/main/java/org/nuxeo/common/utils/DefaultProperties.java
@@ -1,0 +1,66 @@
+/*
+ * (C) Copyright 2015 Nuxeo SA (http://nuxeo.com/) and contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Contributors:
+ *     jcarsique
+ */
+package org.nuxeo.common.utils;
+
+import java.util.Properties;
+
+/**
+ * At the opposite of {@link Properties} which defaults to its "parent", this class provides default values overridden
+ * by its "parent" values which take precedence.
+ * <p>
+ * {@code new DefaultProperties(System.getProperties())} will return System values at first and fallback on its own
+ * values.
+ *
+ * @since 7.4
+ */
+public class DefaultProperties extends Properties {
+
+    private static final long serialVersionUID = 1L;
+
+    /**
+     * Creates an empty property list with no default values.
+     */
+    public DefaultProperties() {
+        this(null);
+    }
+
+    /**
+     * Creates an empty property list with the specified defaults.
+     *
+     * @param defaults the defaults.
+     */
+    public DefaultProperties(Properties defaults) {
+        this.defaults = defaults;
+    }
+
+    @Override
+    public String getProperty(String key) {
+        Object oval = super.get(key);
+        String sval = (oval instanceof String) ? (String) oval : null;
+        String dval = defaults != null ? defaults.getProperty(key) : null;
+        return (dval != null ? dval : sval);
+    }
+
+    @Override
+    public String getProperty(String key, String defaultValue) {
+        String val = getProperty(key);
+        return (val == null) ? defaultValue : val;
+    }
+
+}

--- a/nuxeo-core/nuxeo-core-api/src/main/java/org/nuxeo/ecm/core/api/pathsegment/PathSegmentServiceCompat.java
+++ b/nuxeo-core/nuxeo-core-api/src/main/java/org/nuxeo/ecm/core/api/pathsegment/PathSegmentServiceCompat.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2006-2011 Nuxeo SA (http://nuxeo.com/) and others.
+ * Copyright (c) 2006-2015 Nuxeo SA (http://nuxeo.com/) and others.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/nuxeo-core/nuxeo-core-api/src/main/java/org/nuxeo/ecm/core/api/pathsegment/PathSegmentServiceCompat.java
+++ b/nuxeo-core/nuxeo-core-api/src/main/java/org/nuxeo/ecm/core/api/pathsegment/PathSegmentServiceCompat.java
@@ -14,7 +14,6 @@ package org.nuxeo.ecm.core.api.pathsegment;
 import org.nuxeo.common.utils.IdUtils;
 import org.nuxeo.ecm.core.api.DocumentModel;
 import org.nuxeo.runtime.api.Framework;
-import org.nuxeo.runtime.services.config.ConfigurationService;
 
 /**
  * Service generating a path segment from the title by simplifying it to lowercase and dash-separated words.
@@ -33,8 +32,7 @@ public class PathSegmentServiceCompat implements PathSegmentService {
 
     @Override
     public int getMaxSize() {
-        ConfigurationService cs = Framework.getService(ConfigurationService.class);
-        return Integer.parseInt(cs.getProperty(PathSegmentService.NUXEO_MAX_SEGMENT_SIZE_PROPERTY, "24"));
+        return Integer.parseInt(Framework.getProperty(PathSegmentService.NUXEO_MAX_SEGMENT_SIZE_PROPERTY, "24"));
     }
 
 }

--- a/nuxeo-core/nuxeo-core-api/src/main/java/org/nuxeo/ecm/core/api/pathsegment/PathSegmentServiceDefault.java
+++ b/nuxeo-core/nuxeo-core-api/src/main/java/org/nuxeo/ecm/core/api/pathsegment/PathSegmentServiceDefault.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2006-2011 Nuxeo SA (http://nuxeo.com/) and others.
+ * Copyright (c) 2006-2015 Nuxeo SA (http://nuxeo.com/) and others.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -28,6 +28,7 @@ public class PathSegmentServiceDefault implements PathSegmentService {
     /**
      * @deprecated since 7.4, use {@link PathSegmentService#NUXEO_MAX_SEGMENT_SIZE_PROPERTY} instead
      */
+    @Deprecated
     public static final String NUXEO_MAX_SEGMENT_SIZE_PROPERTY = PathSegmentService.NUXEO_MAX_SEGMENT_SIZE_PROPERTY;
 
     @Override

--- a/nuxeo-core/nuxeo-core-api/src/main/java/org/nuxeo/ecm/core/api/pathsegment/PathSegmentServiceDefault.java
+++ b/nuxeo-core/nuxeo-core-api/src/main/java/org/nuxeo/ecm/core/api/pathsegment/PathSegmentServiceDefault.java
@@ -16,7 +16,6 @@ import java.util.regex.Pattern;
 import org.nuxeo.common.utils.IdUtils;
 import org.nuxeo.ecm.core.api.DocumentModel;
 import org.nuxeo.runtime.api.Framework;
-import org.nuxeo.runtime.services.config.ConfigurationService;
 
 /**
  * Service generating a path segment from the title by just removing slashes and limiting size.
@@ -55,8 +54,7 @@ public class PathSegmentServiceDefault implements PathSegmentService {
 
     @Override
     public int getMaxSize() {
-        ConfigurationService cs = Framework.getService(ConfigurationService.class);
-        return Integer.parseInt(cs.getProperty(PathSegmentService.NUXEO_MAX_SEGMENT_SIZE_PROPERTY, "24"));
+        return Integer.parseInt(Framework.getProperty(PathSegmentService.NUXEO_MAX_SEGMENT_SIZE_PROPERTY, "24"));
     }
 
 }

--- a/nuxeo-features/annot/nuxeo-annot-gwt/src/main/java/org/nuxeo/ecm/platform/annotations/jsf/component/AnnotationsActions.java
+++ b/nuxeo-features/annot/nuxeo-annot-gwt/src/main/java/org/nuxeo/ecm/platform/annotations/jsf/component/AnnotationsActions.java
@@ -42,7 +42,6 @@ import org.nuxeo.ecm.platform.url.api.DocumentView;
 import org.nuxeo.ecm.platform.url.api.DocumentViewCodecManager;
 import org.nuxeo.ecm.platform.web.common.vh.VirtualHostHelper;
 import org.nuxeo.runtime.api.Framework;
-import org.nuxeo.runtime.services.config.ConfigurationService;
 
 /**
  * Handles Annotations related web actions.
@@ -88,8 +87,7 @@ public class AnnotationsActions implements Serializable {
     }
 
     protected boolean isTextAnnotationsEnabled() {
-        ConfigurationService cs = Framework.getService(ConfigurationService.class);
-        return cs.isBooleanPropertyTrue(TEXT_ANNOTATIONS_KEY);
+        return Framework.isBooleanPropertyTrue(TEXT_ANNOTATIONS_KEY);
     }
 
 }

--- a/nuxeo-features/annot/nuxeo-annot-gwt/src/main/java/org/nuxeo/ecm/platform/annotations/jsf/component/AnnotationsActions.java
+++ b/nuxeo-features/annot/nuxeo-annot-gwt/src/main/java/org/nuxeo/ecm/platform/annotations/jsf/component/AnnotationsActions.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright 2013 Nuxeo SA (http://nuxeo.com/) and contributors.
+ * (C) Copyright 2013-2015 Nuxeo SA (http://nuxeo.com/) and contributors.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser General Public License
@@ -27,8 +27,6 @@ import java.security.Principal;
 import javax.faces.context.FacesContext;
 import javax.servlet.http.HttpServletRequest;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import org.jboss.seam.annotations.In;
 import org.jboss.seam.annotations.Install;
 import org.jboss.seam.annotations.Name;
@@ -58,8 +56,6 @@ import org.nuxeo.runtime.services.config.ConfigurationService;
 public class AnnotationsActions implements Serializable {
 
     private static final long serialVersionUID = 1L;
-
-    private static final Log log = LogFactory.getLog(AnnotationsActions.class);
 
     public static final String TEXT_ANNOTATIONS_KEY = "nuxeo.text.annotations";
 

--- a/nuxeo-features/nuxeo-admin-center/nuxeo-admin-center/src/main/java/org/nuxeo/connect/client/jsf/AppCenterViewsManager.java
+++ b/nuxeo-features/nuxeo-admin-center/nuxeo-admin-center/src/main/java/org/nuxeo/connect/client/jsf/AppCenterViewsManager.java
@@ -71,7 +71,6 @@ import org.nuxeo.ecm.webapp.seam.NuxeoSeamHotReloadContextKeeper;
 import org.nuxeo.launcher.config.ConfigurationException;
 import org.nuxeo.launcher.config.ConfigurationGenerator;
 import org.nuxeo.runtime.api.Framework;
-import org.nuxeo.runtime.services.config.ConfigurationService;
 
 /**
  * Manages JSF views for Package Management.
@@ -268,8 +267,7 @@ public class AppCenterViewsManager implements Serializable {
      * @since 5.7.1
      */
     protected boolean shouldValidateStudioSnapshot() {
-        ConfigurationService cs = Framework.getService(ConfigurationService.class);
-        if (cs.isBooleanPropertyTrue("studio.snapshot.disablePkgValidation")) {
+        if (Framework.isBooleanPropertyTrue("studio.snapshot.disablePkgValidation")) {
             return false;
         }
         return Boolean.TRUE.equals(getValidateStudioSnapshot());

--- a/nuxeo-features/nuxeo-platform-ui-select2/src/main/java/org/nuxeo/ecm/platform/ui/select2/common/Select2Common.java
+++ b/nuxeo-features/nuxeo-platform-ui-select2/src/main/java/org/nuxeo/ecm/platform/ui/select2/common/Select2Common.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright 2013 Nuxeo SA (http://nuxeo.com/) and contributors.
+ * (C) Copyright 2013-2015 Nuxeo SA (http://nuxeo.com/) and contributors.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser General Public License
@@ -62,10 +62,10 @@ public class Select2Common {
 
     public static final String OBSOLETE_FIELD_ID = "obsolete";
 
-    public static final List<String> SELECT2_USER_WIDGET_TYPE_LIST = new ArrayList<String>(Arrays.asList(
+    public static final List<String> SELECT2_USER_WIDGET_TYPE_LIST = new ArrayList<>(Arrays.asList(
             "singleUserSuggestion", "multipleUsersSuggestion"));
 
-    public static final List<String> SELECT2_DOC_WIDGET_TYPE_LIST = new ArrayList<String>(Arrays.asList(
+    public static final List<String> SELECT2_DOC_WIDGET_TYPE_LIST = new ArrayList<>(Arrays.asList(
             "singleDocumentSuggestion", "multipleDocumentsSuggestion"));
 
     public static final String USER_TYPE = "USER_TYPE";
@@ -86,11 +86,11 @@ public class Select2Common {
 
     public static final String WARN_MESSAGE_LABEL = "warn_message";
 
-    public static final List<String> SELECT2_DIR_WIDGET_TYPE_LIST = new ArrayList<String>(Arrays.asList(
+    public static final List<String> SELECT2_DIR_WIDGET_TYPE_LIST = new ArrayList<>(Arrays.asList(
             "suggestOneDirectory", "suggestManyDirectory"));
 
-    public static final List<String> SELECT2_DEFAULT_DOCUMENT_SCHEMAS = new ArrayList<String>(Arrays.asList(
-            "dublincore", "common"));
+    public static final List<String> SELECT2_DEFAULT_DOCUMENT_SCHEMAS = new ArrayList<>(Arrays.asList("dublincore",
+            "common"));
 
     public static final String DIR_DEFAULT_SUGGESTION_FORMATTER = "dirEntryDefaultFormatter";
 
@@ -230,7 +230,7 @@ public class Select2Common {
      * @since 5.8
      */
     public static String[] getSchemas(final String schemaNames) {
-        List<String> result = new ArrayList<String>();
+        List<String> result = new ArrayList<>();
         result.addAll(Select2Common.SELECT2_DEFAULT_DOCUMENT_SCHEMAS);
         String[] temp = null;
         if (schemaNames != null && !schemaNames.isEmpty()) {

--- a/nuxeo-features/nuxeo-platform-ui-select2/src/main/java/org/nuxeo/ecm/platform/ui/select2/common/Select2Common.java
+++ b/nuxeo-features/nuxeo-platform-ui-select2/src/main/java/org/nuxeo/ecm/platform/ui/select2/common/Select2Common.java
@@ -29,7 +29,6 @@ import org.apache.commons.logging.LogFactory;
 import org.nuxeo.ecm.core.schema.types.Schema;
 import org.nuxeo.ecm.platform.usermanager.UserConfig;
 import org.nuxeo.runtime.api.Framework;
-import org.nuxeo.runtime.services.config.ConfigurationService;
 
 /**
  * Group fields and methods used at initialization and runtime for select2 feature.
@@ -130,8 +129,7 @@ public class Select2Common {
 
     private static boolean isForceDisplayEmailInSuggestion() {
         if (forceDisplayEmailInSuggestion == null) {
-            ConfigurationService cs = Framework.getService(ConfigurationService.class);
-            forceDisplayEmailInSuggestion = cs.isBooleanPropertyTrue(FORCE_DISPLAY_EMAIL_IN_SUGGESTION);
+            forceDisplayEmailInSuggestion = Framework.isBooleanPropertyTrue(FORCE_DISPLAY_EMAIL_IN_SUGGESTION);
         }
         return forceDisplayEmailInSuggestion;
     }

--- a/nuxeo-jsf/nuxeo-platform-forms-layout-client/src/main/java/org/nuxeo/ecm/platform/forms/layout/facelets/plugins/ListWidgetTypeHandler.java
+++ b/nuxeo-jsf/nuxeo-platform-forms-layout-client/src/main/java/org/nuxeo/ecm/platform/forms/layout/facelets/plugins/ListWidgetTypeHandler.java
@@ -20,7 +20,6 @@ package org.nuxeo.ecm.platform.forms.layout.facelets.plugins;
 
 import org.nuxeo.ecm.platform.forms.layout.api.Widget;
 import org.nuxeo.runtime.api.Framework;
-import org.nuxeo.runtime.services.config.ConfigurationService;
 
 /**
  * List widget type, using a fixed template.
@@ -35,8 +34,7 @@ public class ListWidgetTypeHandler extends TemplateWidgetTypeHandler {
 
     @Override
     protected String getTemplateValue(Widget widget) {
-        ConfigurationService configurationService = Framework.getService(ConfigurationService.class);
-        boolean useCompat = configurationService.isBooleanPropertyTrue("nuxeo.jsf.listWidget.compatEnabled");
+        boolean useCompat = Framework.isBooleanPropertyTrue("nuxeo.jsf.listWidget.compatEnabled");
         if (useCompat) {
             return lookupProperty(COMPAT_TEMPLATE_PROPERTY_NAME, widget);
         } else {

--- a/nuxeo-jsf/nuxeo-platform-forms-layout-client/src/main/java/org/nuxeo/ecm/platform/forms/layout/facelets/plugins/ListWidgetTypeHandler.java
+++ b/nuxeo-jsf/nuxeo-platform-forms-layout-client/src/main/java/org/nuxeo/ecm/platform/forms/layout/facelets/plugins/ListWidgetTypeHandler.java
@@ -1,10 +1,10 @@
 /*
- * (C) Copyright 2006-2007 Nuxeo SAS (http://nuxeo.com/) and contributors.
+ * (C) Copyright 2006-2015 Nuxeo SA (http://nuxeo.com/) and contributors.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser General Public License
  * (LGPL) version 2.1 which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/lgpl.html
+ * http://www.gnu.org/licenses/lgpl-2.1.html
  *
  * This library is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
@@ -14,7 +14,6 @@
  * Contributors:
  *     <a href="mailto:at@nuxeo.com">Anahide Tchertchian</a>
  *
- * $Id: ListWidgetTypeHandler.java 26053 2007-10-16 01:45:43Z atchertchian $
  */
 
 package org.nuxeo.ecm.platform.forms.layout.facelets.plugins;

--- a/nuxeo-jsf/nuxeo-platform-ui-web/src/main/java/org/nuxeo/ecm/platform/ui/web/binding/alias/AliasTagHandler.java
+++ b/nuxeo-jsf/nuxeo-platform-ui-web/src/main/java/org/nuxeo/ecm/platform/ui/web/binding/alias/AliasTagHandler.java
@@ -39,8 +39,6 @@ import javax.faces.view.facelets.TagAttribute;
 import javax.faces.view.facelets.TagException;
 
 import org.nuxeo.runtime.api.Framework;
-import org.nuxeo.runtime.services.config.ConfigurationService;
-
 import com.sun.faces.facelets.tag.jsf.ComponentSupport;
 
 /**
@@ -131,8 +129,7 @@ public class AliasTagHandler extends ComponentHandler {
 
     protected void apply(FaceletContext ctx, UIComponent parent, AliasVariableMapper alias, FaceletHandler nextHandler)
             throws IOException, FacesException, FaceletException, ELException {
-        ConfigurationService configurationService = Framework.getService(ConfigurationService.class);
-        if (configurationService.isBooleanPropertyTrue("nuxeo.jsf.removeAliasOptims")) {
+        if (Framework.isBooleanPropertyTrue("nuxeo.jsf.removeAliasOptims")) {
             applyCompat(ctx, parent, alias, nextHandler);
             return;
         }

--- a/nuxeo-jsf/nuxeo-platform-ui-web/src/main/java/org/nuxeo/ecm/platform/ui/web/binding/alias/AliasTagHandler.java
+++ b/nuxeo-jsf/nuxeo-platform-ui-web/src/main/java/org/nuxeo/ecm/platform/ui/web/binding/alias/AliasTagHandler.java
@@ -1,10 +1,10 @@
 /*
- * (C) Copyright 2010 Nuxeo SAS (http://nuxeo.com/) and contributors.
+ * (C) Copyright 2010-2015 Nuxeo SA (http://nuxeo.com/) and contributors.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser General Public License
  * (LGPL) version 2.1 which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/lgpl.html
+ * http://www.gnu.org/licenses/lgpl-2.1.html
  *
  * This library is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
@@ -14,7 +14,6 @@
  * Contributors:
  *     Nuxeo - initial API and implementation
  *
- * $Id: $
  */
 
 package org.nuxeo.ecm.platform.ui.web.binding.alias;
@@ -117,8 +116,8 @@ public class AliasTagHandler extends ComponentHandler {
                 if (cacheValue) {
                     // resolve value and put it as is in variables
                     Object res = var.getValue().getValue(ctx);
-                    target.setVariable(var.getKey(),
-                            ctx.getExpressionFactory().createValueExpression(res, Object.class));
+                    target.setVariable(var.getKey(), ctx.getExpressionFactory()
+                                                        .createValueExpression(res, Object.class));
                 } else {
                     target.setVariable(var.getKey(), var.getValue());
                 }

--- a/nuxeo-jsf/nuxeo-platform-ui-web/src/main/java/org/nuxeo/ecm/platform/ui/web/tag/fn/Functions.java
+++ b/nuxeo-jsf/nuxeo-platform-ui-web/src/main/java/org/nuxeo/ecm/platform/ui/web/tag/fn/Functions.java
@@ -1,10 +1,10 @@
 /*
- * (C) Copyright 2007-2008 Nuxeo SAS (http://nuxeo.com/) and contributors.
+ * (C) Copyright 2007-2015 Nuxeo SA (http://nuxeo.com/) and contributors.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser General Public License
  * (LGPL) version 2.1 which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/lgpl.html
+ * http://www.gnu.org/licenses/lgpl-2.1.html
  *
  * This library is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
@@ -14,7 +14,6 @@
  * Contributors:
  *     Nuxeo - initial API and implementation
  *
- * $Id: Functions.java 28572 2008-01-08 14:40:44Z fguillaume $
  */
 
 package org.nuxeo.ecm.platform.ui.web.tag.fn;
@@ -185,7 +184,7 @@ public final class Functions {
         }
         StringBuffer result = new StringBuffer();
         result.append(StringUtils.join(collection, separator));
-        if (collection != null && collection.length > 0 && !StringUtils.isBlank(finalSeparator)) {
+        if (collection.length > 0 && !StringUtils.isBlank(finalSeparator)) {
             result.append(finalSeparator);
         }
         return result.toString();
@@ -315,7 +314,7 @@ public final class Functions {
     }
 
     /**
-     * @deprecated since 5.9.1, use {@link #dateFormatter()} instead.
+     * @deprecated since 5.9.1, use {@link #dateFormatter(String)} instead.
      */
     @Deprecated
     public static String dateFormater(String formatLength) {
@@ -497,7 +496,7 @@ public final class Functions {
     public static String printFormattedDuration(Object durationObj, Map<String, String> i18nLabels) {
 
         if (i18nLabels == null) {
-            i18nLabels = new HashMap<String, String>();
+            i18nLabels = new HashMap<>();
         }
         double duration = 0.0;
         if (durationObj instanceof Float) {
@@ -631,7 +630,7 @@ public final class Functions {
 
     public static String userUrl(String patternName, String username, String viewId, boolean newConversation,
             HttpServletRequest req) {
-        Map<String, String> parameters = new HashMap<String, String>();
+        Map<String, String> parameters = new HashMap<>();
         parameters.put("username", username);
         DocumentView docView = new DocumentViewImpl(null, viewId, parameters);
 
@@ -659,7 +658,7 @@ public final class Functions {
     }
 
     public static List<Object> combineLists(List<? extends Object>... lists) {
-        List<Object> combined = new ArrayList<Object>();
+        List<Object> combined = new ArrayList<>();
         for (List<? extends Object> list : lists) {
             combined.addAll(list);
         }

--- a/nuxeo-jsf/nuxeo-platform-ui-web/src/main/java/org/nuxeo/ecm/platform/ui/web/tag/fn/Functions.java
+++ b/nuxeo-jsf/nuxeo-platform-ui-web/src/main/java/org/nuxeo/ecm/platform/ui/web/tag/fn/Functions.java
@@ -51,7 +51,6 @@ import org.nuxeo.ecm.platform.url.DocumentViewImpl;
 import org.nuxeo.ecm.platform.url.api.DocumentView;
 import org.nuxeo.ecm.platform.usermanager.UserManager;
 import org.nuxeo.runtime.api.Framework;
-import org.nuxeo.runtime.services.config.ConfigurationService;
 
 /**
  * Util functions.
@@ -441,9 +440,7 @@ public final class Functions {
      * @since 7.4
      */
     public static BytePrefix getDefaultBytePrefix() {
-        ConfigurationService configurationService = Framework.getService(ConfigurationService.class);
-        return BytePrefix.valueOf(
-                configurationService.getProperty(BYTE_PREFIX_FORMAT_PROPERTY, DEFAULT_BYTE_PREFIX_FORMAT));
+        return BytePrefix.valueOf(Framework.getProperty(BYTE_PREFIX_FORMAT_PROPERTY, DEFAULT_BYTE_PREFIX_FORMAT));
     }
 
     public static String printFileSize(String size) {

--- a/nuxeo-jsf/nuxeo-platform-ui-web/src/main/java/org/nuxeo/ecm/platformui/web/form/NxFormRenderer.java
+++ b/nuxeo-jsf/nuxeo-platform-ui-web/src/main/java/org/nuxeo/ecm/platformui/web/form/NxFormRenderer.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright 2013 Nuxeo SA (http://nuxeo.com/) and contributors.
+ * (C) Copyright 2013-2015 Nuxeo SA (http://nuxeo.com/) and contributors.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser General Public License

--- a/nuxeo-jsf/nuxeo-platform-ui-web/src/main/java/org/nuxeo/ecm/platformui/web/form/NxFormRenderer.java
+++ b/nuxeo-jsf/nuxeo-platform-ui-web/src/main/java/org/nuxeo/ecm/platformui/web/form/NxFormRenderer.java
@@ -24,8 +24,6 @@ import javax.faces.context.FacesContext;
 
 import org.apache.commons.lang.StringUtils;
 import org.nuxeo.runtime.api.Framework;
-import org.nuxeo.runtime.services.config.ConfigurationService;
-
 import com.sun.faces.renderkit.html_basic.FormRenderer;
 
 /**
@@ -42,8 +40,7 @@ public class NxFormRenderer extends FormRenderer {
     public static final String DOUBLE_CLICK_SHIELD_CSS_CLASS_FLAG = "doubleClickShielded";
 
     protected static boolean isDoubleShieldEnabled() {
-        ConfigurationService configurationService = Framework.getService(ConfigurationService.class);
-        return !configurationService.isBooleanPropertyFalse(ENABLE_DOUBLE_CLICK_SHIELD);
+        return !Framework.isBooleanPropertyFalse(ENABLE_DOUBLE_CLICK_SHIELD);
     }
 
     protected static boolean dcDisabledOnElement(UIComponent component) {

--- a/nuxeo-jsf/nuxeo-platform-webapp-base/src/main/java/org/nuxeo/ecm/webapp/action/WebActionsBean.java
+++ b/nuxeo-jsf/nuxeo-platform-webapp-base/src/main/java/org/nuxeo/ecm/webapp/action/WebActionsBean.java
@@ -56,7 +56,6 @@ import org.nuxeo.ecm.platform.ui.web.api.TabActionsSelection;
 import org.nuxeo.ecm.platform.ui.web.api.WebActions;
 import org.nuxeo.ecm.webapp.helpers.EventNames;
 import org.nuxeo.runtime.api.Framework;
-import org.nuxeo.runtime.services.config.ConfigurationService;
 
 /**
  * Component that handles actions retrieval as well as current tab(s) selection.
@@ -494,8 +493,7 @@ public class WebActionsBean implements WebActions, Serializable {
     @Override
     @Factory(value = "useAjaxTabs", scope = ScopeType.SESSION)
     public boolean useAjaxTabs() {
-        ConfigurationService configurationService = Framework.getService(ConfigurationService.class);
-        if (configurationService.isBooleanPropertyTrue(AJAX_TAB_PROPERTY)) {
+        if (Framework.isBooleanPropertyTrue(AJAX_TAB_PROPERTY)) {
             return canUseAjaxTabs();
         }
         return false;

--- a/nuxeo-jsf/nuxeo-platform-webapp-base/src/main/java/org/nuxeo/ecm/webapp/action/WebActionsBean.java
+++ b/nuxeo-jsf/nuxeo-platform-webapp-base/src/main/java/org/nuxeo/ecm/webapp/action/WebActionsBean.java
@@ -96,8 +96,8 @@ public class WebActionsBean implements WebActions, Serializable {
 
     @Override
     public List<Action> getActionsList(String category, ActionContext context, boolean hideUnavailableAction) {
-        List<Action> list = new ArrayList<Action>();
-        List<String> categories = new ArrayList<String>();
+        List<Action> list = new ArrayList<>();
+        List<String> categories = new ArrayList<>();
         if (category != null) {
             String[] split = category.split(",|\\s");
             if (split != null) {
@@ -122,6 +122,7 @@ public class WebActionsBean implements WebActions, Serializable {
         return getActionsList(category, createActionContext(), Boolean.TRUE.equals(hideUnavailableAction));
     }
 
+    @Override
     public List<Action> getActionsList(String category, ActionContext context) {
         return getActionsList(category, context, true);
     }
@@ -131,18 +132,24 @@ public class WebActionsBean implements WebActions, Serializable {
         return getActionsList(category, createActionContext(document), hideUnavailableAction);
     }
 
+    @Override
     public List<Action> getActionsList(String category) {
         return getActionsList(category, createActionContext());
     }
 
+    @Deprecated
+    @Override
     public List<Action> getUnfiltredActionsList(String category, ActionContext context) {
         return getActionsList(category, context, false);
     }
 
+    @Deprecated
+    @Override
     public List<Action> getUnfiltredActionsList(String category) {
         return getUnfiltredActionsList(category, createActionContext());
     }
 
+    @Override
     public List<Action> getAllActions(String category) {
         return actionManager.getAllActions(category);
     }
@@ -245,6 +252,7 @@ public class WebActionsBean implements WebActions, Serializable {
         return null;
     }
 
+    @Override
     public boolean hasCurrentTabId(String category) {
         if (currentTabActions.getCurrentTabAction(category) == null) {
             return false;
@@ -285,6 +293,7 @@ public class WebActionsBean implements WebActions, Serializable {
 
     // tabs management specific to the DEFAULT_TABS_CATEGORY
 
+    @Override
     public void resetCurrentTab() {
         resetCurrentTabs(DEFAULT_TABS_CATEGORY);
     }
@@ -294,6 +303,7 @@ public class WebActionsBean implements WebActions, Serializable {
         subTabsActionsList = null;
     }
 
+    @Override
     @Observer(value = { EventNames.USER_ALL_DOCUMENT_TYPES_SELECTION_CHANGED, EventNames.LOCATION_SELECTION_CHANGED }, create = false)
     @BypassInterceptors
     public void resetTabList() {
@@ -302,6 +312,7 @@ public class WebActionsBean implements WebActions, Serializable {
         resetCurrentTab();
     }
 
+    @Override
     @Factory(value = "tabsActionsList", scope = EVENT)
     public List<Action> getTabsList() {
         if (tabsActionsList == null) {
@@ -310,6 +321,7 @@ public class WebActionsBean implements WebActions, Serializable {
         return tabsActionsList;
     }
 
+    @Override
     @Factory(value = "subTabsActionsList", scope = EVENT)
     public List<Action> getSubTabsList() {
         if (subTabsActionsList == null) {
@@ -322,15 +334,18 @@ public class WebActionsBean implements WebActions, Serializable {
         return subTabsActionsList;
     }
 
+    @Override
     @Factory(value = "currentTabAction", scope = EVENT)
     public Action getCurrentTabAction() {
         return getCurrentTabAction(DEFAULT_TABS_CATEGORY);
     }
 
+    @Override
     public void setCurrentTabAction(Action currentTabAction) {
         setCurrentTabAction(DEFAULT_TABS_CATEGORY, currentTabAction);
     }
 
+    @Override
     @Factory(value = "currentSubTabAction", scope = EVENT)
     public Action getCurrentSubTabAction() {
         Action action = getCurrentTabAction();
@@ -340,6 +355,7 @@ public class WebActionsBean implements WebActions, Serializable {
         return null;
     }
 
+    @Override
     public void setCurrentSubTabAction(Action tabAction) {
         if (tabAction != null) {
             String[] categories = tabAction.getCategories();
@@ -358,6 +374,7 @@ public class WebActionsBean implements WebActions, Serializable {
         }
     }
 
+    @Override
     public String getCurrentTabId() {
         Action currentTab = getCurrentTabAction();
         if (currentTab != null) {
@@ -366,6 +383,7 @@ public class WebActionsBean implements WebActions, Serializable {
         return null;
     }
 
+    @Override
     public void setCurrentTabId(String tabId) {
         if (tabId != null) {
             // do not reset tab when not set as this method
@@ -374,6 +392,7 @@ public class WebActionsBean implements WebActions, Serializable {
         }
     }
 
+    @Override
     public String getCurrentSubTabId() {
         Action currentSubTab = getCurrentSubTabAction();
         if (currentSubTab != null) {
@@ -382,6 +401,7 @@ public class WebActionsBean implements WebActions, Serializable {
         return null;
     }
 
+    @Override
     public void setCurrentSubTabId(String tabId) {
         if (tabId != null) {
             // do not reset tab when not set as this method
@@ -395,10 +415,12 @@ public class WebActionsBean implements WebActions, Serializable {
 
     // navigation API
 
+    @Override
     public String setCurrentTabAndNavigate(String currentTabActionId) {
         return setCurrentTabAndNavigate(navigationContext.getCurrentDocument(), currentTabActionId);
     }
 
+    @Override
     public String setCurrentTabAndNavigate(DocumentModel document, String currentTabActionId) {
         // navigate first because it will reset the tabs list
         String viewId = null;
@@ -416,11 +438,13 @@ public class WebActionsBean implements WebActions, Serializable {
 
     // deprecated API
 
+    @Override
     @Deprecated
     public List<Action> getSubViewActionsList() {
         return getActionsList("SUBVIEW_UPPER_LIST");
     }
 
+    @Override
     @Deprecated
     public void selectTabAction() {
         // if (tabAction != null) {
@@ -428,6 +452,7 @@ public class WebActionsBean implements WebActions, Serializable {
         // }
     }
 
+    @Override
     @Deprecated
     public String getCurrentLifeCycleState() {
         // only user of documentManager in this bean, look it up by hand
@@ -435,11 +460,13 @@ public class WebActionsBean implements WebActions, Serializable {
         return documentManager.getCurrentLifeCycleState(navigationContext.getCurrentDocument().getRef());
     }
 
+    @Override
     @Deprecated
     public void setTabsList(List<Action> tabsList) {
         tabsActionsList = tabsList;
     }
 
+    @Override
     @Deprecated
     public void setSubTabsList(List<Action> tabsList) {
         subTabsActionsList = tabsList;
@@ -458,11 +485,13 @@ public class WebActionsBean implements WebActions, Serializable {
         }
     }
 
+    @Override
     @Deprecated
     public void setCurrentTabAction(String currentTabActionId) {
         setCurrentTabId(currentTabActionId);
     }
 
+    @Override
     @Factory(value = "useAjaxTabs", scope = ScopeType.SESSION)
     public boolean useAjaxTabs() {
         ConfigurationService configurationService = Framework.getService(ConfigurationService.class);
@@ -472,6 +501,7 @@ public class WebActionsBean implements WebActions, Serializable {
         return false;
     }
 
+    @Override
     @Factory(value = "canUseAjaxTabs", scope = ScopeType.SESSION)
     public boolean canUseAjaxTabs() {
         FacesContext context = FacesContext.getCurrentInstance();

--- a/nuxeo-jsf/nuxeo-platform-webapp-base/src/main/java/org/nuxeo/ecm/webapp/helpers/FrameworkPropertyActions.java
+++ b/nuxeo-jsf/nuxeo-platform-webapp-base/src/main/java/org/nuxeo/ecm/webapp/helpers/FrameworkPropertyActions.java
@@ -19,12 +19,10 @@ package org.nuxeo.ecm.webapp.helpers;
 import static org.jboss.seam.annotations.Install.FRAMEWORK;
 
 import org.jboss.seam.ScopeType;
-import org.jboss.seam.annotations.In;
 import org.jboss.seam.annotations.Install;
 import org.jboss.seam.annotations.Name;
 import org.jboss.seam.annotations.Scope;
 import org.nuxeo.runtime.api.Framework;
-import org.nuxeo.runtime.services.config.ConfigurationService;
 
 /**
  * Seam component that exposes getters for all properties managements by the runtime {@link Framework}
@@ -36,25 +34,22 @@ import org.nuxeo.runtime.services.config.ConfigurationService;
 @Install(precedence = FRAMEWORK)
 public class FrameworkPropertyActions {
 
-    @In(create = true)
-    protected transient ConfigurationService configurationService;
-
     public String getProperty(String propertyName) {
-        return configurationService.getProperty(propertyName);
+        return Framework.getProperty(propertyName);
     }
 
     public String getProperty(String propertyName, String defaultValue) {
-        return configurationService.getProperty(propertyName, defaultValue);
+        return Framework.getProperty(propertyName, defaultValue);
     }
 
     /**
      * Returns true if given property has been setup to true (defaults to false if not set).
      *
      * @since 5.8
-     * @see {@link ConfigurationService#isBooleanPropertyTrue(String)}
+     * @see Framework#isBooleanPropertyTrue(String)
      */
     public boolean isBooleanPropertyTrue(String propertyName) {
-        return configurationService.isBooleanPropertyTrue(propertyName);
+        return Framework.isBooleanPropertyTrue(propertyName);
     }
 
 }

--- a/nuxeo-runtime/nuxeo-runtime-test/src/test/java/org/nuxeo/runtime/services/config/TestConfigurationService.java
+++ b/nuxeo-runtime/nuxeo-runtime-test/src/test/java/org/nuxeo/runtime/services/config/TestConfigurationService.java
@@ -34,6 +34,7 @@ public class TestConfigurationService extends NXRuntimeTestCase {
 
     ConfigurationService cs;
 
+    @Override
     @Before
     public void setUp() throws Exception {
         super.setUp();

--- a/nuxeo-runtime/nuxeo-runtime-test/src/test/java/org/nuxeo/runtime/services/config/TestConfigurationService.java
+++ b/nuxeo-runtime/nuxeo-runtime-test/src/test/java/org/nuxeo/runtime/services/config/TestConfigurationService.java
@@ -45,23 +45,23 @@ public class TestConfigurationService extends NXRuntimeTestCase {
     @Test
     public void testExtensionPoint() throws Exception {
         // Assert properties don't exist
-        assertNull(cs.getProperty("nuxeo.test.dummyBooleanProperty"));
-        assertNull(cs.getProperty("nuxeo.test.anotherDummyBooleanProperty"));
-        assertNull(cs.getProperty("nuxeo.test.dummyStringProperty"));
+        assertNull(Framework.getProperty("nuxeo.test.dummyBooleanProperty"));
+        assertNull(Framework.getProperty("nuxeo.test.anotherDummyBooleanProperty"));
+        assertNull(Framework.getProperty("nuxeo.test.dummyStringProperty"));
         // Deploy contribution with properties
         deployContrib("org.nuxeo.runtime.test.tests", "configuration-test-contrib.xml");
-        assertNotNull(cs.getProperty("nuxeo.test.dummyBooleanProperty"));
-        assertNotNull(cs.getProperty("nuxeo.test.anotherDummyBooleanProperty"));
-        assertNotNull(cs.getProperty("nuxeo.test.dummyStringProperty"));
-        assertNull(cs.getProperty("nuxeo.test.invalidDummyProperty"));
+        assertNotNull(Framework.getProperty("nuxeo.test.dummyBooleanProperty"));
+        assertNotNull(Framework.getProperty("nuxeo.test.anotherDummyBooleanProperty"));
+        assertNotNull(Framework.getProperty("nuxeo.test.dummyStringProperty"));
+        assertNull(Framework.getProperty("nuxeo.test.invalidDummyProperty"));
     }
 
     @Test
     public void testProperties() throws Exception {
         deployContrib("org.nuxeo.runtime.test.tests", "configuration-test-contrib.xml");
-        assertTrue(cs.isBooleanPropertyTrue("nuxeo.test.dummyBooleanProperty"));
-        assertFalse(cs.isBooleanPropertyTrue("nuxeo.test.anotherDummyBooleanProperty"));
-        assertEquals("dummyValue", cs.getProperty("nuxeo.test.dummyStringProperty"));
+        assertTrue(Framework.isBooleanPropertyTrue("nuxeo.test.dummyBooleanProperty"));
+        assertFalse(Framework.isBooleanPropertyTrue("nuxeo.test.anotherDummyBooleanProperty"));
+        assertEquals("dummyValue", Framework.getProperty("nuxeo.test.dummyStringProperty"));
     }
 
     @Test
@@ -71,26 +71,26 @@ public class TestConfigurationService extends NXRuntimeTestCase {
         // Deploy contribution with properties
         deployContrib("org.nuxeo.runtime.test.tests", "configuration-test-contrib.xml");
         // Assert property has overridden value
-        assertEquals("anotherDummyValue", cs.getProperty("nuxeo.test.dummyStringProperty"));
+        assertEquals("anotherDummyValue", Framework.getProperty("nuxeo.test.dummyStringProperty"));
         // Assert property don't exist
-        assertNull(cs.getProperty("nuxeo.test.overrideContribDummyProperty"));
+        assertNull(Framework.getProperty("nuxeo.test.overrideContribDummyProperty"));
         // Deploy another contrib with a new property and override existing properties
         deployContrib("org.nuxeo.runtime.test.tests", "configuration-override-contrib.xml");
         // Assert new property was added
-        assertEquals("overrideContrib", cs.getProperty("nuxeo.test.overrideContribDummyProperty"));
+        assertEquals("overrideContrib", Framework.getProperty("nuxeo.test.overrideContribDummyProperty"));
         // Assert framework property still takes precedence
-        assertEquals("anotherDummyValue", cs.getProperty("nuxeo.test.dummyStringProperty"));
+        assertEquals("anotherDummyValue", Framework.getProperty("nuxeo.test.dummyStringProperty"));
         Framework.getProperties().remove("nuxeo.test.dummyStringProperty");
         // Assert old properties have overridden values
-        assertEquals("dummyStringValueOverridden", cs.getProperty("nuxeo.test.dummyStringProperty"));
-        assertTrue(cs.isBooleanPropertyFalse("nuxeo.test.dummyBooleanProperty"));
+        assertEquals("dummyStringValueOverridden", Framework.getProperty("nuxeo.test.dummyStringProperty"));
+        assertTrue(Framework.isBooleanPropertyFalse("nuxeo.test.dummyBooleanProperty"));
 
         // Undeploy contrib
         undeployContrib("org.nuxeo.runtime.test.tests", "configuration-override-contrib.xml");
         // Assert property was removed
-        assertNull(cs.getProperty("nuxeo.test.overrideContribDummyProperty"));
+        assertNull(Framework.getProperty("nuxeo.test.overrideContribDummyProperty"));
         // Assert overridden values were restored
-        assertEquals("dummyValue", cs.getProperty("nuxeo.test.dummyStringProperty"));
-        assertTrue(cs.isBooleanPropertyTrue("nuxeo.test.dummyBooleanProperty"));
+        assertEquals("dummyValue", Framework.getProperty("nuxeo.test.dummyStringProperty"));
+        assertTrue(Framework.isBooleanPropertyTrue("nuxeo.test.dummyBooleanProperty"));
     }
 }

--- a/nuxeo-runtime/nuxeo-runtime/src/main/java/org/nuxeo/runtime/AbstractRuntimeService.java
+++ b/nuxeo-runtime/nuxeo-runtime/src/main/java/org/nuxeo/runtime/AbstractRuntimeService.java
@@ -29,6 +29,7 @@ import org.apache.commons.logging.LogFactory;
 
 import org.nuxeo.common.codec.CryptoProperties;
 import org.nuxeo.common.logging.JavaUtilLoggingHelper;
+import org.nuxeo.common.utils.DefaultProperties;
 import org.nuxeo.common.utils.TextTemplate;
 import org.nuxeo.runtime.api.Framework;
 import org.nuxeo.runtime.model.ComponentInstance;
@@ -65,7 +66,12 @@ public abstract class AbstractRuntimeService implements RuntimeService {
 
     protected File workingDir;
 
-    protected CryptoProperties properties = new CryptoProperties(System.getProperties());
+    /**
+     * Default properties overridden by System properties
+     */
+    protected DefaultProperties configurationProperties = new DefaultProperties(System.getProperties());
+
+    protected CryptoProperties properties = new CryptoProperties(configurationProperties);
 
     protected ComponentManager manager;
 
@@ -310,6 +316,11 @@ public abstract class AbstractRuntimeService implements RuntimeService {
         }
         msg.append(hr);
         return (warnings.isEmpty() && pendingRegistrations.isEmpty() && unstartedRegistrations.isEmpty());
+    }
+
+    @Override
+    public DefaultProperties getConfigurationProperties() {
+        return configurationProperties;
     }
 
 }

--- a/nuxeo-runtime/nuxeo-runtime/src/main/java/org/nuxeo/runtime/RuntimeService.java
+++ b/nuxeo-runtime/nuxeo-runtime/src/main/java/org/nuxeo/runtime/RuntimeService.java
@@ -231,4 +231,13 @@ public interface RuntimeService {
      */
     void setProperty(String name, Object value);
 
+    /**
+     * For internal use. Return a properties where to set default values.
+     *
+     * @since 7.4
+     * @see org.nuxeo.runtime.services.config.ConfigurationService
+     * @see org.nuxeo.runtime.services.config.ConfigurationPropertyRegistry
+     */
+    Properties getConfigurationProperties();
+
 }

--- a/nuxeo-runtime/nuxeo-runtime/src/main/java/org/nuxeo/runtime/api/Framework.java
+++ b/nuxeo-runtime/nuxeo-runtime/src/main/java/org/nuxeo/runtime/api/Framework.java
@@ -24,7 +24,6 @@ import javax.security.auth.login.LoginContext;
 import javax.security.auth.login.LoginException;
 
 import org.apache.commons.io.FileDeleteStrategy;
-import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
@@ -418,37 +417,45 @@ public final class Framework {
     }
 
     /**
+     * Return the {@code key} value as {@code Boolean} if set, else return {@code null} FIXME JC: not sure this method
+     * is relevant/useful
+     *
+     * @since 7.4
+     */
+    public static Boolean getPropertyAsBoolean(String key) {
+        String value = getProperty(key);
+        if (key == null) {
+            return null;
+        }
+        return Boolean.parseBoolean(value);
+    }
+
+    /**
      * Returns true if given property is false when compared to a boolean value. Returns false if given property in
      * unset.
      * <p>
-     * Checks for the system properties if property is not found in the runtime properties.
+     * It is equivalent to {@code !Boolean.parseBoolean(getProperty(propName, "true"))}
      *
      * @since 5.8
      */
     public static boolean isBooleanPropertyFalse(String propName) {
-        String v = getProperty(propName);
-        if (v == null) {
-            v = System.getProperty(propName);
-        }
-        if (StringUtils.isBlank(v)) {
-            return false;
-        }
-        return !Boolean.parseBoolean(v);
+        Boolean propValue = getPropertyAsBoolean(propName);
+        return propValue != null && !propValue;
+        // FIXME JC: is it better than return !Boolean.parseBoolean(getProperty(propName, "true")) ?
     }
 
     /**
-     * Returns true if given property is true when compared to a boolean value.
+     * Returns true if given property is true when compared to a boolean value. Returns false if given property in
+     * unset.
      * <p>
-     * Checks for the system properties if property is not found in the runtime properties.
+     * It is equivalent to {@code Boolean.parseBoolean(getProperty(propName))}
      *
      * @since 5.6
      */
     public static boolean isBooleanPropertyTrue(String propName) {
-        String v = getProperty(propName);
-        if (v == null) {
-            v = System.getProperty(propName);
-        }
-        return Boolean.parseBoolean(v);
+        Boolean propValue = getPropertyAsBoolean(propName);
+        return propValue != null && propValue;
+        // FIXME JC: is it better than return Boolean.parseBoolean(getProperty(propName)) ?
     }
 
     /**

--- a/nuxeo-runtime/nuxeo-runtime/src/main/java/org/nuxeo/runtime/api/Framework.java
+++ b/nuxeo-runtime/nuxeo-runtime/src/main/java/org/nuxeo/runtime/api/Framework.java
@@ -27,6 +27,7 @@ import org.apache.commons.io.FileDeleteStrategy;
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+
 import org.nuxeo.common.Environment;
 import org.nuxeo.common.collections.ListenerList;
 import org.nuxeo.runtime.RuntimeService;

--- a/nuxeo-runtime/nuxeo-runtime/src/main/java/org/nuxeo/runtime/osgi/OSGiRuntimeService.java
+++ b/nuxeo-runtime/nuxeo-runtime/src/main/java/org/nuxeo/runtime/osgi/OSGiRuntimeService.java
@@ -382,7 +382,8 @@ public class OSGiRuntimeService extends AbstractRuntimeService implements Framew
                     return o1.compareToIgnoreCase(o2);
                 }
             });
-            CryptoProperties props = new CryptoProperties(System.getProperties());
+            configurationProperties.clear();
+            CryptoProperties props = new CryptoProperties(configurationProperties);
             for (String name : names) {
                 if (name.endsWith(".config") || name.endsWith(".ini") || name.endsWith(".properties")) {
                     FileInputStream in = new FileInputStream(new File(dir, name));

--- a/nuxeo-runtime/nuxeo-runtime/src/main/java/org/nuxeo/runtime/services/config/ConfigurationPropertyRegistry.java
+++ b/nuxeo-runtime/nuxeo-runtime/src/main/java/org/nuxeo/runtime/services/config/ConfigurationPropertyRegistry.java
@@ -17,12 +17,13 @@
  */
 package org.nuxeo.runtime.services.config;
 
-import java.util.HashMap;
-import java.util.Map;
+import java.util.Properties;
 
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+
+import org.nuxeo.runtime.api.Framework;
 import org.nuxeo.runtime.model.SimpleContributionRegistry;
 
 /**
@@ -34,7 +35,7 @@ public class ConfigurationPropertyRegistry extends SimpleContributionRegistry<Co
 
     private static final Log log = LogFactory.getLog(ConfigurationPropertyRegistry.class);
 
-    protected Map<String, String> properties = new HashMap<>();
+    protected Properties properties = Framework.getRuntime().getConfigurationProperties();
 
     @Override
     public String getContributionId(ConfigurationPropertyDescriptor contrib) {
@@ -50,14 +51,14 @@ public class ConfigurationPropertyRegistry extends SimpleContributionRegistry<Co
             return;
         }
         String value = contrib.getValue();
-        properties.put(name, value);
-        log.info("Registering property with name " + name + " and value " + value);
+        properties.setProperty(name, value);
+        log.info("Registered property with name " + name + " and value " + value);
     }
 
     @Override
     public void contributionRemoved(String id, ConfigurationPropertyDescriptor origContrib) {
         properties.remove(id);
-        log.info("Unregistering property with name " + id);
+        log.info("Unregistered property with name " + id);
     }
 
     @Override
@@ -75,11 +76,4 @@ public class ConfigurationPropertyRegistry extends SimpleContributionRegistry<Co
         return true;
     }
 
-    public boolean hasProperty(String key) {
-        return properties.containsKey(key);
-    }
-
-    public String getProperty(String key) {
-        return properties.get(key);
-    }
 }

--- a/nuxeo-runtime/nuxeo-runtime/src/main/java/org/nuxeo/runtime/services/config/ConfigurationService.java
+++ b/nuxeo-runtime/nuxeo-runtime/src/main/java/org/nuxeo/runtime/services/config/ConfigurationService.java
@@ -28,28 +28,8 @@ package org.nuxeo.runtime.services.config;
 public interface ConfigurationService {
 
     /**
-     * Returns the given property value if any, otherwise null.
-     *
-     * @param key the property key
+     * FIXME JC: is this one not wanted?
      */
-    String getProperty(String key);
-
-    /**
-     * Returns the given property value if any, otherwise returns the given default value.
-     *
-     * @param key the property key
-     * @param defaultValue the default value for this key
-     */
-    String getProperty(String key, String defaultValue);
-
-    /**
-     * Returns true if given property is true when compared to a boolean value.
-     */
-    boolean isBooleanPropertyTrue(String key);
-
-    /**
-     * Returns true if given property is false when compared to a boolean value.
-     */
-    boolean isBooleanPropertyFalse(String key);
+    void setProperty(String key, String value);
 
 }

--- a/nuxeo-runtime/nuxeo-runtime/src/main/java/org/nuxeo/runtime/services/config/ConfigurationServiceImpl.java
+++ b/nuxeo-runtime/nuxeo-runtime/src/main/java/org/nuxeo/runtime/services/config/ConfigurationServiceImpl.java
@@ -17,10 +17,9 @@
  */
 package org.nuxeo.runtime.services.config;
 
-import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
-import org.nuxeo.runtime.api.Framework;
+
 import org.nuxeo.runtime.model.ComponentInstance;
 import org.nuxeo.runtime.model.DefaultComponent;
 
@@ -35,41 +34,31 @@ public class ConfigurationServiceImpl extends DefaultComponent implements Config
 
     protected ConfigurationPropertyRegistry registry = new ConfigurationPropertyRegistry();
 
-    @Override
-    public String getProperty(String key) {
-        return getProperty(key, null);
-    }
+    // Use Framework methods instead
+
+    // @Override
+    // public String getProperty(String key) {
+    // return Framework.getProperty(key);
+    // }
+    //
+    // @Override
+    // public String getProperty(String key, String defaultValue) {
+    // return Framework.getProperty(key, defaultValue);
+    // }
+    //
+    // @Override
+    // public boolean isBooleanPropertyTrue(String key) {
+    // return Framework.isBooleanPropertyTrue(key);
+    // }
+    //
+    // @Override
+    // public boolean isBooleanPropertyFalse(String key) {
+    // return Framework.isBooleanPropertyFalse(key);
+    // }
 
     @Override
-    public String getProperty(String key, String defaultValue) {
-        if (Framework.getProperties().containsKey(key)) {
-            return Framework.getProperty(key, defaultValue);
-        }
-        if (registry.hasProperty(key)) {
-            return registry.getProperty(key);
-        }
-        return defaultValue;
-    }
-
-    @Override
-    public boolean isBooleanPropertyTrue(String key) {
-        if (Framework.getProperties().containsKey(key)) {
-            return Framework.isBooleanPropertyTrue(key);
-        }
-        String value = getProperty(key);
-        return Boolean.parseBoolean(value);
-    }
-
-    @Override
-    public boolean isBooleanPropertyFalse(String key) {
-        if (Framework.getProperties().containsKey(key)) {
-            return Framework.isBooleanPropertyFalse(key);
-        }
-        String value = getProperty(key);
-        if (StringUtils.isBlank(value)) {
-            return false;
-        }
-        return !Boolean.parseBoolean(value);
+    public void setProperty(String key, String value) {
+        registry.properties.setProperty(key, value);
     }
 
     @Override

--- a/nuxeo-services/nuxeo-platform-query-api/src/main/java/org/nuxeo/ecm/platform/query/api/AbstractPageProvider.java
+++ b/nuxeo-services/nuxeo-platform-query-api/src/main/java/org/nuxeo/ecm/platform/query/api/AbstractPageProvider.java
@@ -34,7 +34,6 @@ import org.nuxeo.ecm.core.api.SortInfo;
 import org.nuxeo.ecm.platform.query.nxql.CoreQueryAndFetchPageProvider;
 import org.nuxeo.ecm.platform.query.nxql.CoreQueryDocumentPageProvider;
 import org.nuxeo.runtime.api.Framework;
-import org.nuxeo.runtime.services.config.ConfigurationService;
 
 /**
  * Basic implementation for a {@link PageProvider}.
@@ -840,14 +839,14 @@ public abstract class AbstractPageProvider<T> implements PageProvider<T> {
     protected long getDefaultMaxPageSize() {
         long res = DEFAULT_MAX_PAGE_SIZE;
         if (Framework.isInitialized()) {
-            ConfigurationService cs = Framework.getService(ConfigurationService.class);
-            String maxPageSize = cs.getProperty(DEFAULT_MAX_PAGE_SIZE_RUNTIME_PROP);
-            if (!StringUtils.isBlank(maxPageSize)) {
+            String defaultMaxPageSize = Framework.getProperty(DEFAULT_MAX_PAGE_SIZE_RUNTIME_PROP);
+            if (!StringUtils.isBlank(defaultMaxPageSize)) {
                 try {
-                    res = Long.parseLong(maxPageSize.trim());
+                    res = Long.parseLong(defaultMaxPageSize.trim());
                 } catch (NumberFormatException e) {
                     log.warn(String.format("Invalid max page size defined for property "
-                            + "\"%s\": %s (waiting for a long value)", DEFAULT_MAX_PAGE_SIZE_RUNTIME_PROP, maxPageSize));
+                            + "\"%s\": %s (waiting for a long value)", DEFAULT_MAX_PAGE_SIZE_RUNTIME_PROP,
+                            defaultMaxPageSize));
                 }
             }
         }

--- a/nuxeo-services/nuxeo-platform-query-api/src/main/java/org/nuxeo/ecm/platform/query/api/AbstractPageProvider.java
+++ b/nuxeo-services/nuxeo-platform-query-api/src/main/java/org/nuxeo/ecm/platform/query/api/AbstractPageProvider.java
@@ -1,10 +1,10 @@
 /*
- * (C) Copyright 2010 Nuxeo SA (http://nuxeo.com/) and contributors.
+ * (C) Copyright 2010-2015 Nuxeo SA (http://nuxeo.com/) and contributors.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser General Public License
  * (LGPL) version 2.1 which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/lgpl.html
+ * http://www.gnu.org/licenses/lgpl-2.1.html
  *
  * This library is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
@@ -242,7 +242,7 @@ public abstract class AbstractPageProvider<T> implements PageProvider<T> {
 
     @Override
     public List<Long> getPageSizeOptions() {
-        List<Long> res = new ArrayList<Long>();
+        List<Long> res = new ArrayList<>();
         if (pageSizeOptions != null) {
             res.addAll(pageSizeOptions);
         }
@@ -263,7 +263,7 @@ public abstract class AbstractPageProvider<T> implements PageProvider<T> {
     @Override
     public List<SortInfo> getSortInfos() {
         // break reference
-        List<SortInfo> res = new ArrayList<SortInfo>();
+        List<SortInfo> res = new ArrayList<>();
         if (sortInfos != null) {
             res.addAll(sortInfos);
         }
@@ -314,7 +314,7 @@ public abstract class AbstractPageProvider<T> implements PageProvider<T> {
 
     @Override
     public void setSortInfo(SortInfo sortInfo) {
-        List<SortInfo> newSortInfos = new ArrayList<SortInfo>();
+        List<SortInfo> newSortInfos = new ArrayList<>();
         if (sortInfo != null) {
             newSortInfos.add(sortInfo);
         }
@@ -331,7 +331,7 @@ public abstract class AbstractPageProvider<T> implements PageProvider<T> {
                 // do nothing: sort on this column is not set
             } else if (getSortInfoIndex(sortColumn, !sortAscending) != -1) {
                 // change direction
-                List<SortInfo> newSortInfos = new ArrayList<SortInfo>();
+                List<SortInfo> newSortInfos = new ArrayList<>();
                 for (SortInfo sortInfo : getSortInfos()) {
                     if (sortColumn.equals(sortInfo.getSortColumn())) {
                         newSortInfos.add(new SortInfo(sortColumn, sortAscending));
@@ -677,15 +677,15 @@ public abstract class AbstractPageProvider<T> implements PageProvider<T> {
     @Override
     public PageSelections<T> getCurrentSelectPage() {
         if (currentSelectPage == null) {
-            List<PageSelection<T>> entries = new ArrayList<PageSelection<T>>();
+            List<PageSelection<T>> entries = new ArrayList<>();
             List<T> currentPage = getCurrentPage();
-            currentSelectPage = new PageSelections<T>();
+            currentSelectPage = new PageSelections<>();
             currentSelectPage.setName(name);
             if (currentPage != null && !currentPage.isEmpty()) {
                 if (selectedEntries == null || selectedEntries.isEmpty()) {
                     // no selection at all
                     for (int i = 0; i < currentPage.size(); i++) {
-                        entries.add(new PageSelection<T>(currentPage.get(i), false));
+                        entries.add(new PageSelection<>(currentPage.get(i), false));
                     }
                 } else {
                     boolean allSelected = true;
@@ -695,7 +695,7 @@ public abstract class AbstractPageProvider<T> implements PageProvider<T> {
                         if (!Boolean.TRUE.equals(selected)) {
                             allSelected = false;
                         }
-                        entries.add(new PageSelection<T>(entry, selected.booleanValue()));
+                        entries.add(new PageSelection<>(entry, selected.booleanValue()));
                     }
                     if (allSelected) {
                         currentSelectPage.setSelected(true);

--- a/nuxeo-services/nuxeo-platform-query-api/src/main/java/org/nuxeo/ecm/platform/query/nxql/CoreQueryDocumentPageProvider.java
+++ b/nuxeo-services/nuxeo-platform-query-api/src/main/java/org/nuxeo/ecm/platform/query/nxql/CoreQueryDocumentPageProvider.java
@@ -1,10 +1,10 @@
 /*
- * (C) Copyright 2010 Nuxeo SA (http://nuxeo.com/) and contributors.
+ * (C) Copyright 2010-2015 Nuxeo SA (http://nuxeo.com/) and contributors.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser General Public License
  * (LGPL) version 2.1 which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/lgpl.html
+ * http://www.gnu.org/licenses/lgpl-2.1.html
  *
  * This library is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
@@ -30,7 +30,6 @@ import org.nuxeo.ecm.core.api.DocumentModelList;
 import org.nuxeo.ecm.core.api.Filter;
 import org.nuxeo.ecm.core.api.NuxeoException;
 import org.nuxeo.ecm.core.api.SortInfo;
-import org.nuxeo.ecm.core.query.QueryParseException;
 import org.nuxeo.ecm.platform.query.api.AbstractPageProvider;
 import org.nuxeo.ecm.platform.query.api.PageProviderDefinition;
 import org.nuxeo.ecm.platform.query.api.PageSelections;
@@ -113,7 +112,7 @@ public class CoreQueryDocumentPageProvider extends AbstractPageProvider<Document
                 throw new NuxeoException(String.format("Cannot perform null query: check provider '%s'", getName()));
             }
 
-            currentPageDocuments = new ArrayList<DocumentModel>();
+            currentPageDocuments = new ArrayList<>();
 
             try {
 
@@ -228,8 +227,8 @@ public class CoreQueryDocumentPageProvider extends AbstractPageProvider<Document
         } else {
             DocumentModel searchDocumentModel = getSearchDocumentModel();
             if (searchDocumentModel == null) {
-                throw new NuxeoException(String.format(
-                        "Cannot build query of provider '%s': " + "no search document model is set", getName()));
+                throw new NuxeoException(String.format("Cannot build query of provider '%s': "
+                        + "no search document model is set", getName()));
             }
             newQuery = NXQLQueryBuilder.getQuery(searchDocumentModel, def.getWhereClause(), getParameters(), sortArray);
         }

--- a/nuxeo-services/nuxeo-platform-query-api/src/main/java/org/nuxeo/ecm/platform/query/nxql/CoreQueryDocumentPageProvider.java
+++ b/nuxeo-services/nuxeo-platform-query-api/src/main/java/org/nuxeo/ecm/platform/query/nxql/CoreQueryDocumentPageProvider.java
@@ -34,7 +34,6 @@ import org.nuxeo.ecm.platform.query.api.AbstractPageProvider;
 import org.nuxeo.ecm.platform.query.api.PageProviderDefinition;
 import org.nuxeo.ecm.platform.query.api.PageSelections;
 import org.nuxeo.runtime.api.Framework;
-import org.nuxeo.runtime.services.config.ConfigurationService;
 
 /**
  * Page provider performing a query on a core session.
@@ -276,8 +275,7 @@ public class CoreQueryDocumentPageProvider extends AbstractPageProvider<Document
             String maxResultsStr = (String) getProperties().get(MAX_RESULTS_PROPERTY);
             if (maxResultsStr != null) {
                 if (DEFAULT_NAVIGATION_RESULTS_KEY.equals(maxResultsStr)) {
-                    ConfigurationService cs = Framework.getService(ConfigurationService.class);
-                    maxResultsStr = cs.getProperty(DEFAULT_NAVIGATION_RESULTS_PROPERTY,
+                    maxResultsStr = Framework.getProperty(DEFAULT_NAVIGATION_RESULTS_PROPERTY,
                             DEFAULT_NAVIGATION_RESULTS_VALUE);
                 } else if (PAGE_SIZE_RESULTS_KEY.equals(maxResultsStr)) {
                     maxResultsStr = Long.valueOf(getPageSize()).toString();

--- a/nuxeo-services/nuxeo-platform-query-api/src/main/java/org/nuxeo/ecm/platform/query/nxql/NXQLQueryBuilder.java
+++ b/nuxeo-services/nuxeo-platform-query-api/src/main/java/org/nuxeo/ecm/platform/query/nxql/NXQLQueryBuilder.java
@@ -47,7 +47,6 @@ import org.nuxeo.ecm.platform.query.api.PredicateFieldDefinition;
 import org.nuxeo.ecm.platform.query.api.WhereClauseDefinition;
 import org.nuxeo.ecm.platform.query.core.FieldDescriptor;
 import org.nuxeo.runtime.api.Framework;
-import org.nuxeo.runtime.services.config.ConfigurationService;
 
 /**
  * Helper to generate NXQL queries from XMap descriptors
@@ -486,8 +485,7 @@ public class NXQLQueryBuilder {
         // parser should be robust to any user input however this is much more
         // complicated to implement correctly than the following simple user
         // input filtering scheme.
-        ConfigurationService cs = Framework.getService(ConfigurationService.class);
-        String ignoredChars = cs.getProperty(IGNORED_CHARS_KEY, DEFAULT_SPECIAL_CHARACTERS_REGEXP);
+        String ignoredChars = Framework.getProperty(IGNORED_CHARS_KEY, DEFAULT_SPECIAL_CHARACTERS_REGEXP);
         String res = "";
         value = value.replaceAll("[" + ignoredChars + "]", " ");
         value = value.trim();

--- a/nuxeo-services/nuxeo-platform-query-api/src/main/java/org/nuxeo/ecm/platform/query/nxql/NXQLQueryBuilder.java
+++ b/nuxeo-services/nuxeo-platform-query-api/src/main/java/org/nuxeo/ecm/platform/query/nxql/NXQLQueryBuilder.java
@@ -1,10 +1,10 @@
 /*
- * (C) Copyright 2010 Nuxeo SA (http://nuxeo.com/) and contributors.
+ * (C) Copyright 2010-2015 Nuxeo SA (http://nuxeo.com/) and contributors.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the GNU Lesser General Public License
  * (LGPL) version 2.1 which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/lgpl.html
+ * http://www.gnu.org/licenses/lgpl-2.1.html
  *
  * This library is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
@@ -98,9 +98,7 @@ public class NXQLQueryBuilder {
             selectStatement = DEFAULT_SELECT_STATEMENT;
         }
         queryBuilder.append(selectStatement);
-        if (whereClause != null) {
-            queryBuilder.append(getQueryElement(model, whereClause, params));
-        }
+        queryBuilder.append(getQueryElement(model, whereClause, params));
         String sortClause = getSortClause(sortInfos);
         if (sortClause != null && sortClause.length() > 0) {
             queryBuilder.append(" ");
@@ -110,7 +108,7 @@ public class NXQLQueryBuilder {
     }
 
     public static String getQueryElement(DocumentModel model, WhereClauseDefinition whereClause, Object[] params) {
-        List<String> elements = new ArrayList<String>();
+        List<String> elements = new ArrayList<>();
         PredicateDefinition[] predicates = whereClause.getPredicates();
         if (predicates != null) {
             Escaper escaper = null;
@@ -185,7 +183,7 @@ public class NXQLQueryBuilder {
             query = query.replaceAll(REGEXP_EXCLUDE_QUOTE, StringUtils.EMPTY);
             Pattern p1 = Pattern.compile(REGEXP_NAMED_PARAMETER);
             Matcher m1 = p1.matcher(query);
-            List<String> matches = new ArrayList<String>();
+            List<String> matches = new ArrayList<>();
             while (m1.find()) {
                 matches.add(m1.group().substring(m1.group().indexOf(":") + 1));
             }
@@ -213,7 +211,7 @@ public class NXQLQueryBuilder {
                     if (quoteParameters) {
                         pattern = pattern.replaceAll(key, "'" + parameter + "'");
                     } else {
-                        pattern = pattern.replaceAll(key, parameter != null ? parameter.toString() : null);
+                        pattern = pattern.replaceAll(key, parameter.toString());
                     }
                 }
             }
@@ -267,7 +265,7 @@ public class NXQLQueryBuilder {
         if (addParentheses) {
             queryBuilder.append('(');
         }
-        List<String> result = new ArrayList<String>(listParam.size());
+        List<String> result = new ArrayList<>(listParam.size());
         for (Object param : listParam) {
             result.add(prepareStringLiteral(param.toString(), quoteParameters, escape));
         }
@@ -279,7 +277,7 @@ public class NXQLQueryBuilder {
 
     public static String replaceStringList(String pattern, List<?> listParams, boolean quoteParameters, boolean escape,
             String key) {
-        List<String> result = new ArrayList<String>(listParams.size());
+        List<String> result = new ArrayList<>(listParams.size());
         for (Object param : listParams) {
             result.add(prepareStringLiteral(param.toString(), quoteParameters, escape));
         }
@@ -471,14 +469,6 @@ public class NXQLQueryBuilder {
         }
     }
 
-    /**
-     * Prepares a statement for a fulltext field by converting FULLTEXT virtual operators to a syntax that the search
-     * syntax accepts.
-     *
-     * @param value
-     * @return the serialized statement
-     */
-
     public static final String DEFAULT_SPECIAL_CHARACTERS_REGEXP = "!#$%&'()+,./\\\\:-@{|}`^~";
 
     public static final String IGNORED_CHARS_KEY = "org.nuxeo.query.builder.ignored.chars";
@@ -518,6 +508,13 @@ public class NXQLQueryBuilder {
         return res.trim();
     }
 
+    /**
+     * Prepares a statement for a fulltext field by converting FULLTEXT virtual operators to a syntax that the search
+     * syntax accepts.
+     *
+     * @param value
+     * @return the serialized statement
+     */
     public static String serializeFullText(String value) {
         value = sanitizeFulltextInput(value);
         return "= " + NXQL.escapeString(value);
@@ -663,7 +660,7 @@ public class NXQLQueryBuilder {
         if (rawValue == null) {
             return null;
         }
-        List<String> values = new ArrayList<String>();
+        List<String> values = new ArrayList<>();
         if (rawValue instanceof ArrayList) {
             rawValue = ((ArrayList<Object>) rawValue).toArray();
         }


### PR DESCRIPTION
Draft suggested improvement:
- Only one entry point to get a property value: `Framework.getProperty()`.
- This improvements plugs `ConfigurationService` into the Framework properties.
- It should also provide a fix for the issue with `OSGiRuntimeService.reloadProperties()`: properties set from the ConfigurationService will be reloaded for real.
- Remove a lot of duplicated code.
- Closes the error-prone trap "`Framework.getProperty()` returns null whereas `ConfigurationService.getProperty()` would have returned a default value".
- Do not deprecate the whole code based on `Framework.getProperty()`

See FIXME questions:
- is `getPropertyAsBoolean(String)` useful?
- is `ConfigurationService.setProperty(String, String)` not wanted?
