### PR TITLE
NXP-20641: allow mim-type check to be disabled on FileManager.createDocumentFromBlob

### DIFF
--- a/nuxeo-features/nuxeo-automation/nuxeo-automation-features/src/main/java/org/nuxeo/ecm/automation/core/operations/services/FileManagerImport.java
+++ b/nuxeo-features/nuxeo-automation/nuxeo-automation-features/src/main/java/org/nuxeo/ecm/automation/core/operations/services/FileManagerImport.java
@@ -62,6 +62,9 @@ public class FileManagerImport {
     @Param(name = "overwite", required = false)
     protected Boolean overwite = false;
 
+    @Param(name = "noMimeTypeCheck", required = false)
+    protected Boolean noMimeTypeCheck = false;
+
     protected DocumentModel getCurrentDocument() throws OperationException {
         String cdRef = (String) context.get("currentDocument");
         return as.getAdaptedValue(context, cdRef, DocumentModel.class);
@@ -71,7 +74,7 @@ public class FileManagerImport {
     public DocumentModel run(Blob blob) throws OperationException, IOException {
         DocumentModel currentDocument = getCurrentDocument();
         return fileManager.createDocumentFromBlob(session, blob, currentDocument.getPathAsString(), overwite,
-                blob.getFilename());
+                blob.getFilename(), noMimeTypeCheck);
     }
 
     @OperationMethod

--- a/nuxeo-services/nuxeo-platform-filemanager-api/src/main/java/org/nuxeo/ecm/platform/filemanager/api/FileManager.java
+++ b/nuxeo-services/nuxeo-platform-filemanager-api/src/main/java/org/nuxeo/ecm/platform/filemanager/api/FileManager.java
@@ -55,6 +55,21 @@ public interface FileManager {
             String fullName) throws IOException;
 
     /**
+     * Returns an initialized doc based on a given blob.
+     *
+     * @param input the blob containing the content and the mime type
+     * @param path the path were to create the document
+     * @param overwrite boolean how decide to overwrite or not
+     * @param fullName the fullname that contains the filename
+     * @param noMimeTypeCheck true if the blob's mime-type doesn't have to be checked against fullName
+     * @return the created Document
+     *
+     * @since 8.10
+     */
+    DocumentModel createDocumentFromBlob(CoreSession documentManager, Blob input, String path, boolean overwrite,
+        String fullName, boolean noMimeTypeCheck) throws IOException;
+
+    /**
      * Just applies the same actions as creation but does not changes the doc type.
      *
      * @param input the blob containing the content and the mime type

--- a/nuxeo-services/nuxeo-platform-filemanager-core/src/main/java/org/nuxeo/ecm/platform/filemanager/service/FileManagerService.java
+++ b/nuxeo-services/nuxeo-platform-filemanager-core/src/main/java/org/nuxeo/ecm/platform/filemanager/service/FileManagerService.java
@@ -204,10 +204,17 @@ public class FileManagerService extends DefaultComponent implements FileManager 
     }
 
     public DocumentModel createDocumentFromBlob(CoreSession documentManager, Blob input, String path, boolean overwrite,
-            String fullName) throws IOException {
+        String fullName) throws IOException {
+        return createDocumentFromBlob(documentManager, input, path, overwrite, fullName, false);
+    }
+
+    public DocumentModel createDocumentFromBlob(CoreSession documentManager, Blob input, String path, boolean overwrite,
+            String fullName, boolean noMimeTypeCheck) throws IOException {
 
         // check mime type to be able to select the best importer plugin
-        input = checkMimeType(input, fullName);
+        if (!noMimeTypeCheck) {
+            input = checkMimeType(input, fullName);
+        }
 
         List<FileImporter> importers = new ArrayList<FileImporter>(fileImporters.values());
         Collections.sort(importers);

--- a/nuxeo-services/nuxeo-platform-filemanager-core/src/test/java/org/nuxeo/ecm/platform/filemanager/TestFileManagerService.java
+++ b/nuxeo-services/nuxeo-platform-filemanager-core/src/test/java/org/nuxeo/ecm/platform/filemanager/TestFileManagerService.java
@@ -45,6 +45,7 @@ import org.nuxeo.ecm.core.api.Blobs;
 import org.nuxeo.ecm.core.api.CoreSession;
 import org.nuxeo.ecm.core.api.DocumentModel;
 import org.nuxeo.ecm.core.api.DocumentRef;
+import org.nuxeo.ecm.core.blob.binary.BinaryBlob;
 import org.nuxeo.ecm.core.test.CoreFeature;
 import org.nuxeo.ecm.core.test.annotations.Granularity;
 import org.nuxeo.ecm.core.test.annotations.RepositoryConfig;
@@ -108,6 +109,47 @@ public class TestFileManagerService {
         assertEquals("hello.doc", doc.getProperty("dublincore", "title"));
         assertEquals("hello.doc", doc.getProperty("file", "filename"));
         assertNotNull(doc.getProperty("file", "content"));
+        BinaryBlob blob = (BinaryBlob) doc.getProperty("file", "content");
+        assertEquals(blob.getMimeType(), "application/msword");
+
+        // let's make the same test but this time without mime-type checking
+        // because the blob already carries a mime-type that matches the file name
+        // using mime-type check on or off should yield the same result
+        doc = service.createDocumentFromBlob(coreSession, input, workspace.getPathAsString(), true,
+            "test-data/hello2.doc", true);
+        assertNotNull(doc);
+        assertEquals("hello2.doc", doc.getProperty("dublincore", "title"));
+        assertEquals("hello2.doc", doc.getProperty("file", "filename"));
+        assertNotNull(doc.getProperty("file", "content"));
+        blob = (BinaryBlob) doc.getProperty("file", "content");
+        assertEquals(blob.getMimeType(), "application/msword");
+    }
+
+    @Test
+    public void testCreateFromBlobWithMimeTypeCheck() throws IOException {
+        // if we use a mime-type that does not match the file's name,
+        // we should still get a mime-type matching the file's name
+        // but only if we use mime-type check
+        File file = getTestFile("test-data/hello.doc");
+        Blob input = Blobs.createBlob(file, "application/sometype");
+        DocumentModel doc = service.createDocumentFromBlob(coreSession, input, workspace.getPathAsString(), true,
+            "test-data/hello3.doc");
+        assertNotNull(doc);
+        assertEquals("hello3.doc", doc.getProperty("dublincore", "title"));
+        assertEquals("hello3.doc", doc.getProperty("file", "filename"));
+        assertNotNull(doc.getProperty("file", "content"));
+        BinaryBlob blob = (BinaryBlob) doc.getProperty("file", "content");
+        assertEquals(blob.getMimeType(), "application/msword");
+
+        input = Blobs.createBlob(file, "application/sometype");
+        doc = service.createDocumentFromBlob(coreSession, input, workspace.getPathAsString(), true,
+            "test-data/hello3.doc", true);
+        assertNotNull(doc);
+        assertEquals("hello3.doc", doc.getProperty("dublincore", "title"));
+        assertEquals("hello3.doc", doc.getProperty("file", "filename"));
+        assertNotNull(doc.getProperty("file", "content"));
+        blob = (BinaryBlob) doc.getProperty("file", "content");
+        assertEquals(blob.getMimeType(), "application/sometype");
     }
 
     @Test


### PR DESCRIPTION
Private method checkMimeType retrieves the mime-type based on the file's name, and if that fails, it relies on the blob's mime-type, but only if it's normalized. Otherwise, it tries to read the blob, and fails if the blob as no stream available. This happens for a native Google Drive document. I propose a flag to to disable the checkMimeType. Default behavior is not changed.