### PR TITLE
SUPNXP-14791 Retrieve Latest non-Versionable Rendition

### DIFF
--- a/nuxeo-features/nuxeo-platform-rendition/nuxeo-platform-rendition-api/src/main/java/org/nuxeo/ecm/platform/rendition/Constants.java
+++ b/nuxeo-features/nuxeo-platform-rendition/nuxeo-platform-rendition-api/src/main/java/org/nuxeo/ecm/platform/rendition/Constants.java
@@ -42,5 +42,9 @@ public class Constants {
     // live doc if the rendition was derived from a versionable doc, otherwise null
     public static final String RENDITION_SOURCE_VERSIONABLE_ID_PROPERTY = "rend:sourceVersionableId";
 
+    // date the source doc was modified according to property named
+    // RenditionDefinition#sourceDocumentModificationDatePropertyName
+    public static final String RENDITION_SOURCE_MODIFICATION_DATE_PROPERTY = "rend:sourceModificationDate";
+
     public static final String RENDITION_NAME_PROPERTY = "rend:renditionName";
 }

--- a/nuxeo-features/nuxeo-platform-rendition/nuxeo-platform-rendition-core/src/main/java/org/nuxeo/ecm/platform/rendition/service/RenditionFinder.java
+++ b/nuxeo-features/nuxeo-platform-rendition/nuxeo-platform-rendition-core/src/main/java/org/nuxeo/ecm/platform/rendition/service/RenditionFinder.java
@@ -17,7 +17,9 @@ package org.nuxeo.ecm.platform.rendition.service;
 
 import static org.nuxeo.ecm.platform.rendition.Constants.RENDITION_NAME_PROPERTY;
 import static org.nuxeo.ecm.platform.rendition.Constants.RENDITION_SOURCE_ID_PROPERTY;
+import static org.nuxeo.ecm.platform.rendition.Constants.RENDITION_SOURCE_MODIFICATION_DATE_PROPERTY;
 
+import java.text.SimpleDateFormat;
 import java.util.Calendar;
 import java.util.List;
 
@@ -67,6 +69,15 @@ public class RenditionFinder extends UnrestrictedSessionRunner {
                 }
             }
             query.append("ecm:isCheckedInVersion = 1 AND ");
+        } else {
+            String modificationDatePropertyName = getSourceDocumentModificationDatePropertyName();
+            Calendar sourceLastModified = (Calendar) source.getPropertyValue(modificationDatePropertyName);
+            if (sourceLastModified != null) {
+                query.append(RENDITION_SOURCE_MODIFICATION_DATE_PROPERTY);
+                query.append(" >= ");
+                query.append(formatTimestamp(sourceLastModified));
+                query.append(" AND ");
+            }
         }
         query.append(RENDITION_SOURCE_ID_PROPERTY);
         query.append(" = '");
@@ -76,19 +87,7 @@ public class RenditionFinder extends UnrestrictedSessionRunner {
         List<DocumentModel> docs = session.query(query.toString());
         if (docs.size() > 0) {
             storedRendition = docs.get(0);
-            if (!isVersionable) {
-                Calendar renditionLastModified = (Calendar) storedRendition.getPropertyValue("dc:modified");
-                String modificationDatePropertyName = getSourceDocumentModificationDatePropertyName();
-                Calendar sourceLastModified = (Calendar) source.getPropertyValue(modificationDatePropertyName);
-                if (renditionLastModified == null || sourceLastModified == null
-                        || sourceLastModified.after(renditionLastModified)) {
-                    storedRendition = null;
-                } else {
-                    storedRendition.detach(true);
-                }
-            } else {
-                storedRendition.detach(true);
-            }
+            storedRendition.detach(true);
         }
     }
 
@@ -102,4 +101,7 @@ public class RenditionFinder extends UnrestrictedSessionRunner {
         return def.getSourceDocumentModificationDatePropertyName();
     }
 
+    protected static String formatTimestamp(Calendar cal) {
+        return new SimpleDateFormat("'TIMESTAMP' ''yyyy-MM-dd HH:mm:ss.SSS''").format(cal.getTime());
+    }
 }

--- a/nuxeo-features/nuxeo-platform-rendition/nuxeo-platform-rendition-core/src/main/resources/schemas/rendition.xsd
+++ b/nuxeo-features/nuxeo-platform-rendition/nuxeo-platform-rendition-core/src/main/resources/schemas/rendition.xsd
@@ -5,6 +5,7 @@
 
   <xs:element name="sourceId" type="xs:string"/> <!-- Version document -->
   <xs:element name="sourceVersionableId" type="xs:string"/> <!-- Live document -->
