### PR TITLE
NXP-17772: SQLDirectoryFeature try to reset any kind of Directory

### DIFF
--- a/nuxeo-services/nuxeo-platform-directory/nuxeo-platform-directory-sql/src/test/java/org/nuxeo/ecm/directory/sql/SQLDirectoryFeature.java
+++ b/nuxeo-services/nuxeo-platform-directory/nuxeo-platform-directory-sql/src/test/java/org/nuxeo/ecm/directory/sql/SQLDirectoryFeature.java
@@ -103,6 +103,13 @@ public class SQLDirectoryFeature extends SimpleFeature {
         // record all directories in their entirety
         allDirectoryData.clear();
         for (Directory dir : directoryService.getDirectories()) {
+            // skip non SQL directories
+            if (!(dir instanceof SQLDirectory))
+                continue;
+            // skip read-only SQL directories
+            SQLDirectoryDescriptor config = ((SQLDirectory) dir).getConfig();
+            if ( config != null && Boolean.TRUE.equals(config.getReadOnly()))
+                continue;
             Map<String, Map<String, Object>> data = new HashMap<>();
             Session session = dir.getSession();
 			try {
@@ -131,6 +138,13 @@ public class SQLDirectoryFeature extends SimpleFeature {
         DirectoryService directoryService = Framework.getService(DirectoryService.class);
         // clear all directories
         for (Directory dir : directoryService.getDirectories()) {
+            // skip non SQL directories
+            if (!(dir instanceof SQLDirectory))
+                continue;
+            // skip read-only SQL directories
+            SQLDirectoryDescriptor config = ((SQLDirectory) dir).getConfig();
+            if ( config != null && Boolean.TRUE.equals(config.getReadOnly()))
+                continue;
             Session session = dir.getSession();
             try {
             	Map<String,Serializable> filter = Collections.emptyMap();


### PR DESCRIPTION
Introduced by [NXP-17772](https://jira.nuxeo.com/browse/NXP-17772) in 6.0-HF20 into `SQLDirectoryFeature`, directories entries get destroyed/recreated btw tests.
→ nuxeo/nuxeo@560c2e579b46fb0d44ac8141d9c84fcea7f2b07c — _„NXP-17772 set directories autocommit mode only in single datasource mode”_

But `SQLDirectoryFeature` do not restrict to `SQLDirectory` but to any Directory registered at `DirectoryService` no matter of type or Read-Only state.

Tests using both `SQLDirectory` and other types Directory may fail.
PS: `PlatformFeature` rely on `SQLDirectoryFeature`

IMHO `SQLDirectoryFeature` should only take care of `SQLDirectory` and moreover only those not marked as Read-Only.

**Attached:** Sample minimal maven project [test-sqlfeature.zip](https://github.com/nuxeo/nuxeo/files/461769/test-sqlfeature.zip) with a test success on 6.0-HF19 and failing on 6.0-HF20