### PR TITLE
NXP-17356 Change body into template in EmailHelper javadoc

### DIFF
--- a/nuxeo-features/nuxeo-platform-notification/nuxeo-platform-notification-core/src/main/java/org/nuxeo/ecm/platform/ec/notification/email/EmailHelper.java
+++ b/nuxeo-features/nuxeo-platform-notification/nuxeo-platform-notification-core/src/main/java/org/nuxeo/ecm/platform/ec/notification/email/EmailHelper.java
@@ -71,7 +71,7 @@ import freemarker.template.TemplateException;
  * mail.put(&quot;from&quot;, &quot;dion@almaer.com&quot;);
  * mail.put(&quot;to&quot;, &quot;dion@almaer.com&quot;);
  * mail.put(&quot;subject&quot;, &quot;a subject&quot;);
- * mail.put(&quot;body&quot;, &quot;the body&quot;);
+ * mail.put(&quot;template&quot;, &quot;a template name&quot;);
  * &lt;p&gt;
  * EmailHelper.sendmail(mail);
  * </pre>


### PR DESCRIPTION
2016-09-16 14:59

JIRA:

https://jira.nuxeo.com/browse/NXP-17356

Explanation:

The EmailHelper javadoc at top of file was not correct.
It specified a "body" parameter but `mail.get("body")` was never called.
It should be a "template" parameter since there is `mail.get(NotificationConstants.TEMPLATE_KEY)`, where TEMPLATE_KEY is "template".

