### PR TITLE
NXP-19012: automation trace fails in 7.10

### DIFF
--- a/nuxeo-features/nuxeo-automation/nuxeo-automation-scripting/src/main/java/org/nuxeo/automation/scripting/internals/operation/ScriptingOperationImpl.java
+++ b/nuxeo-features/nuxeo-automation/nuxeo-automation-scripting/src/main/java/org/nuxeo/automation/scripting/internals/operation/ScriptingOperationImpl.java
@@ -108,12 +108,12 @@ public class ScriptingOperationImpl {
                 DocumentModelList docs = new DocumentModelListImpl();
                 List<?> l = (List<?>) entry;
                 for (Object item : l) {
-                    if (ctx.get(entryId) instanceof DocumentScriptingWrapper) {
+                    if (item instanceof DocumentScriptingWrapper) {
                         docs.add(((DocumentScriptingWrapper) item).getDoc());
                     }
                 }
                 if (docs.size() == l.size() && docs.size() > 0) {
-                    ctx.put(entryId, ((DocumentScriptingWrapper) entry).getDoc());
+                    ctx.put(entryId, docs);
                 }
             }
         }

--- a/nuxeo-features/nuxeo-automation/nuxeo-automation-scripting/src/test/java/org/nuxeo/automation/scripting/test/TestScriptRunnerInfrastructure.java
+++ b/nuxeo-features/nuxeo-automation/nuxeo-automation-scripting/src/test/java/org/nuxeo/automation/scripting/test/TestScriptRunnerInfrastructure.java
@@ -51,6 +51,7 @@ import org.nuxeo.ecm.automation.OperationDocumentation.Param;
 import org.nuxeo.ecm.automation.OperationException;
 import org.nuxeo.ecm.automation.OperationType;
 import org.nuxeo.ecm.automation.core.Constants;
+import org.nuxeo.ecm.automation.core.trace.TracerFactory;
 import org.nuxeo.ecm.core.api.Blob;
 import org.nuxeo.ecm.core.api.Blobs;
 import org.nuxeo.ecm.core.api.CoreInstance;
@@ -92,6 +93,9 @@ public class TestScriptRunnerInfrastructure {
     ByteArrayOutputStream outContent = new ByteArrayOutputStream();
 
     private PrintStream outStream;
+
+    @Inject
+    TracerFactory factory;
 
     @Before
     public void setUpStreams() {
@@ -434,6 +438,29 @@ public class TestScriptRunnerInfrastructure {
         ctx.put("docs", docs);
         Object result = automationService.run(ctx, "Scripting.SimpleScript", null);
         assertNotNull(result);
+    }
+
+    /*
+     * NXP-19012
+     */
+    @Test
+    public void canUnwrapContextWithTrace() throws OperationException {
+        if (!factory.getRecordingState()) {
+            factory.toggleRecording();
+        }
+
+        OperationContext ctx = new OperationContext(session);
+        DocumentModel root = session.getRootDocument();
+        DocumentModelList docs = new DocumentModelListImpl();
+        docs.add(root);
+        docs.add(root);
+        ctx.put("docs", docs);
+        ctx.setInput(root);
+        Map<String, Object> params = new HashMap<>();
+        Object result = automationService.run(ctx, "Scripting.ChainWithScripting", params);
+        assertNotNull(result);
+        // check if the context has been unwrapped correctly
+        assertTrue(ctx.get("docs") instanceof DocumentModelList && ((DocumentModelList) ctx.get("docs")).size() == 2);
     }
 
     @Test

--- a/nuxeo-features/nuxeo-automation/nuxeo-automation-scripting/src/test/resources/automation-scripting-contrib.xml
+++ b/nuxeo-features/nuxeo-automation/nuxeo-automation-scripting/src/test/resources/automation-scripting-contrib.xml
@@ -456,6 +456,19 @@
         }
       ]]></script>
     </scriptedOperation>
+  
+    <scriptedOperation id="Scripting.LogScript">
+      <inputType>void</inputType>
+      <outputType>void</outputType>
+      <category>javascript</category>
+      <description></description>
+      <script><![CDATA[
+        function run(input, params) {
+          Log(input, {'level': 'INFO','message': 'Success!'});
+          return input;
+         }
+      ]]></script>
+    </scriptedOperation>
 
   </extension>
 
@@ -498,6 +511,15 @@
       </operation>
       <operation id="Scripting.MVELResolver">
         <param type="string" name="mvel">expr:Foo @{myvar}</param>
+      </operation>
+    </chain>
+  
+    <chain id="Scripting.ChainWithScripting">
+      <operation id="Context.FetchDocument"/>
+      <operation id="Scripting.LogScript"/>
+      <operation id="Log">
+        <param type="string" name="level">info</param>
+        <param type="string" name="message">Success!</param>
       </operation>
     </chain>
 


### PR DESCRIPTION
In an automation chain which includes an automation script, and automation tracing is enabled, a UnsupportedOperationException was thrown when generating the trace. This was due to a problem with the context unwrap from **DocumentScriptingWrapper** to **DocumentModel**.

This commit provides a fix (and unit test) for the issue in 7.10, but it is not necessary for master, as the new **WrapperHelper** solves the problem.