### PR TITLE
fix-NXP-21364-pdf-preview-shows-wrong-characters-7.10

### DIFF
--- a/nuxeo-services/nuxeo-platform-convert/pom.xml
+++ b/nuxeo-services/nuxeo-platform-convert/pom.xml
@@ -40,6 +40,10 @@
     </dependency>
     <dependency>
       <groupId>org.nuxeo.ecm.core</groupId>
+      <artifactId>nuxeo-core-convert-plugins</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.nuxeo.ecm.core</groupId>
       <artifactId>nuxeo-core-mimetype</artifactId>
     </dependency>
     <dependency>


### PR DESCRIPTION
Context: https://jira.nuxeo.com/browse/NXP-21364

When detecting the encoding of the provided html file in `UTF8CharsetConverter`, `CharsetDetector` generates a `CharsetMatch` with “Big5” encoding (with a value of confidence of 10).
This sample html file contains an inline image in base64. When this image is removed, the encoding of the html file is correctly evaluated as “UTF-8”.
I tried to create a new test case based on the sample html file, using the inline image block, which resulted also in a “UTF-8” match. Apparently it’s the match between that specific image block and the rest of the file that causes the evaluation to result in a “Big5” match (making it difficult to find a failing html resource that is not this particular one).

(T&P did not create the PR: https://qa2.nuxeo.org/jenkins/job/TestAndPush/job/ondemand-testandpush-mnixo-7.10/1/)