### PR TITLE
NXP-21266: allow blob uris to be used as content source

### DIFF
--- a/nuxeo-services/nuxeo-platform-web-common/src/main/resources/OSGI-INF/web-request-controller-contrib.xml
+++ b/nuxeo-services/nuxeo-platform-web-common/src/main/resources/OSGI-INF/web-request-controller-contrib.xml
@@ -50,7 +50,7 @@
     <header name="X-XSS-Protection">1; mode=block</header>
     <header name="X-Frame-Options">${nuxeo.frame.options:=SAMEORIGIN}</header>
     <!-- this is a permissive Content-Security-Policy, which should be overridden for more security -->
-    <header name="Content-Security-Policy">default-src *; script-src 'unsafe-inline' 'unsafe-eval' data: *; style-src 'unsafe-inline' *; font-src data: *</header>
+    <header name="Content-Security-Policy">default-src * blob:; script-src 'unsafe-inline' 'unsafe-eval' data: *; style-src 'unsafe-inline' *; font-src data: *</header>
   </extension>
 
 </component>


### PR DESCRIPTION
Fix for CSP issue in PDF preview with images to be backported to 8.10