### PR TITLE
NXP-15756 Remove Summary tab for Collection documents

### DIFF
--- a/nuxeo-features/nuxeo-platform-collections/nuxeo-platform-collections-jsf/src/main/resources/OSGI-INF/collection-actions-contrib.xml
+++ b/nuxeo-features/nuxeo-platform-collections/nuxeo-platform-collections-jsf/src/main/resources/OSGI-INF/collection-actions-contrib.xml
@@ -86,6 +86,10 @@
       <filter-id>can_zip_export</filter-id>
     </action>
 
+    <action id="TAB_VIEW">
+      <filter-id>denyForCollection</filter-id>
+    </action>
+
   </extension>
 
   <extension target="org.nuxeo.ecm.platform.actions.ActionService"
@@ -145,6 +149,12 @@
     <filter id="can_zip_export" append="true" >
       <rule grant="false">
         <type>Collections</type>
+        <type>Collection</type>
+      </rule>
+    </filter>
+
+    <filter id="denyForCollection">
+      <rule grant="false">
         <type>Collection</type>
       </rule>
     </filter>


### PR DESCRIPTION
2016-09-20 11:02 AM Paris

**JIRA:** https://jira.nuxeo.com/browse/NXP-15756

**Description:** The goal was to remove the Summary tab (the one between the Content and Edit tabs) for Collection documents

**Screen shot:**
<img width="1278" alt="capture d ecran 2016-09-20 a 10 59 37" src="https://cloud.githubusercontent.com/assets/21174666/18664138/b441e73a-7f21-11e6-9017-787e8c0f1de1.png">

2016-09-20 04:47 PM Paris

**Jenkins:**
TestAndPush succeeds!
https://qa.nuxeo.org/jenkins/view/TestAndPush/job/TestAndPush/job/ondemand-testandpush-egiuly/5/
