### PR TITLE
NXP-17875 Set SMTP timeouts in testSendMail()

### DIFF
--- a/nuxeo-features/nuxeo-automation/nuxeo-automation-test/src/test/java/org/nuxeo/ecm/automation/server/test/EmbeddedAutomationClientTest.java
+++ b/nuxeo-features/nuxeo-automation/nuxeo-automation-test/src/test/java/org/nuxeo/ecm/automation/server/test/EmbeddedAutomationClientTest.java
@@ -382,6 +382,8 @@ public class EmbeddedAutomationClientTest extends AbstractAutomationClientTest {
         List<String> mailProperties = new ArrayList<>();
         mailProperties.add(String.format("mail.smtp.host = %s", "badHostName"));
         mailProperties.add(String.format("mail.smtp.port = %s", "2525"));
+        mailProperties.add(String.format("mail.smtp.connectiontimeout = %s", "1000"));
+        mailProperties.add(String.format("mail.smtp.timeout = %s", "1000"));
         FileUtils.writeLines(file, mailProperties);
 
         Document rootDoc = (Document) session.newRequest(FetchDocument.ID).set("value", "/").execute();


### PR DESCRIPTION
This patch fixes a failure in unit test EmbeddedAutomationClientTest.testSendMail() while running in my environment