### PR TITLE
NXP-20379 Add getLogEntriesFor(String uuid, String repositoryId) method

### DIFF
--- a/nuxeo-features/nuxeo-elasticsearch/nuxeo-elasticsearch-audit/src/main/java/org/nuxeo/elasticsearch/audit/ESAuditBackend.java
+++ b/nuxeo-features/nuxeo-elasticsearch/nuxeo-elasticsearch-audit/src/main/java/org/nuxeo/elasticsearch/audit/ESAuditBackend.java
@@ -243,8 +243,9 @@ public class ESAuditBackend extends AbstractAuditBackend implements AuditBackend
         List<LogEntry> logEntries = buildLogEntries(searchResponse);
         // Scroll on next results
         for (; //
-        searchResponse.getHits().getHits().length > 0 && logEntries.size() < searchResponse.getHits().getTotalHits(); //
-        searchResponse = runNextScroll(searchResponse.getScrollId(), keepAlive)) {
+                searchResponse.getHits().getHits().length > 0
+                        && logEntries.size() < searchResponse.getHits().getTotalHits(); //
+                searchResponse = runNextScroll(searchResponse.getScrollId(), keepAlive)) {
             // Build log entries
             logEntries.addAll(buildLogEntries(searchResponse));
         }
@@ -567,6 +568,7 @@ public class ESAuditBackend extends AbstractAuditBackend implements AuditBackend
         return false;
     }
 
+    @SuppressWarnings("deprecation")
     public String migrate(final int batchSize) {
 
         final String MIGRATION_WORK_ID = "AuditMigration";

--- a/nuxeo-features/nuxeo-elasticsearch/nuxeo-elasticsearch-audit/src/main/java/org/nuxeo/elasticsearch/audit/ESAuditBackend.java
+++ b/nuxeo-features/nuxeo-elasticsearch/nuxeo-elasticsearch-audit/src/main/java/org/nuxeo/elasticsearch/audit/ESAuditBackend.java
@@ -123,6 +123,22 @@ public class ESAuditBackend extends AbstractAuditBackend implements AuditBackend
             entries.add(logEntry);
             addLogEntries(entries);
         }
+
+        @Override
+        public List<LogEntry> getLogEntriesFor(String uuid, String repositoryId) {
+            throw new UnsupportedOperationException("Not implemented yet!");
+        }
+
+        @Override
+        public List<LogEntry> getLogEntriesFor(String uuid) {
+            throw new UnsupportedOperationException("Not implemented yet!");
+        }
+
+        @Override
+        public List<LogEntry> getLogEntriesFor(String uuid, Map<String, FilterMapEntry> filterMap,
+                boolean doDefaultSort) {
+            throw new UnsupportedOperationException("Not implemented yet!");
+        }
     };
 
     protected Client getClient() {
@@ -186,8 +202,17 @@ public class ESAuditBackend extends AbstractAuditBackend implements AuditBackend
     }
 
     @Override
+    public List<LogEntry> getLogEntriesFor(String uuid, String repositoryId) {
+        TermQueryBuilder docFilter = QueryBuilders.termQuery("docUUID", uuid);
+        TermQueryBuilder repoFilter = QueryBuilders.termQuery("repositoryId", repositoryId);
+        QueryBuilder filter;
+        filter = QueryBuilders.boolQuery().must(docFilter);
+        filter = QueryBuilders.boolQuery().must(repoFilter);
+        return getLogEntries(filter, false);
+    }
+
+    @Override
     public List<LogEntry> getLogEntriesFor(String uuid, Map<String, FilterMapEntry> filterMap, boolean doDefaultSort) {
-        SearchRequestBuilder builder = getSearchRequestBuilder(esClient);
         TermQueryBuilder docFilter = QueryBuilders.termQuery("docUUID", uuid);
         QueryBuilder filter;
         if (MapUtils.isEmpty(filterMap)) {
@@ -199,11 +224,17 @@ public class ESAuditBackend extends AbstractAuditBackend implements AuditBackend
                 ((BoolQueryBuilder) filter).must(QueryBuilders.termQuery(entry.getColumnName(), entry.getObject()));
             }
         }
