### PR TITLE
Fix nxp 20878 repair test rendition service teardown logic

### DIFF
--- a/nuxeo-core/nuxeo-core-test/src/main/java/org/nuxeo/ecm/core/test/CoreFeature.java
+++ b/nuxeo-core/nuxeo-core-test/src/main/java/org/nuxeo/ecm/core/test/CoreFeature.java
@@ -323,7 +323,18 @@ public class CoreFeature extends SimpleFeature {
     }
 
     protected void batchRemoveDocuments(List<DocumentRef> ids) {
-        session.removeDocuments(ids.toArray(new DocumentRef[0]));
+        List<DocumentRef> deferredIds = new ArrayList<>();
+        for (DocumentRef id : ids) {
+            if (!session.exists(id)) {
+                continue;
+            }
+            if (session.canRemoveDocument(id)) {
+                session.removeDocument(id);
+            } else {
+                deferredIds.add(id);
+            }
+        }
+        session.removeDocuments(deferredIds.toArray(new DocumentRef[0]));
     }
 
     protected void initializeSession(FeaturesRunner runner) {

--- a/nuxeo-features/nuxeo-platform-rendition/nuxeo-platform-rendition-core/src/main/java/org/nuxeo/ecm/platform/rendition/lazy/AbstractLazyCachableRenditionProvider.java
+++ b/nuxeo-features/nuxeo-platform-rendition/nuxeo-platform-rendition-core/src/main/java/org/nuxeo/ecm/platform/rendition/lazy/AbstractLazyCachableRenditionProvider.java
@@ -89,6 +89,13 @@ public abstract class AbstractLazyCachableRenditionProvider implements Rendition
             blobs = ts.getBlobs(key);
             if (ts.isCompleted(key)) {
                 ts.release(key);
+            } else {
+                Work work = getRenditionWork(key, doc, def);
+                String workId = work.getId();
+                WorkManager wm = Framework.getService(WorkManager.class);
+                if (wm.find(workId, null) == null) {
+                    wm.schedule(work, Scheduling.IF_NOT_SCHEDULED);
+                }
             }
         }
 

--- a/nuxeo-features/nuxeo-platform-rendition/nuxeo-platform-rendition-core/src/test/java/org/nuxeo/ecm/platform/rendition/service/RenditionFeature.java
+++ b/nuxeo-features/nuxeo-platform-rendition/nuxeo-platform-rendition-core/src/test/java/org/nuxeo/ecm/platform/rendition/service/RenditionFeature.java
@@ -28,11 +28,12 @@ import org.nuxeo.runtime.test.runner.Deploy;
 import org.nuxeo.runtime.test.runner.Features;
 import org.nuxeo.runtime.test.runner.LocalDeploy;
 import org.nuxeo.runtime.test.runner.SimpleFeature;
+import org.nuxeo.transientstore.test.TransientStoreFeature;
 
 /**
  * @since 7.3
  */
-@Features({ CoreFeature.class, SQLDirectoryFeature.class })
+@Features({ CoreFeature.class, SQLDirectoryFeature.class, TransientStoreFeature.class })
 @Deploy({ "org.nuxeo.ecm.platform.convert", //
         "org.nuxeo.ecm.platform.login", //
         "org.nuxeo.ecm.platform.web.common", //
@@ -43,8 +44,7 @@ import org.nuxeo.runtime.test.runner.SimpleFeature;
         "org.nuxeo.ecm.platform.rendition.core", //
         "org.nuxeo.ecm.automation.core", //
         "org.nuxeo.ecm.platform.io.core", //
-        "org.nuxeo.ecm.platform.dublincore", //
-        "org.nuxeo.ecm.core.cache" //
+        "org.nuxeo.ecm.platform.dublincore" //
 })
 @LocalDeploy({ "org.nuxeo.ecm.platform.test:test-usermanagerimpl/userservice-config.xml", //
         "org.nuxeo.ecm.platform.rendition.core:test-directories-contrib.xml", //


### PR DESCRIPTION
Commit https://github.com/nuxeo/nuxeo/commit/e0939af8521d10e4c479dd080c37d5a39d80ae7f specifically fixes the teardown logic problem.

A second Commit https://github.com/nuxeo/nuxeo/pull/312/commits/d1c32bf22cde663ac33072454a46ad69579a4fca is included to request assistance. Specifically in TestRenditionService line 933 of the patch, why does this assertion fail intermittently (approximately 60% of the time)? This seems to me like some form of caching/invalidation problem. Is the problem unique to the Unit Test Environment? I tried running the unit test with a PostgreSQL backend and the same problem seemed to present itself. It is also interesting that String property dc:description appears to always be updated in the new session while Calendar property dc:issued does not. Your assistance troubleshooting this issue is much appreciated.
