### PR TITLE
NXP-19604: Forbid usage of download service for blob without digest

### DIFF
--- a/nuxeo-core/nuxeo-core-api/src/main/java/org/nuxeo/ecm/core/api/impl/blob/StringBlob.java
+++ b/nuxeo-core/nuxeo-core-api/src/main/java/org/nuxeo/ecm/core/api/impl/blob/StringBlob.java
@@ -24,6 +24,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.Serializable;
 
+import org.apache.commons.codec.digest.DigestUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
@@ -85,4 +86,11 @@ public class StringBlob extends AbstractBlob implements Serializable {
         return string;
     }
 
+    @Override
+    public String getDigest() {
+        if (digest == null) {
+            digest = DigestUtils.md5Hex(string);
+        }
+        return super.getDigest();
+    }
 }

--- a/nuxeo-core/nuxeo-core-io/src/main/java/org/nuxeo/ecm/core/io/download/DownloadServiceImpl.java
+++ b/nuxeo-core/nuxeo-core-io/src/main/java/org/nuxeo/ecm/core/io/download/DownloadServiceImpl.java
@@ -233,6 +233,9 @@ public class DownloadServiceImpl extends DefaultComponent implements DownloadSer
         }
 
         try {
+            if (blob.getDigest() == null) {
+                throw new NuxeoException("Blob doesn't have digest, which could lead to cache issue");
+            }
             String etag = '"' + blob.getDigest() + '"'; // with quotes per RFC7232 2.3
             response.setHeader("ETag", etag); // re-send even on SC_NOT_MODIFIED
             addCacheControlHeaders(request, response);


### PR DESCRIPTION
Hi,

There's a [T&P](https://qa.nuxeo.org/jenkins/job/TestAndPush/job/ondemand-testandpush-kleturc/2/) currently running to try to discover all forbidden usages of DownloadService. If you know some of them, let me know.