### PR TITLE
feature-NXP-20691-preview-office-with-pdf

### DIFF
--- a/nuxeo-features/preview/nuxeo-preview-core/src/main/java/org/nuxeo/ecm/platform/preview/adapter/MimeTypePreviewerDescriptor.java
+++ b/nuxeo-features/preview/nuxeo-preview-core/src/main/java/org/nuxeo/ecm/platform/preview/adapter/MimeTypePreviewerDescriptor.java
@@ -22,7 +22,11 @@
 package org.nuxeo.ecm.platform.preview.adapter;
 
 import org.nuxeo.common.xmap.annotation.XNode;
+import org.nuxeo.common.xmap.annotation.XNodeList;
 import org.nuxeo.common.xmap.annotation.XObject;
+
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * @author Alexandre Russel
@@ -30,18 +34,18 @@ import org.nuxeo.common.xmap.annotation.XObject;
 @XObject("previewer")
 public class MimeTypePreviewerDescriptor {
 
-    @XNode("pattern")
-    private String pattern;
+    @XNodeList(value = "pattern", type = ArrayList.class, componentType = String.class)
+    private List<String> patterns;
 
     @XNode("@class")
     private Class<? extends MimeTypePreviewer> klass;
 
-    public String getPattern() {
-        return pattern;
+    public List<String> getPatterns() {
+        return patterns;
     }
 
-    public void setPattern(String pattern) {
-        this.pattern = pattern;
+    public void setPatterns(List<String> patterns) {
+        this.patterns = patterns;
     }
 
     public Class<? extends MimeTypePreviewer> getKlass() {

--- a/nuxeo-features/preview/nuxeo-preview-core/src/main/java/org/nuxeo/ecm/platform/preview/adapter/OfficePreviewer.java
+++ b/nuxeo-features/preview/nuxeo-preview-core/src/main/java/org/nuxeo/ecm/platform/preview/adapter/OfficePreviewer.java
@@ -1,0 +1,42 @@
+/*
+ * (C) Copyright 2016 Nuxeo SA (http://nuxeo.com/) and others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Contributors:
+ *     Miguel Nixo
+ */
+
+package org.nuxeo.ecm.platform.preview.adapter;
+
+import org.nuxeo.ecm.core.api.Blob;
+import org.nuxeo.ecm.core.api.DocumentModel;
+import org.nuxeo.ecm.core.api.blobholder.BlobHolder;
+import org.nuxeo.ecm.core.convert.api.ConversionService;
+import org.nuxeo.runtime.api.Framework;
+
+import java.util.List;
+
+/**
+ * @since 8.10
+ */
+public class OfficePreviewer extends AbstractPreviewer implements MimeTypePreviewer {
+
+    public List<Blob> getPreview(Blob blob, DocumentModel dm) {
+        ConversionService conversionService = Framework.getService(ConversionService.class);
+        BlobHolder result = conversionService.convert("any2pdf", dm.getAdapter(BlobHolder.class), null);
+        PdfPreviewer pdfPreviewer = new PdfPreviewer();
+        return pdfPreviewer.getPreview(result.getBlob(), dm);
+    }
+
+}

--- a/nuxeo-features/preview/nuxeo-preview-core/src/main/java/org/nuxeo/ecm/platform/preview/adapter/PreviewAdapterManagerComponent.java
+++ b/nuxeo-features/preview/nuxeo-preview-core/src/main/java/org/nuxeo/ecm/platform/preview/adapter/PreviewAdapterManagerComponent.java
@@ -70,7 +70,9 @@ public class PreviewAdapterManagerComponent extends DefaultComponent implements 
             }
         } else if (PREVIEWED_MIME_TYPE.equals(extensionPoint)) {
             MimeTypePreviewerDescriptor desc = (MimeTypePreviewerDescriptor) contribution;
-            previewerFactory.put(desc.getPattern(), newInstance(desc.getKlass()));
+            for (String pattern : desc.getPatterns()) {
+                previewerFactory.put(pattern, newInstance(desc.getKlass()));
+            }
         } else if (BLOB_POST_PROCESSOR_EP.equals(extensionPoint)) {
             BlobPostProcessorDescriptor desc = (BlobPostProcessorDescriptor) contribution;
             blobPostProcessors.add(newInstance(desc.getKlass()));

--- a/nuxeo-features/preview/nuxeo-preview-core/src/main/resources/OSGI-INF/preview-adapter-contrib.xml
+++ b/nuxeo-features/preview/nuxeo-preview-core/src/main/resources/OSGI-INF/preview-adapter-contrib.xml
@@ -34,5 +34,35 @@
       <previewer class="org.nuxeo.ecm.platform.preview.adapter.MarkdownPreviewer">
         <pattern>text/x-web-markdown</pattern>
       </previewer>
+      <previewer class="org.nuxeo.ecm.platform.preview.adapter.OfficePreviewer">
+        <!-- Microsoft office documents -->
+        <pattern>application/msword</pattern>
+        <pattern>application/vnd.ms-powerpoint</pattern>
+        <pattern>application/vnd.ms-excel</pattern>
+        <!-- Microsoft office 2007 documents -->
+        <pattern>application/vnd.openxmlformats-officedocument.wordprocessingml.document</pattern>
+        <pattern>application/vnd.openxmlformats-officedocument.presentationml.presentation</pattern>
+        <pattern>application/vnd.openxmlformats-officedocument.spreadsheetml.sheet</pattern>
+        <!-- OpenOffice.org 1.x documents -->
+        <pattern>application/vnd.sun.xml.writer</pattern>
+        <pattern>application/vnd.sun.xml.writer.template</pattern>
+        <pattern>application/vnd.sun.xml.impress</pattern>
+        <pattern>application/vnd.sun.xml.impress.template</pattern>
+        <pattern>application/vnd.sun.xml.calc</pattern>
+        <pattern>application/vnd.sun.xml.calc.template</pattern>
+        <pattern>application/vnd.sun.xml.draw</pattern>
+        <pattern>application/vnd.sun.xml.draw.template</pattern>
+        <!-- OpenOffice.org 2.x documents -->
+        <pattern>application/vnd.oasis.opendocument.spreadsheet</pattern>
+        <pattern>application/vnd.oasis.opendocument.spreadsheet-template</pattern>
+        <pattern>application/vnd.oasis.opendocument.text</pattern>
+        <pattern>application/vnd.oasis.opendocument.text-template</pattern>
+        <pattern>application/vnd.oasis.opendocument.presentation</pattern>
+        <pattern>application/vnd.oasis.opendocument.presentation-template</pattern>
+        <pattern>application/vnd.oasis.opendocument.graphics</pattern>
+        <pattern>application/vnd.oasis.opendocument.graphics-template</pattern>
+        <!-- WordPerfect -->
+        <pattern>application/wordperfect</pattern>
+      </previewer>
     </extension>
 </component>


### PR DESCRIPTION
Adds a new `OfficePreviewer` that converts the documents to PDF (`any2pdf`) and uses the `PdfPreviewer` to preview them. Office documents were previously previewed using HTML conversions.
The `MimeTypePreviewer` extension point of `PreviewAdapterManagerComponent` now supports the contribution of previews with multiple mime type patterns.