### PR TITLE
NXP-20523 Fetch test file resource as stream in BlobToFileTest

### DIFF
--- a/nuxeo-features/nuxeo-automation/nuxeo-automation-core/src/test/java/org/nuxeo/ecm/automation/core/operations/blob/BlobToFileTest.java
+++ b/nuxeo-features/nuxeo-automation/nuxeo-automation-core/src/test/java/org/nuxeo/ecm/automation/core/operations/blob/BlobToFileTest.java
@@ -50,6 +50,7 @@ import javax.inject.Inject;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 @RunWith(FeaturesRunner.class)
 @Features(CoreFeature.class)
@@ -120,6 +121,7 @@ public class BlobToFileTest {
     protected void testNotAllowed(OperationContext ctx, String id, Map<String, Object> params) throws IOException {
         try {
             automationService.run(ctx, id, params);
+            fail("Expected OperationException");
         } catch (OperationException e) {
             assertNotNull(e.getMessage());
             assertTrue(e.getMessage().contains("Not allowed"));


### PR DESCRIPTION
JIRA: https://jira.nuxeo.com/browse/NXP-20523

_2016-09-28 3:30 PM_
Take Florent's 1st feedback into account:
- Replace `FileUtils.getFile(..)` by `new File(..)`
- Remove `src/test/resources/pdfMerge1.pdf` and use `getResourceAsStream("pdfMerge1.pdf")` instead, in order to fetch pdfMerge1.pdf test file resource

_2016-09-28 4:30 PM_
Take Florent's 2nd feedback into account

_2016-09-28 5:10 PM_
Test&Push on going

_2016-09-28 6:09 PM_
Take Remi's feedback into account

_2016-09-29 9:30 AM_
Test&Push succeeds!