+  <xs:element name="sourceModificationDate" type="xs:dateTime"/> <!-- Modification date -->
   <xs:element name="renditionName" type="xs:string"/> <!-- Rendition name -->
 
 </xs:schema>

--- a/nuxeo-features/nuxeo-platform-rendition/nuxeo-platform-rendition-core/src/test/java/org/nuxeo/ecm/platform/rendition/service/DummyDocToTxt.java
+++ b/nuxeo-features/nuxeo-platform-rendition/nuxeo-platform-rendition-core/src/test/java/org/nuxeo/ecm/platform/rendition/service/DummyDocToTxt.java
@@ -1,13 +1,17 @@
 package org.nuxeo.ecm.platform.rendition.service;
 
+import org.apache.commons.lang.StringUtils;
 import org.nuxeo.ecm.automation.core.Constants;
 import org.nuxeo.ecm.automation.core.annotations.Context;
 import org.nuxeo.ecm.automation.core.annotations.Operation;
 import org.nuxeo.ecm.automation.core.annotations.OperationMethod;
 import org.nuxeo.ecm.core.api.Blob;
 import org.nuxeo.ecm.core.api.Blobs;
+import org.nuxeo.ecm.core.api.CoreSession;
 import org.nuxeo.ecm.core.api.DocumentModel;
