### PR TITLE
Fix nxp 20500 validate email when editing user

### DIFF
--- a/nuxeo-distribution/nuxeo-jsf-ui-webdriver-tests/src/test/java/org/nuxeo/ftest/cap/ITUsersTest.java
+++ b/nuxeo-distribution/nuxeo-jsf-ui-webdriver-tests/src/test/java/org/nuxeo/ftest/cap/ITUsersTest.java
@@ -61,7 +61,7 @@ public class ITUsersTest extends AbstractTest {
         UsersTabSubPage usersTab = login().getAdminCenter().getUsersGroupsHomePage().getUsersTab();
         String username = TEST_USERNAME + System.currentTimeMillis();
 
-        usersTab.getUserCreatePage().inviteUser(username, username, "lastname1", "company1", "email1", "members");
+        usersTab.getUserCreatePage().inviteUser(username, username, "lastname1", "company1", "email1@test.com", "members");
 
         // Need few seconds to display the search view after
         AbstractPage.findElementWithTimeout(By.id("usersListingView:searchForm:searchText"));
@@ -78,7 +78,7 @@ public class ITUsersTest extends AbstractTest {
         String username = "jsmith";
         usersTab = usersTab.searchUser(username);
         if (!usersTab.isUserFound(username)) {
-            page = usersTab.getUserCreatePage().createUser(username, "firstname", "lastname1", "company1", "email1",
+            page = usersTab.getUserCreatePage().createUser(username, "firstname", "lastname1", "company1", "email1@test.com",
                     TEST_PASSWORD, "members");
             RestHelper.addUserToDelete(username);
             // no confirmation message anymore
@@ -113,7 +113,7 @@ public class ITUsersTest extends AbstractTest {
         usersTab = usersTab.searchUser(TEST_USERNAME);
         assertFalse(usersTab.isUserFound(TEST_USERNAME));
         // check invalid password match
-        page = usersTab.getUserCreatePage().createUser(TEST_USERNAME, firstname, "lastname1", "company1", "email1",
+        page = usersTab.getUserCreatePage().createUser(TEST_USERNAME, firstname, "lastname1", "company1", "email1@test.com",
                 TEST_PASSWORD, "foo", "members", false);
         assertEquals(page.getErrorFeedbackMessage(), "Please correct errors.");
         UserCreationFormPage creationPage = asPage(UserCreationFormPage.class);
@@ -121,7 +121,7 @@ public class ITUsersTest extends AbstractTest {
 
         // start again with passwords match
         page = creationPage.cancelCreation().getUserCreatePage().createUser(TEST_USERNAME, firstname, "lastname1",
-                "company1", "email1", TEST_PASSWORD, "members", false);
+                "company1", "email1@test.com", TEST_PASSWORD, "members", false);
         assertEquals("User created.", page.getInfoFeedbackMessage());
         RestHelper.addUserToDelete(TEST_USERNAME);
 
@@ -133,7 +133,7 @@ public class ITUsersTest extends AbstractTest {
         usersTab = usersTab.exitAdminCenter().getAdminCenter().getUsersGroupsHomePage().getUsersTab();
 
         // user already exists
-        page = usersTab.getUserCreatePage().createUser(TEST_USERNAME, "firstname1", "lastname1", "company1", "email1",
+        page = usersTab.getUserCreatePage().createUser(TEST_USERNAME, "firstname1", "lastname1", "company1", "email1@test.com",
                 TEST_PASSWORD, "members");
         assertEquals("User already exists.", page.getErrorFeedbackMessage());
         // cancel

--- a/nuxeo-services/nuxeo-invite/src/main/resources/schemas/userinfo.xsd
+++ b/nuxeo-services/nuxeo-invite/src/main/resources/schemas/userinfo.xsd
@@ -12,6 +12,7 @@
   <xs:element name="email">
     <xs:simpleType>
       <xs:restriction base="xs:string">
+        <!-- the same pattern is used in user.xsd -->
         <xs:pattern value="[^@]+@[^\.]+\..+" />
       </xs:restriction>
     </xs:simpleType>

--- a/nuxeo-services/nuxeo-platform-directory/nuxeo-platform-directory-types-contrib/src/main/resources/directoryschema/user.xsd
+++ b/nuxeo-services/nuxeo-platform-directory/nuxeo-platform-directory-types-contrib/src/main/resources/directoryschema/user.xsd
@@ -14,6 +14,7 @@
   <xs:element name="email">
     <xs:simpleType>
       <xs:restriction base="xs:string">
+        <!-- the same pattern is used in userinfo.xsd -->
         <xs:pattern value="[^@]+@[^\.]+\..+" />
       </xs:restriction>
     </xs:simpleType>

--- a/nuxeo-services/nuxeo-platform-directory/nuxeo-platform-directory-types-contrib/src/main/resources/directoryschema/user.xsd
+++ b/nuxeo-services/nuxeo-platform-directory/nuxeo-platform-directory-types-contrib/src/main/resources/directoryschema/user.xsd
@@ -11,7 +11,13 @@
   <xs:element name="firstName" type="xs:string" />
   <xs:element name="lastName" type="xs:string" />
   <xs:element name="company" type="xs:string" />
-  <xs:element name="email" type="xs:string" />
+  <xs:element name="email">
+    <xs:simpleType>
+      <xs:restriction base="xs:string">
+        <xs:pattern value="[^@]+@[^\.]+\..+" />
+      </xs:restriction>
+    </xs:simpleType>
+  </xs:element>
 
   <!-- inverse reference -->
   <xs:element name="groups" type="nxs:stringList" />


### PR DESCRIPTION
When editing a user, the email was not verified (whereas it was when creating a user).
So I added a pattern constraint on the email in the `user.xsd` schema used when editing a user.

For more information, please check the JIRA issue: https://jira.nuxeo.com/browse/NXP-20500

T&P succeeded