### PR TITLE
preserves the groupId within an ACE; the aceId is analyzed using a regular expression instead of split()

### DIFF
--- a/nuxeo-core/nuxeo-core-api/src/main/java/org/nuxeo/ecm/core/api/security/ACE.java
+++ b/nuxeo-core/nuxeo-core-api/src/main/java/org/nuxeo/ecm/core/api/security/ACE.java
@@ -61,7 +61,7 @@ public final class ACE implements Serializable, Cloneable {
 
     private Map<String, Serializable> contextData = new HashMap<>();
 
-    protected static final Pattern p = Pattern.compile("^(.+):([^:]+):([^:]+):([^:]*):([^:]*):([^:]*)$");
+    protected static final Pattern ID_PATTERN = Pattern.compile("^(.+):([^:]+):([^:]+):([^:]*):([^:]*):([^:]*)$");
 
     /**
      * Create an ACE from an id.
@@ -78,12 +78,12 @@ public final class ACE implements Serializable, Cloneable {
         // The ":" separator is still present even if the tokens are empty
         //   Example: jsmith:ReadWrite:true:::
         // The first token (username) is allowed to contain embedded ":".
-        String[] parts = new String[6];
-        Matcher m = p.matcher(aceId);
+        Matcher m = ID_PATTERN.matcher(aceId);
         if (!m.matches()) {
             throw new IllegalArgumentException(String.format("Invalid ACE id: %s", aceId));
         }
 
+        String[] parts = new String[m.groupCount()];
         for (int i = 1; i <= m.groupCount(); i++) {
             parts[i - 1] = m.group(i);
         }

--- a/nuxeo-core/nuxeo-core-api/src/main/java/org/nuxeo/ecm/core/api/security/ACE.java
+++ b/nuxeo-core/nuxeo-core-api/src/main/java/org/nuxeo/ecm/core/api/security/ACE.java
@@ -24,6 +24,8 @@ import java.util.Calendar;
 import java.util.GregorianCalendar;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.regex.*;
+import java.util.ArrayList;
 
 import org.apache.commons.lang.StringUtils;
 
@@ -69,10 +71,23 @@ public final class ACE implements Serializable, Cloneable {
             return null;
         }
 
-        String[] parts = aceId.split(":");
-        if (parts.length < 3) {
-            throw new IllegalArgumentException(String.format("Invalid ACE id: %s", aceId));
+	// An ACE is composed of tokens separated with ":" caracter
+	// First 3 tokens are mandatory; following 3 tokens are optional
+        ArrayList<String> tokenList = new ArrayList<>();
+	Pattern p = Pattern.compile("^(.+):([^:]+):([^:]+):([^:]*):([^:]*):([^:]*)$");
+        Matcher m = p.matcher(aceId);
+        boolean b = m.matches();
+        if(!b) {
+	   throw new IllegalArgumentException(String.format("Invalid ACE id: %s", aceId));
+	}
+
+	for(int i=1; i <= m.groupCount(); i++) {
+		tokenList.add(m.group(i));
         }
+
+	// Turn ArrayList into an array of Strings	
+	String[] parts = new String[tokenList.size()];
+        parts = tokenList.toArray(new String[]{});
 
         String username = parts[0];
         String permission = parts[1];

--- a/nuxeo-core/nuxeo-core-api/src/main/java/org/nuxeo/ecm/core/api/security/ACE.java
+++ b/nuxeo-core/nuxeo-core-api/src/main/java/org/nuxeo/ecm/core/api/security/ACE.java
@@ -24,8 +24,8 @@ import java.util.Calendar;
 import java.util.GregorianCalendar;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.regex.*;
-import java.util.ArrayList;
+import java.util.regex.Pattern;
+import java.util.regex.Matcher;
 
 import org.apache.commons.lang.StringUtils;
 
@@ -61,6 +61,8 @@ public final class ACE implements Serializable, Cloneable {
 
     private Map<String, Serializable> contextData = new HashMap<>();
 
+    protected static final Pattern p = Pattern.compile("^(.+):([^:]+):([^:]+):([^:]*):([^:]*):([^:]*)$");
+
     /**
      * Create an ACE from an id.
      *
@@ -71,23 +73,20 @@ public final class ACE implements Serializable, Cloneable {
             return null;
         }
 
-	// An ACE is composed of tokens separated with ":" caracter
-	// First 3 tokens are mandatory; following 3 tokens are optional
-        ArrayList<String> tokenList = new ArrayList<>();
-	Pattern p = Pattern.compile("^(.+):([^:]+):([^:]+):([^:]*):([^:]*):([^:]*)$");
+        // An ACE is composed of tokens separated with ":" caracter
+        // First 3 tokens are mandatory; following 3 tokens are optional
+        // The ":" separator is still present even if the tokens are empty
+        //   Example: jsmith:ReadWrite:true:::
+        // The first token (username) is allowed to contain embedded ":".
+        String[] parts = new String[6];
         Matcher m = p.matcher(aceId);
-        boolean b = m.matches();
-        if(!b) {
-	   throw new IllegalArgumentException(String.format("Invalid ACE id: %s", aceId));
-	}
-
-	for(int i=1; i <= m.groupCount(); i++) {
-		tokenList.add(m.group(i));
+        if (!m.matches()) {
+            throw new IllegalArgumentException(String.format("Invalid ACE id: %s", aceId));
         }
 
-	// Turn ArrayList into an array of Strings	
-	String[] parts = new String[tokenList.size()];
-        parts = tokenList.toArray(new String[]{});
+        for (int i = 1; i <= m.groupCount(); i++) {
+            parts[i - 1] = m.group(i);
+        }
 
         String username = parts[0];
         String permission = parts[1];

--- a/nuxeo-core/nuxeo-core-api/src/test/java/org/nuxeo/ecm/core/api/security/TestACE.java
+++ b/nuxeo-core/nuxeo-core-api/src/test/java/org/nuxeo/ecm/core/api/security/TestACE.java
@@ -153,6 +153,17 @@ public class TestACE {
         assertEquals(cal1, ace.getBegin());
         assertNull(ace.getEnd());
         assertTrue(ace.isEffective());
+        
+        // Tests with a username that includes colons ":"
+        aceId = "mycorp:dep:research:project23:read:true::" + cal1.getTimeInMillis() + ":";
+        ace = ACE.fromId(aceId);
+        assertNotNull(ace);
+        assertEquals("mycorp:dep:research:project23", ace.getUsername());
+        assertEquals("read", ace.getPermission());
+        assertTrue(ace.isGranted());
+        assertEquals(cal1, ace.getBegin());
+        assertNull(ace.getEnd());
+        assertTrue(ace.isEffective());
     }
 
     @Test(expected = IllegalArgumentException.class)


### PR DESCRIPTION
Our Nuxeo platform is configured to use external users and groups defined in our LDAP directory. The group IDs include “:” characters and were correctly supported with Nuxeo 5.8 .

We encountered an exception while trying to remove a permission associated to such a group with Nuxeo 7.10. The issue is related to the group ID format that includes “:” characters that conflicts with Nuxeo's ACE format that also uses “:” as a separator.

The fix is a code change that preserves the first item of an ACE ID, even if it contains colons ":". It does not break the ACE format logic; it just makes the ACE parser more precise and therefore more robust to unexpected username/group ID formats like ours.

The exception we get while trying to remove permissions for group “ur1:dsi:snum:groupes:groupe2” : chain :
Name: Document.RemovePermission
Exception: OperationException
Caught error: Failed to invoke operation Document.RemovePermission
Caused by: java.lang.NumberFormatException: For input string: “groupe2”
Hierarchy calls 
org.nuxeo.ecm.automation.core.operations.document.RemovePermission

at org.nuxeo.ecm.automation.core.impl.OperationServiceImpl.run(OperationServiceImpl.java:232)
at org.nuxeo.ecm.automation.core.impl.OperationServiceImpl.run(OperationServiceImpl.java:115)
at org.nuxeo.ecm.automation.server.jaxrs.OperationResource.execute(OperationResource.java:51)
at org.nuxeo.ecm.automation.server.jaxrs.ExecutableResource.doPost(ExecutableResource.java:61)
… 88 more
Caused by: org.nuxeo.ecm.automation.OperationException: Failed to invoke operation Document.RemovePermission
at org.nuxeo.ecm.automation.core.impl.InvokableMethod.invoke(InvokableMethod.java:182)
at org.nuxeo.ecm.automation.core.impl.CompiledChainImpl.doInvoke(CompiledChainImpl.java:128)
at org.nuxeo.ecm.automation.core.impl.CompiledChainImpl.invoke(CompiledChainImpl.java:114)
at org.nuxeo.ecm.automation.core.impl.OperationServiceImpl.run(OperationServiceImpl.java:208)
… 91 more
Caused by: java.lang.NumberFormatException: For input string: “groupe2”
at java.lang.NumberFormatException.forInputString(NumberFormatException.java:65)
at java.lang.Long.parseLong(Long.java:589)
at java.lang.Long.valueOf(Long.java:803)
at org.nuxeo.ecm.core.api.security.ACE.fromId(ACE.java:82)
at org.nuxeo.ecm.automation.core.operations.document.RemovePermission.removePermission(RemovePermission.java:83)
at org.nuxeo.ecm.automation.core.operations.document.RemovePermission.run(RemovePermission.java:61)
at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
at java.lang.reflect.Method.invoke(Method.java:497)
at org.nuxeo.ecm.automation.core.impl.InvokableMethod.doInvoke(InvokableMethod.java:164)
at org.nuxeo.ecm.automation.core.impl.InvokableMethod.invoke(InvokableMethod.java:170)
… 94 more

