### PR TITLE
NXP-20344: deactivate no-cache header on resources but keep it on pages

### DIFF
--- a/nuxeo-services/nuxeo-platform-web-common/src/main/java/org/nuxeo/ecm/platform/web/common/requestcontroller/filter/NuxeoRequestControllerFilter.java
+++ b/nuxeo-services/nuxeo-platform-web-common/src/main/java/org/nuxeo/ecm/platform/web/common/requestcontroller/filter/NuxeoRequestControllerFilter.java
@@ -310,9 +310,9 @@ public class NuxeoRequestControllerFilter implements Filter {
      */
     public static void addCacheHeader(HttpServletResponse httpResponse, Boolean isPrivate, String cacheTime) {
         if (isPrivate) {
-            httpResponse.addHeader("Cache-Control", "private, max-age=" + cacheTime);
+            httpResponse.setHeader("Cache-Control", "private, max-age=" + cacheTime);
         } else {
-            httpResponse.addHeader("Cache-Control", "public, max-age=" + cacheTime);
+            httpResponse.setHeader("Cache-Control", "public, max-age=" + cacheTime);
         }
         // Generating expires using current date and adding cache time.
         // we are using the format Expires: Thu, 01 Dec 1994 16:00:00 GMT

--- a/nuxeo-services/nuxeo-platform-web-common/src/main/resources/OSGI-INF/web-request-controller-contrib.xml
+++ b/nuxeo-services/nuxeo-platform-web-common/src/main/resources/OSGI-INF/web-request-controller-contrib.xml
@@ -46,7 +46,6 @@
     point="responseHeaders">
     <header name="X-UA-Compatible">IE=10; IE=11</header>
     <header name="Cache-Control">no-cache</header>
-    <header name="Pragma">no-cache</header>
     <header name="X-Content-Type-Options">nosniff</header>
     <header name="X-XSS-Protection">1; mode=block</header>
     <header name="X-Frame-Options">${nuxeo.frame.options:=SAMEORIGIN}</header>


### PR DESCRIPTION
@vlad @florent wdyt? cache control was already configurable in RequestControllerService through filterConfig (cached=true|false) so just made sure we kept a single Cache-Control header and removed "Pragma" since specs say it's mean to be used in clients' requests not server responses.

Note: Could use a review of default filter config for more aggressive caching of static resources.
