### PR TITLE
fix-NXP-19709-version-order-2

### DIFF
--- a/nuxeo-distribution/nuxeo-functional-tests/src/main/java/org/nuxeo/functionaltests/contentView/ContentViewElement.java
+++ b/nuxeo-distribution/nuxeo-functional-tests/src/main/java/org/nuxeo/functionaltests/contentView/ContentViewElement.java
@@ -101,6 +101,20 @@ public class ContentViewElement extends WebFragmentImpl {
     }
 
     /**
+     * @since 9.1
+     */
+    public WebElement getItemWithTitleAndVersion(String title, String version) {
+        for (WebElement item : getItems()) {
+            String t = item.findElement(By.xpath("td[3]")).getText(); // title
+            String v = item.findElement(By.xpath("td[7]")).getText(); // version
+            if (t.equals(title) && v.equals(version)) {
+                return item;
+            }
+        }
+        throw new NoSuchElementException("No item with title \"" + title + "\" and version " + version);
+    }
+
+    /**
      * @since 8.3
      */
     public void clickOnItemTitle(String title) {

--- a/nuxeo-distribution/nuxeo-functional-tests/src/main/java/org/nuxeo/functionaltests/pages/tabs/SectionContentTabSubPage.java
+++ b/nuxeo-distribution/nuxeo-functional-tests/src/main/java/org/nuxeo/functionaltests/pages/tabs/SectionContentTabSubPage.java
@@ -22,6 +22,7 @@ package org.nuxeo.functionaltests.pages.tabs;
 
 import org.nuxeo.functionaltests.AbstractTest;
 import org.nuxeo.functionaltests.AjaxRequestManager;
+import org.nuxeo.functionaltests.Locator;
 import org.nuxeo.functionaltests.Required;
 import org.nuxeo.functionaltests.contentView.ContentViewElement;
 import org.nuxeo.functionaltests.pages.AbstractPage;
@@ -93,6 +94,12 @@ public class SectionContentTabSubPage extends DocumentBasePage {
 
     public DocumentBasePage goToDocument(String documentTitle) {
         getElement().clickOnItemTitle(documentTitle);
+        return asPage(DocumentBasePage.class);
+    }
+
+    public DocumentBasePage goToDocumentWithVersion(String title, String version) {
+        WebElement rowElement = getContentView().getItemWithTitleAndVersion(title, version);
+        Locator.findElementWaitUntilEnabledAndClick(rowElement, By.linkText(title));
         return asPage(DocumentBasePage.class);
     }
 

--- a/nuxeo-distribution/nuxeo-jsf-ui-webdriver-tests/src/test/java/org/nuxeo/ftest/cap/ITPublishDocumentTests.java
+++ b/nuxeo-distribution/nuxeo-jsf-ui-webdriver-tests/src/test/java/org/nuxeo/ftest/cap/ITPublishDocumentTests.java
@@ -708,7 +708,7 @@ public class ITPublishDocumentTests extends AbstractTest {
         assertEquals(new HashSet<>(Arrays.asList("0.1", "0.2")), new HashSet<>(Arrays.asList(ver0, ver1)));
 
         // approve version 0.2 as manager
-        sectionPage.goToDocument(TEST_NOTE_TITLE);
+        sectionPage.goToDocumentWithVersion(TEST_NOTE_TITLE, "0.2");
         asPage(SummaryTabSubPage.class).approvePublication();
 
         // check only 0.2 are published in test section as manager (need refresh)


### PR DESCRIPTION
[NXP-19709](https://jira.nuxeo.com/browse/NXP-19709): click on the relevant version, don't depend on database order