-        TimeValue keepAlive = TimeValue.timeValueMinutes(1);
-        builder.setQuery(QueryBuilders.constantScoreQuery(filter)).setScroll(keepAlive).setSize(100);
+        return getLogEntries(filter, doDefaultSort);
+    }
+
+    protected List<LogEntry> getLogEntries(QueryBuilder filter, boolean doDefaultSort) {
+        SearchRequestBuilder builder = getSearchRequestBuilder(esClient);
         if (doDefaultSort) {
             builder.addSort("eventDate", SortOrder.DESC);
         }
+        TimeValue keepAlive = TimeValue.timeValueMinutes(1);
+        builder.setQuery(QueryBuilders.constantScoreQuery(filter)).setScroll(keepAlive).setSize(100);
+
         logSearchRequest(builder);
         SearchResponse searchResponse = builder.get();
         logSearchResponse(searchResponse);

--- a/nuxeo-features/nuxeo-elasticsearch/nuxeo-elasticsearch-audit/src/test/java/org/nuxeo/elasticsearch/TestAuditWithElasticSearch.java
+++ b/nuxeo-features/nuxeo-elasticsearch/nuxeo-elasticsearch-audit/src/test/java/org/nuxeo/elasticsearch/TestAuditWithElasticSearch.java
@@ -46,8 +46,8 @@ import org.nuxeo.runtime.test.runner.Features;
 import org.nuxeo.runtime.test.runner.FeaturesRunner;
 import org.nuxeo.runtime.test.runner.LocalDeploy;
 
-@Deploy({ "org.nuxeo.runtime.metrics", "org.nuxeo.ecm.platform.audit.api", "org.nuxeo.ecm.platform.audit", "org.nuxeo.ecm.platform.uidgen.core",
-        "org.nuxeo.elasticsearch.seqgen",
+@Deploy({ "org.nuxeo.runtime.metrics", "org.nuxeo.ecm.platform.audit.api", "org.nuxeo.ecm.platform.audit",
+        "org.nuxeo.ecm.platform.uidgen.core", "org.nuxeo.elasticsearch.seqgen",
         "org.nuxeo.elasticsearch.seqgen.test:elasticsearch-seqgen-index-test-contrib.xml",
         "org.nuxeo.elasticsearch.audit" })
 @RunWith(FeaturesRunner.class)
@@ -70,8 +70,8 @@ public class TestAuditWithElasticSearch {
     @Test
     public void shouldUseESBackend() throws Exception {
 
-        NXAuditEventsService audit = (NXAuditEventsService) Framework.getRuntime().getComponent(
-                NXAuditEventsService.NAME);
+        NXAuditEventsService audit = (NXAuditEventsService) Framework.getRuntime()
+                                                                     .getComponent(NXAuditEventsService.NAME);
         Assert.assertNotNull(audit);
 
         AuditBackend backend = audit.getBackend();
@@ -118,8 +118,8 @@ public class TestAuditWithElasticSearch {
         entryById = reader.getLogEntryByID(123L);
         Assert.assertNull(entryById);
 
-        NXAuditEventsService audit = (NXAuditEventsService) Framework.getRuntime().getComponent(
-                NXAuditEventsService.NAME);
+        NXAuditEventsService audit = (NXAuditEventsService) Framework.getRuntime()
+                                                                     .getComponent(NXAuditEventsService.NAME);
         AuditBackend backend = audit.getBackend();
         Assert.assertEquals(1L, backend.getEventsCount(entry.getEventId()).longValue());
     }

--- a/nuxeo-features/nuxeo-elasticsearch/nuxeo-elasticsearch-audit/src/test/java/org/nuxeo/elasticsearch/TestAuditWithElasticSearch.java
+++ b/nuxeo-features/nuxeo-elasticsearch/nuxeo-elasticsearch-audit/src/test/java/org/nuxeo/elasticsearch/TestAuditWithElasticSearch.java
@@ -96,7 +96,7 @@ public class TestAuditWithElasticSearch {
 
         // test audit trail
         AuditReader reader = Framework.getLocalService(AuditReader.class);
-        List<LogEntry> trail = reader.getLogEntriesFor(doc.getId());
+        List<LogEntry> trail = reader.getLogEntriesFor(doc.getId(), doc.getRepositoryName());
 
         Assert.assertNotNull(trail);
         Assert.assertEquals(2, trail.size());

--- a/nuxeo-features/nuxeo-elasticsearch/nuxeo-elasticsearch-audit/src/test/java/org/nuxeo/elasticsearch/TestESHistoryProvider.java
+++ b/nuxeo-features/nuxeo-elasticsearch/nuxeo-elasticsearch-audit/src/test/java/org/nuxeo/elasticsearch/TestESHistoryProvider.java
@@ -204,7 +204,7 @@ public class TestESHistoryProvider {
         Framework.getLocalService(AuditLogger.class).addLogEntries(entries);
 
         LogEntryGen.flushAndSync();
-        List<LogEntry> logs = reader.getLogEntriesFor(doc.getId());
+        List<LogEntry> logs = reader.getLogEntriesFor(doc.getId(), doc.getRepositoryName());
         if (verbose) {
             dump(logs);
         }

--- a/nuxeo-features/nuxeo-elasticsearch/nuxeo-elasticsearch-audit/src/test/java/org/nuxeo/elasticsearch/TestESHistoryProvider.java
+++ b/nuxeo-features/nuxeo-elasticsearch/nuxeo-elasticsearch-audit/src/test/java/org/nuxeo/elasticsearch/TestESHistoryProvider.java
@@ -55,12 +55,12 @@ import org.nuxeo.runtime.test.runner.FeaturesRunner;
 import org.nuxeo.runtime.test.runner.LocalDeploy;
 import org.nuxeo.runtime.transaction.TransactionHelper;
 
-@Deploy({ "org.nuxeo.ecm.platform.audit.api", "org.nuxeo.runtime.metrics", "org.nuxeo.ecm.platform.audit", "org.nuxeo.ecm.platform.uidgen.core",
-        "org.nuxeo.elasticsearch.seqgen",
+@Deploy({ "org.nuxeo.ecm.platform.audit.api", "org.nuxeo.runtime.metrics", "org.nuxeo.ecm.platform.audit",
+        "org.nuxeo.ecm.platform.uidgen.core", "org.nuxeo.elasticsearch.seqgen",
         "org.nuxeo.elasticsearch.seqgen.test:elasticsearch-seqgen-index-test-contrib.xml",
         "org.nuxeo.elasticsearch.audit" })
 @RunWith(FeaturesRunner.class)
-@Features(RepositoryElasticSearchFeature.class )
+@Features(RepositoryElasticSearchFeature.class)
 @LocalDeploy({ "org.nuxeo.elasticsearch.audit:elasticsearch-test-contrib.xml",
         "org.nuxeo.elasticsearch.audit:elasticsearch-audit-index-test-contrib.xml",
         "org.nuxeo.elasticsearch.audit:audit-test-contrib.xml" })
@@ -282,8 +282,8 @@ public class TestESHistoryProvider {
 
             // filter on category
             searchDoc.setPropertyValue("basicauditsearch:eventIds", null);
-            searchDoc.setPropertyValue("basicauditsearch:eventCategories", new String[] { "eventDocumentCategory",
-                    "bonusCategory" });
+            searchDoc.setPropertyValue("basicauditsearch:eventCategories",
+                    new String[] { "eventDocumentCategory", "bonusCategory" });
             pp.setSearchDocumentModel(searchDoc);
             entries = (List<LogEntry>) pp.getCurrentPage();
             assertEquals(20, entries.size());

--- a/nuxeo-features/nuxeo-platform-audit/nuxeo-platform-audit-api/src/main/java/org/nuxeo/ecm/platform/audit/api/AuditReader.java
+++ b/nuxeo-features/nuxeo-platform-audit/nuxeo-platform-audit-api/src/main/java/org/nuxeo/ecm/platform/audit/api/AuditReader.java
@@ -33,13 +33,34 @@ import java.util.Map;
 public interface AuditReader {
 
     /**
+     * Returns the logs given a doc uuid and a repository id.
+     *
+     * @param uuid the document uuid
+     * @param repositoryId the repository id
+     * @return a list of log entries
+     * @since 8.4
+     */
+    List<LogEntry> getLogEntriesFor(String uuid, String repositoryId);
+
+    /**
      * Returns the logs given a doc uuid.
      *
      * @param uuid the document uuid
      * @return a list of log entries
+     * @deprecated since 8.4, use {@link (org.nuxeo.ecm.platform.audit.api.AuditReader.getLogEntriesFor(String,
+     *             String))} instead.
      */
+    @Deprecated
     List<LogEntry> getLogEntriesFor(String uuid);
 
+    /**
+     * Returns the logs given a doc uuid, a map of filters and a default sort.
+     *
+     * @param uuid the document uuid
+     * @param filterMap the map of filters to apply
+     * @param doDefaultSort the default sort to set
+     * @return a list of log entries
+     */
     List<LogEntry> getLogEntriesFor(String uuid, Map<String, FilterMapEntry> filterMap, boolean doDefaultSort);
 
     /**

--- a/nuxeo-features/nuxeo-platform-audit/nuxeo-platform-audit-api/src/main/java/org/nuxeo/ecm/platform/audit/api/AuditReader.java
+++ b/nuxeo-features/nuxeo-platform-audit/nuxeo-platform-audit-api/src/main/java/org/nuxeo/ecm/platform/audit/api/AuditReader.java
@@ -117,7 +117,8 @@ public interface AuditReader {
      * @param pageSize number of results per page
      * @return a list of log entries.
      */
-    List<LogEntry> queryLogsByPage(String[] eventIds, Date limit, String category, String path, int pageNb, int pageSize);
+    List<LogEntry> queryLogsByPage(String[] eventIds, Date limit, String category, String path, int pageNb,
+            int pageSize);
 
     List<LogEntry> queryLogsByPage(String[] eventIds, Date limit, String[] category, String path, int pageNb,
             int pageSize);

--- a/nuxeo-features/nuxeo-platform-audit/nuxeo-platform-audit-core/src/main/java/org/nuxeo/ecm/platform/audit/impl/LogEntryImpl.java
+++ b/nuxeo-features/nuxeo-platform-audit/nuxeo-platform-audit-core/src/main/java/org/nuxeo/ecm/platform/audit/impl/LogEntryImpl.java
@@ -56,6 +56,7 @@ import org.nuxeo.ecm.platform.audit.api.comment.UIAuditComment;
 @NamedQueries({
         @NamedQuery(name = "LogEntry.removeByEventIdAndPath", query = "delete LogEntry log where log.eventId = :eventId and log.docPath like :pathPattern"),
         @NamedQuery(name = "LogEntry.findByDocument", query = "from LogEntry log where log.docUUID=:docUUID ORDER BY log.eventDate DESC"),
+        @NamedQuery(name = "LogEntry.findByDocumentAndRepository", query = "from LogEntry log where log.docUUID=:docUUID and log.repositoryId=:repositoryId ORDER BY log.eventDate DESC"),
         @NamedQuery(name = "LogEntry.findAll", query = "from LogEntry log order by log.eventDate DESC"),
         @NamedQuery(name = "LogEntry.findByEventIdAndPath", query = "from LogEntry log where log.eventId=:eventId and log.docPath LIKE :pathPattern"),
         @NamedQuery(name = "LogEntry.findByHavingExtendedInfo", query = "from LogEntry log where log.extendedInfos['one'] is not null order by log.eventDate DESC"),

--- a/nuxeo-features/nuxeo-platform-audit/nuxeo-platform-audit-core/src/main/java/org/nuxeo/ecm/platform/audit/service/AbstractAuditBackend.java
+++ b/nuxeo-features/nuxeo-platform-audit/nuxeo-platform-audit-core/src/main/java/org/nuxeo/ecm/platform/audit/service/AbstractAuditBackend.java
@@ -395,6 +395,29 @@ public abstract class AbstractAuditBackend implements AuditBackend {
         return component.bulker.await(time, unit);
     }
 
+    /**
+     * Returns the logs given a doc uuid and a repository id.
+     *
+     * @param uuid the document uuid
+     * @param repositoryId the repository id
+     * @return a list of log entries
+     * @since 8.4
+     */
+    @Override
+    public List<LogEntry> getLogEntriesFor(String uuid, String repositoryId) {
+        return getLogEntriesFor(uuid, repositoryId);
+    }
+
+    /**
+     * Returns the logs given a doc uuid.
+     *
+     * @param uuid the document uuid
+     * @return a list of log entries
+     * @deprecated since 8.4, use
+     *             {@link (org.nuxeo.ecm.platform.audit.service.AbstractAuditBackend.getLogEntriesFor(String, String))}
+     *             instead.
+     */
+    @Deprecated
     @Override
     public List<LogEntry> getLogEntriesFor(String uuid) {
         return getLogEntriesFor(uuid, Collections.<String, FilterMapEntry> emptyMap(), false);

--- a/nuxeo-features/nuxeo-platform-audit/nuxeo-platform-audit-core/src/main/java/org/nuxeo/ecm/platform/audit/service/AbstractAuditBackend.java
+++ b/nuxeo-features/nuxeo-platform-audit/nuxeo-platform-audit-core/src/main/java/org/nuxeo/ecm/platform/audit/service/AbstractAuditBackend.java
@@ -82,8 +82,8 @@ public abstract class AbstractAuditBackend implements AuditBackend {
     protected final AuditBackendDescriptor config;
 
     protected AbstractAuditBackend(NXAuditEventsService component, AuditBackendDescriptor config) {
-       this.component = component;
-       this.config = config;
+        this.component = component;
+        this.config = config;
     }
 
     protected final ExpressionEvaluator expressionEvaluator = new ExpressionEvaluator(new ExpressionFactoryImpl());
@@ -152,9 +152,10 @@ public abstract class AbstractAuditBackend implements AuditBackend {
         }
 
         // Global extended info
-        populateExtendedInfo(entry, source, context,  component.getExtendedInfoDescriptors());
+        populateExtendedInfo(entry, source, context, component.getExtendedInfoDescriptors());
         // Event id related extended info
-        populateExtendedInfo(entry, source, context,  component.getEventExtendedInfoDescriptors().get(entry.getEventId()));
+        populateExtendedInfo(entry, source, context,
+                component.getEventExtendedInfoDescriptors().get(entry.getEventId()));
 
         if (eventContext != null) {
             @SuppressWarnings("unchecked")
@@ -213,14 +214,12 @@ public abstract class AbstractAuditBackend implements AuditBackend {
         entry.setEventId(eventName);
         entry.setEventDate(eventDate);
 
-
-
         if (ctx instanceof DocumentEventContext) {
             DocumentEventContext docCtx = (DocumentEventContext) ctx;
             DocumentModel document = docCtx.getSourceDocument();
             if (document.hasFacet(SYSTEM_DOCUMENT) && !document.hasFacet(FORCE_AUDIT_FACET)) {
                 // do not log event on System documents
-               // unless it has the FORCE_AUDIT_FACET facet
+                // unless it has the FORCE_AUDIT_FACET facet
                 return null;
             }
 
@@ -295,8 +294,8 @@ public abstract class AbstractAuditBackend implements AuditBackend {
     }
 
     @Override
-    public List<LogEntry> queryLogsByPage(String[] eventIds, String dateRange, String category, String path,
-            int pageNb, int pageSize) {
+    public List<LogEntry> queryLogsByPage(String[] eventIds, String dateRange, String category, String path, int pageNb,
+            int pageSize) {
         String[] categories = { category };
         return queryLogsByPage(eventIds, dateRange, categories, path, pageNb, pageSize);
     }

--- a/nuxeo-features/nuxeo-platform-audit/nuxeo-platform-audit-core/src/main/java/org/nuxeo/ecm/platform/audit/service/BaseLogEntryProvider.java
+++ b/nuxeo-features/nuxeo-platform-audit/nuxeo-platform-audit-core/src/main/java/org/nuxeo/ecm/platform/audit/service/BaseLogEntryProvider.java
@@ -19,6 +19,10 @@
 
 package org.nuxeo.ecm.platform.audit.service;
 
+import java.util.List;
+import java.util.Map;
+
+import org.nuxeo.ecm.platform.audit.api.FilterMapEntry;
 import org.nuxeo.ecm.platform.audit.api.LogEntry;
 
 /**
@@ -29,6 +33,41 @@ import org.nuxeo.ecm.platform.audit.api.LogEntry;
 public interface BaseLogEntryProvider {
 
     public abstract void addLogEntry(LogEntry entry);
+
+    /**
+     * Returns the logs given a doc uuid and a repository id.
+     *
+     * @param uuid the document uuid
+     * @param repositoryId the repository id
+     * @return a list of log entries
+     * @since 8.4
+     */
+    public abstract List<LogEntry> getLogEntriesFor(String uuid, String repositoryId);
+
+    /**
+     * Returns the logs given a doc uuid.
+     *
+     * @param uuid the document uuid
+     * @return a list of log entries
+     * @deprecated since 8.4, use
+     *             {@link (org.nuxeo.ecm.platform.audit.service.BaseLogEntryProvider.getLogEntriesFor(String, String))}
+     *             instead.
+     */
+    @Deprecated
+    public abstract List<LogEntry> getLogEntriesFor(String uuid);
+
+    /**
+     * Returns the logs given a doc uuid, a map of filters and a default sort.
+     *
+     * @param uuid the document uuid
+     * @param filterMap the map of filters to apply
+     * @param doDefaultSort the default sort to set
+     * @return a list of log entries
+     * @deprecated
+     */
+    @Deprecated
+    public abstract List<LogEntry> getLogEntriesFor(String uuid, Map<String, FilterMapEntry> filterMap,
+            boolean doDefaultSort);
 
     public abstract int removeEntries(String eventId, String pathPattern);
 

--- a/nuxeo-features/nuxeo-platform-audit/nuxeo-platform-audit-core/src/main/java/org/nuxeo/ecm/platform/audit/service/DefaultAuditBackend.java
+++ b/nuxeo-features/nuxeo-platform-audit/nuxeo-platform-audit-core/src/main/java/org/nuxeo/ecm/platform/audit/service/DefaultAuditBackend.java
@@ -124,6 +124,20 @@ public class DefaultAuditBackend extends AbstractAuditBackend {
     }
 
     @Override
+    public List<LogEntry> getLogEntriesFor(final String uuid, final String repositoryId) {
+        return getOrCreatePersistenceProvider().run(false, new RunCallback<List<LogEntry>>() {
+            @Override
+            public List<LogEntry> runWith(EntityManager em) {
+                return getLogEntriesFor(em, uuid, repositoryId);
+            }
+        });
+    }
+
+    protected List<LogEntry> getLogEntriesFor(EntityManager em, String uuid, String repositoryId) {
+        return LogEntryProvider.createProvider(em).getLogEntriesFor(uuid, repositoryId);
+    }
+
+    @Override
     public List<LogEntry> getLogEntriesFor(final String uuid) {
         return getOrCreatePersistenceProvider().run(false, new RunCallback<List<LogEntry>>() {
             @Override

--- a/nuxeo-features/nuxeo-platform-audit/nuxeo-platform-audit-core/src/main/java/org/nuxeo/ecm/platform/audit/service/DefaultAuditBackend.java
+++ b/nuxeo-features/nuxeo-platform-audit/nuxeo-platform-audit-core/src/main/java/org/nuxeo/ecm/platform/audit/service/DefaultAuditBackend.java
@@ -54,7 +54,10 @@ public class DefaultAuditBackend extends AbstractAuditBackend {
 
     @Override
     public int getApplicationStartedOrder() {
-        return ((DefaultComponent)Framework.getRuntime().getComponent("org.nuxeo.ecm.core.persistence.PersistenceComponent")).getApplicationStartedOrder()+1;
+        return ((DefaultComponent) Framework.getRuntime()
+                                            .getComponent("org.nuxeo.ecm.core.persistence.PersistenceComponent"))
+                                                                                                                 .getApplicationStartedOrder()
+                + 1;
     }
 
     @Override
@@ -84,7 +87,8 @@ public class DefaultAuditBackend extends AbstractAuditBackend {
         ClassLoader last = thread.getContextClassLoader();
         try {
             thread.setContextClassLoader(PersistenceProvider.class.getClassLoader());
-            PersistenceProviderFactory persistenceProviderFactory = Framework.getLocalService(PersistenceProviderFactory.class);
+            PersistenceProviderFactory persistenceProviderFactory = Framework.getLocalService(
+                    PersistenceProviderFactory.class);
             persistenceProvider = persistenceProviderFactory.newProvider("nxaudit-logs");
             persistenceProvider.openPersistenceUnit();
         } finally {
@@ -220,7 +224,8 @@ public class DefaultAuditBackend extends AbstractAuditBackend {
         });
     }
 
-    protected List<?> nativeQuery(EntityManager em, String query, Map<String, Object> params, int pageNb, int pageSize) {
+    protected List<?> nativeQuery(EntityManager em, String query, Map<String, Object> params, int pageNb,
+            int pageSize) {
         return LogEntryProvider.createProvider(em).nativeQuery(query, params, pageNb, pageSize);
     }
 

--- a/nuxeo-features/nuxeo-platform-audit/nuxeo-platform-audit-core/src/main/java/org/nuxeo/ecm/platform/audit/service/LogEntryProvider.java
+++ b/nuxeo-features/nuxeo-platform-audit/nuxeo-platform-audit-core/src/main/java/org/nuxeo/ecm/platform/audit/service/LogEntryProvider.java
@@ -106,6 +106,19 @@ public class LogEntryProvider implements BaseLogEntryProvider {
     }
 
     @SuppressWarnings("unchecked")
+    @Override
+    public List<LogEntry> getLogEntriesFor(String uuid, String repositoryId) {
+        if (log.isDebugEnabled()) {
+            log.debug("getLogEntriesFor() UUID=" + uuid + " and repositoryId=" + repositoryId);
+        }
+        Query query = em.createNamedQuery("LogEntry.findByDocumentAndRepository");
+        query.setParameter("docUUID", uuid);
+        query.setParameter("repositoryId", repositoryId);
+        return doPublish(query.getResultList());
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
     public List<LogEntry> getLogEntriesFor(String uuid) {
         if (log.isDebugEnabled()) {
             log.debug("getLogEntriesFor() UUID=" + uuid);
@@ -116,7 +129,7 @@ public class LogEntryProvider implements BaseLogEntryProvider {
     }
 
     @SuppressWarnings("unchecked")
-    @Deprecated
+    @Override
     public List<LogEntry> getLogEntriesFor(String uuid, Map<String, FilterMapEntry> filterMap, boolean doDefaultSort) {
         if (log.isDebugEnabled()) {
             log.debug("getLogEntriesFor() UUID=" + uuid);

--- a/nuxeo-features/nuxeo-platform-audit/nuxeo-platform-audit-core/src/main/java/org/nuxeo/ecm/platform/audit/service/LogEntryProvider.java
+++ b/nuxeo-features/nuxeo-platform-audit/nuxeo-platform-audit-core/src/main/java/org/nuxeo/ecm/platform/audit/service/LogEntryProvider.java
@@ -150,11 +150,18 @@ public class LogEntryProvider implements BaseLogEntryProvider {
             String currentColumnName = currentFilterMapEntry.getColumnName();
 
             if ("LIKE".equals(currentOperator)) {
-                queryStr.append(" AND log.").append(currentColumnName).append(" LIKE :").append(
-                        currentQueryParameterName).append(" ");
+                queryStr.append(" AND log.")
+                        .append(currentColumnName)
+                        .append(" LIKE :")
+                        .append(currentQueryParameterName)
+                        .append(" ");
             } else {
-                queryStr.append(" AND log.").append(currentColumnName).append(currentOperator).append(":").append(
-                        currentQueryParameterName).append(" ");
+                queryStr.append(" AND log.")
+                        .append(currentColumnName)
+                        .append(currentOperator)
+                        .append(":")
+                        .append(currentQueryParameterName)
+                        .append(" ");
             }
         }
 
@@ -202,7 +209,7 @@ public class LogEntryProvider implements BaseLogEntryProvider {
         Query query = em.createQuery("from LogEntry log where " + whereClause);
         if (pageNb > 1) {
             query.setFirstResult((pageNb - 1) * pageSize);
-        }else if(pageNb == 0){
+        } else if (pageNb == 0) {
             log.warn("Requested pageNb equals 0 but page index start at 1. Will fallback to fetch the first page");
         }
         query.setMaxResults(pageSize);

--- a/nuxeo-features/nuxeo-platform-audit/nuxeo-platform-audit-core/src/test/java/org/nuxeo/ecm/platform/audit/TestLogEntryProvider.java
+++ b/nuxeo-features/nuxeo-platform-audit/nuxeo-platform-audit-core/src/test/java/org/nuxeo/ecm/platform/audit/TestLogEntryProvider.java
@@ -115,8 +115,8 @@ public class TestLogEntryProvider extends PersistenceTestCase {
     public void testHavingKey() {
         LogEntry entry = doCreateEntryAndPersist("id");
         providerUnderTest.addLogEntry(entry);
-        List<LogEntry> entries = providerUnderTest.nativeQueryLogs("log.id = " + entry.getId()
-                + " and log.extendedInfos['id'] is not null", 1, 10);
+        List<LogEntry> entries = providerUnderTest.nativeQueryLogs(
+                "log.id = " + entry.getId() + " and log.extendedInfos['id'] is not null", 1, 10);
         assertEquals(1, entries.size());
         assertEquals(new Long(1L), entries.get(0).getExtendedInfos().get("id").getValue(Long.class));
     }

--- a/nuxeo-features/nuxeo-platform-audit/nuxeo-platform-audit-core/src/test/java/org/nuxeo/ecm/platform/audit/TestLogEntryProvider.java
+++ b/nuxeo-features/nuxeo-platform-audit/nuxeo-platform-audit-core/src/test/java/org/nuxeo/ecm/platform/audit/TestLogEntryProvider.java
@@ -76,21 +76,25 @@ public class TestLogEntryProvider extends PersistenceTestCase {
         return new String[] { eventId() };
     }
 
-    protected LogEntry doCreateEntry(String docId) {
+    protected LogEntry doCreateEntry(String docId, String repositoryId) {
         LogEntry createdEntry = new LogEntryImpl();
         createdEntry.setEventId(eventId());
         createdEntry.setDocUUID(docId);
         createdEntry.setEventDate(new Date());
         createdEntry.setDocPath("/" + docId);
-        createdEntry.setRepositoryId("test");
+        createdEntry.setRepositoryId(repositoryId);
         createdEntry.setExtendedInfos(createExtendedInfos());
         return createdEntry;
     }
 
-    protected LogEntry doCreateEntryAndPersist(String docId) {
-        LogEntry entry = doCreateEntry(docId);
+    protected LogEntry doCreateEntryAndPersist(String docId, String repositoryId) {
+        LogEntry entry = doCreateEntry(docId, repositoryId);
         entityManager.persist(entry);
         return entry;
+    }
+
+    protected LogEntry doCreateEntryAndPersist(String docId) {
+        return doCreateEntryAndPersist(docId, "test");
     }
 
     protected List<LogEntry> doEncapsulate(LogEntry entry) {
@@ -101,7 +105,7 @@ public class TestLogEntryProvider extends PersistenceTestCase {
 
     @Test
     public void testAddLogEntry() {
-        LogEntry entry = doCreateEntry("id");
+        LogEntry entry = doCreateEntry("id", "test");
         providerUnderTest.addLogEntry(entry);
         boolean hasId = entry.getId() != 0;
         assertTrue(hasId);
@@ -128,6 +132,36 @@ public class TestLogEntryProvider extends PersistenceTestCase {
         LogEntry fetchedEntry = fetchedEntries.get(0);
         assertNotNull(fetchedEntry);
         assertEquals("id", fetchedEntry.getDocUUID());
+    }
+
+    @Test
+    public void testByUuidAndRepository() {
+        LogEntry entry1 = doCreateEntryAndPersist("id", "repository1");
+        providerUnderTest.addLogEntry(entry1);
+        LogEntry entry2 = doCreateEntryAndPersist("id", "repository2");
+        providerUnderTest.addLogEntry(entry2);
+
+        List<LogEntry> fetchedEntries = providerUnderTest.getLogEntriesFor("id");
+        assertNotNull(fetchedEntries);
+        int entriesCount = fetchedEntries.size();
+        assertEquals(2, entriesCount);
+        List<LogEntry> fetchedEntries1 = providerUnderTest.getLogEntriesFor("id", "repository1");
+        assertNotNull(fetchedEntries1);
+        int entriesCount1 = fetchedEntries1.size();
+        assertEquals(1, entriesCount1);
+        List<LogEntry> fetchedEntries2 = providerUnderTest.getLogEntriesFor("id", "repository2");
+        assertNotNull(fetchedEntries2);
+        int entriesCount2 = fetchedEntries2.size();
+        assertEquals(1, entriesCount2);
+
+        LogEntry fetchedEntry1 = fetchedEntries1.get(0);
+        assertNotNull(fetchedEntry1);
+        assertEquals("id", fetchedEntry1.getDocUUID());
+        assertEquals("repository1", fetchedEntry1.getRepositoryId());
+        LogEntry fetchedEntry2 = fetchedEntries2.get(0);
+        assertNotNull(fetchedEntry2);
+        assertEquals("id", fetchedEntry2.getDocUUID());
+        assertEquals("repository2", fetchedEntry2.getRepositoryId());
     }
 
     @SuppressWarnings("deprecation")

--- a/nuxeo-features/nuxeo-platform-audit/nuxeo-platform-audit-core/src/test/java/org/nuxeo/ecm/platform/audit/TestNXAuditEventsService.java
+++ b/nuxeo-features/nuxeo-platform-audit/nuxeo-platform-audit-core/src/test/java/org/nuxeo/ecm/platform/audit/TestNXAuditEventsService.java
@@ -176,7 +176,7 @@ public class TestNXAuditEventsService {
         eventService.fireEvent(event);
         waitForAsyncCompletion();
 
-        List<LogEntry> entries = serviceUnderTest.getLogEntriesFor(repo.source.getId());
+        List<LogEntry> entries = serviceUnderTest.getLogEntriesFor(repo.source.getId(), repo.source.getRepositoryName());
         assertEquals(2, entries.size());
 
         // entries are not ordered => skip creation log

--- a/nuxeo-features/nuxeo-platform-audit/nuxeo-platform-audit-core/src/test/java/org/nuxeo/ecm/platform/audit/TestTransactedAudit.java
+++ b/nuxeo-features/nuxeo-platform-audit/nuxeo-platform-audit-core/src/test/java/org/nuxeo/ecm/platform/audit/TestTransactedAudit.java
@@ -73,7 +73,7 @@ public class TestTransactedAudit {
 
         // test audit trail
         AuditReader reader = Framework.getLocalService(AuditReader.class);
-        List<LogEntry> trail = reader.getLogEntriesFor(doc.getId());
+        List<LogEntry> trail = reader.getLogEntriesFor(doc.getId(), repo.getRepositoryName());
 
         assertThat(trail, notNullValue());
         assertThat(trail.size(), is(3));

--- a/nuxeo-features/nuxeo-platform-audit/nuxeo-platform-audit-io/src/main/java/org/nuxeo/ecm/platform/audit/io/IOAuditAdapter.java
+++ b/nuxeo-features/nuxeo-platform-audit/nuxeo-platform-audit-io/src/main/java/org/nuxeo/ecm/platform/audit/io/IOAuditAdapter.java
@@ -96,7 +96,7 @@ public class IOAuditAdapter extends AbstractIOResourceAdapter {
                         uuid = doc.getId();
                     }
 
-                    List<LogEntry> logEntries = logService.getLogEntriesFor(uuid);
+                    List<LogEntry> logEntries = logService.getLogEntriesFor(uuid, repo);
 
                     docLogs.put(docRef, logEntries);
                 } catch (DocumentNotFoundException e) {

--- a/nuxeo-features/nuxeo-webengine-features/nuxeo-webengine-base/src/main/java/org/nuxeo/ecm/core/rest/AuditService.java
+++ b/nuxeo-features/nuxeo-webengine-features/nuxeo-webengine-base/src/main/java/org/nuxeo/ecm/core/rest/AuditService.java
@@ -56,7 +56,8 @@ public class AuditService extends DefaultAdapter {
         DocumentObject document = (DocumentObject) getTarget();
         DocumentModel model = document.getAdapter(DocumentModel.class);
         String id = model.getId();
-        return logs.getLogEntriesFor(id);
+        String repo = model.getRepositoryName();
+        return logs.getLogEntriesFor(id, repo);
     }
 
 }


### PR DESCRIPTION
_2016-09-22 07:01 PM_
JIRA https://jira.nuxeo.com/browse/NXP-20379

_2016-09-26 10:44 AM_
@jcarsique @efge 
Thanks for your feedback. I've taken it into account:
- I've done a final Format commit, of all the files I've updated.
- I've used the deprecation in Interface instead of Implementation.
- I've used the `@Depracted` annotation.
- I've used the `@deprecated since 8.4, use {...}` in Javadoc for the method I created. However, I've written `@deprecated` and not `@deprecated since ...` for the already existing and deprecated method `getLogEntriesFor(String uuid, Map<String, FilterMapEntry> filterMap, boolean doDefaultSort)` because I couldn't find since when is has been deprecated.

Could you tell me if it's ok now?
The TestAndPush is on going.
Thanks :)

_2016-09-26 5:16 PM_
TestAndPush succeeds! :)