-import org.nuxeo.ecm.core.convert.api.ConversionService;
+import org.nuxeo.ecm.core.api.DocumentRef;
+import org.nuxeo.ecm.core.api.PropertyException;
+import org.nuxeo.runtime.transaction.TransactionHelper;
 
 @Operation(id = DummyDocToTxt.ID, category = Constants.CAT_CONVERSION, label = "Convert Doc To Txt", description = "very dummy just for tests !")
 public class DummyDocToTxt {
@@ -15,11 +19,52 @@ public class DummyDocToTxt {
     public static final String ID = "DummyDoc.ToTxt";
 
     @Context
-    protected ConversionService service;
+    protected CoreSession session;
 
     @OperationMethod
     public Blob run(DocumentModel doc) throws Exception {
-        return Blobs.createBlob(doc.getTitle());
+        DocumentRef docRef = doc.getRef();
+        String content = doc.getTitle();
+        String desc = "";
+        Boolean delayed = null;
+        try {
+            desc = (String) doc.getPropertyValue("dc:description");
+            delayed = (Boolean) doc.getContextData("delayed");
+        } catch (PropertyException ignored) {}
+        if (StringUtils.isNotBlank(desc)) {
+            content += String.format("%n" + desc);
+        }
+        if (delayed != null) {
+            // Sync #1
+            TestRenditionService.RenditionThread.cyclicBarrier.await();
+
+            // Sync #2
+            TestRenditionService.RenditionThread.cyclicBarrier.await();
+            nextTransaction();
+
+            if (Boolean.TRUE.equals(delayed)) {
+
+                // Delayed Sync #3
+                TestRenditionService.RenditionThread.cyclicBarrier.await();
+                nextTransaction();
+            } else {
+
+                doc = session.getDocument(docRef);
+                desc = (String) doc.getPropertyValue("dc:description");
+                if (StringUtils.isNotBlank(desc)) {
+                    content += String.format("%n" + desc);
+                }
+            }
+        }
+
+        return Blobs.createBlob(content);
+    }
+
+    protected void nextTransaction() {
+        if (TransactionHelper.isTransactionActiveOrMarkedRollback()) {
+            TransactionHelper.commitOrRollbackTransaction();
+            TransactionHelper.startTransaction();
+        }
     }
 
 }

--- a/nuxeo-features/nuxeo-platform-rendition/nuxeo-platform-rendition-core/src/test/java/org/nuxeo/ecm/platform/rendition/service/TestRenditionService.java
+++ b/nuxeo-features/nuxeo-platform-rendition/nuxeo-platform-rendition-core/src/test/java/org/nuxeo/ecm/platform/rendition/service/TestRenditionService.java
@@ -30,10 +30,12 @@ import static org.nuxeo.ecm.platform.rendition.Constants.RENDITION_SOURCE_VERSIO
 
 import java.io.Serializable;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Calendar;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.CyclicBarrier;
 
 import javax.inject.Inject;
 
@@ -41,9 +43,11 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.nuxeo.ecm.core.api.Blob;
 import org.nuxeo.ecm.core.api.Blobs;
+import org.nuxeo.ecm.core.api.CoreInstance;
 import org.nuxeo.ecm.core.api.CoreSession;
 import org.nuxeo.ecm.core.api.DocumentModel;
 import org.nuxeo.ecm.core.api.DocumentRef;
+import org.nuxeo.ecm.core.api.IdRef;
 import org.nuxeo.ecm.core.api.NuxeoException;
 import org.nuxeo.ecm.core.api.PathRef;
 import org.nuxeo.ecm.core.api.VersioningOption;
@@ -55,6 +59,7 @@ import org.nuxeo.ecm.core.api.security.SecurityConstants;
 import org.nuxeo.ecm.core.api.security.impl.ACPImpl;
 import org.nuxeo.ecm.core.event.EventService;
 import org.nuxeo.ecm.core.test.CoreFeature;
+import org.nuxeo.ecm.core.test.StorageConfiguration;
 import org.nuxeo.ecm.core.versioning.VersioningService;
 import org.nuxeo.ecm.platform.rendition.Rendition;
 import org.nuxeo.runtime.api.Framework;
@@ -251,6 +256,21 @@ public class TestRenditionService {
         assertTrue(rendition2.isStored());
         assertEquals(rendition.getHostDocument().getRef(), rendition2.getHostDocument().getRef());
 
+        // update the source Document
+        file.setPropertyValue("dc:description", "I have been updated again");
+        file = session.saveDocument(file);
+        assertEquals("0.2+", file.getVersionLabel());
+
+        // needed for MySQL otherwise version order could be random
+        coreFeature.getStorageConfiguration().maybeSleepToNextSecond();
+
+        // now store rendition for version 0.3
+        rendition = renditionService.getRendition(file, PDF_RENDITION_DEFINITION, true);
+        assertEquals("0.3", rendition.getHostDocument().getVersionLabel());
+        assertTrue(rendition.isStored());
+
+        assertTrue(rendition.getHostDocument().isVersion());
+
     }
 
     @Test
@@ -303,10 +323,16 @@ public class TestRenditionService {
             assertNotEquals(renditionDocument.getRef(), totoRendition.getHostDocument().getRef());
         }
 
+        coreFeature.getStorageConfiguration().maybeSleepToNextSecond();
+
         // now "update" the folder
         folder = session.getDocument(folder.getRef());
         folder.setPropertyValue("dc:description", "I have been updated");
         folder = session.saveDocument(folder);
+        session.save();
+        nextTransaction();
+
+        folder = session.getDocument(folder.getRef());
         rendition = getRendition(folder, renditionName, false, isLazy);
         assertFalse(rendition.isStored());
         assertTrue(rendition.isCompleted());
@@ -531,6 +557,145 @@ public class TestRenditionService {
         rendition = renditionService.getRendition(folder, renditionName);
         assertNotNull(rendition);
         assertTrue(rendition.isStored());
+    }
+
+    @Test
+    public void shouldStoreLatestNonVersionedRendition() throws Exception {
+        final StorageConfiguration storageConfiguration = coreFeature.getStorageConfiguration();
+        final String repositoryName = session.getRepositoryName();
+        final String username = session.getPrincipal().getName();
+        final String renditionName = "renditionDefinitionWithCustomOperationChain";
+        final String sourceDocumentModificationDatePropertyName = "dc:issued";
+        DocumentModel folder = session.createDocumentModel("/", "dummy", "Folder");
+        folder.setPropertyValue(sourceDocumentModificationDatePropertyName, Calendar.getInstance());
+        folder = session.createDocument(folder);
+        session.save();
+        nextTransaction();
+        eventService.waitForAsyncCompletion();
+
+        folder = session.getDocument(folder.getRef());
+        final String folderId = folder.getId();
+
+        RenditionThread t1 = new RenditionThread(storageConfiguration, repositoryName, username,
+                folderId, renditionName, true);
+        RenditionThread t2 = new RenditionThread(storageConfiguration, repositoryName, username,
+                folderId, renditionName, false);
+        t1.start();
+        t2.start();
+
+        // Sync #1
+        RenditionThread.cyclicBarrier.await();
+
+        // now "update" the folder description
+        Calendar modificationDate = Calendar.getInstance();
+        String desc = "I have been updated";
+        folder = session.getDocument(folder.getRef());
+        folder.setPropertyValue("dc:description", desc);
+        folder.setPropertyValue(sourceDocumentModificationDatePropertyName, modificationDate);
+        folder = session.saveDocument(folder);
+
+        session.save();
+        nextTransaction();
+        eventService.waitForAsyncCompletion();
+
+        // Sync #2
+        RenditionThread.cyclicBarrier.await();
+
+        // Sync #3
+        RenditionThread.cyclicBarrier.await();
+
+        t1.join();
+        t2.join();
+
+        nextTransaction();
+        eventService.waitForAsyncCompletion();
+
+        // get the "updated" folder rendition
+        Rendition rendition = renditionService.getRendition(folder, renditionName, true);
+        assertNotNull(rendition);
+        assertTrue(rendition.isStored());
+        Calendar cal = rendition.getModificationDate();
+        assertTrue(!cal.before(modificationDate));
+        assertNotNull(rendition.getBlob());
+        assertTrue(rendition.getBlob().getString().contains(desc));
+
+        // verify the thread renditions
+        List<Rendition> renditions = Arrays.asList(
+                new Rendition[] {t1.getDetachedRendition(), t2.getDetachedRendition()});
+        for (Rendition rend : renditions) {
+            assertNotNull(rend);
+            assertTrue(rend.isStored());
+            assertTrue(!cal.before(rend.getModificationDate()));
+            assertNotNull(rend.getBlob());
+            assertTrue(rendition.getBlob().getString().contains(desc));
+        }
+    }
+
+
+    protected static class RenditionThread extends Thread {
+
+        public static final CyclicBarrier cyclicBarrier = new CyclicBarrier(3);
+        private final StorageConfiguration storageConfiguration;
+        private final String repositoryName;
+        private final String username;
+        private final String docId;
+        private final String renditionName;
+        private final boolean delayed;
+
+        private Rendition detachedRendition;
+
+        public RenditionThread(StorageConfiguration storageConfiguration, String repositoryName, String username,
+                String docId, String renditionName, boolean delayed) {
+            super();
+            this.storageConfiguration = storageConfiguration;
+            this.repositoryName = repositoryName;
+            this.username = username;
+            this.docId = docId;
+            this.renditionName = renditionName;
+            this.delayed = delayed;
+        }
+
+        @Override
+        public void run() {
+            TransactionHelper.startTransaction();
+            try {
+                try (CoreSession session = CoreInstance.openCoreSession(repositoryName, username)) {
+                    DocumentModel doc = session.getDocument(new IdRef(docId));
+
+                    doc.putContextData("delayed", Boolean.valueOf(delayed));
+
+                    RenditionService renditionService = Framework.getService(RenditionService.class);
+                    detachedRendition = renditionService.getRendition(doc, renditionName, true);
+
+                }
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            } finally {
+                TransactionHelper.commitOrRollbackTransaction();
+                storageConfiguration.maybeSleepToNextSecond();
+            }
+            if (!delayed) {
+                try {
+
+                    // Not-Delayed Sync #3
+                    RenditionThread.cyclicBarrier.await();
+                } catch (Exception e) {
+                    throw new RuntimeException(e);
+                }
+            }
+        }
+
+        public Rendition getDetachedRendition() {
+            return detachedRendition;
+        }
+
+    }
+
+    protected static void nextTransaction() {
+        if (TransactionHelper.isTransactionActiveOrMarkedRollback()) {
+            TransactionHelper.commitOrRollbackTransaction();
+            TransactionHelper.startTransaction();
+        }
     }
 
     @Test

--- a/nuxeo-features/nuxeo-platform-rendition/nuxeo-platform-rendition-core/src/test/resources/test-rendition-contrib.xml
+++ b/nuxeo-features/nuxeo-platform-rendition/nuxeo-platform-rendition-core/src/test/resources/test-rendition-contrib.xml
@@ -22,6 +22,7 @@
       <label>label.rendition.pdf</label>
       <operationChain>Dummy</operationChain>
       <allowEmptyBlob>true</allowEmptyBlob>
+      <sourceDocumentModificationDatePropertyName>dc:issued</sourceDocumentModificationDatePropertyName>
     </renditionDefinition>
 
     <renditionDefinition name="renditionDefinitionWithUnknownOperationChain" enabled="true">


### PR DESCRIPTION
Patch includes new test TestRenditionService.shouldStoreLatestNonVersionedRendition() that exposes the problem. it also includes code modifications to fix the problem by preventing retrieval of stale, non-versionable renditions. Maven test was successfully run against the patched nuxeo-platform-rendition module using three back-end databases namely, H2, PostgreSQL, and MySQL.