### PR TITLE
fix-NXP-19575-remove-password-from-json-payload-7.10

### DIFF
--- a/nuxeo-features/rest-api/nuxeo-rest-api-test/src/test/java/org/nuxeo/ecm/restapi/test/UserGroupTest.java
+++ b/nuxeo-features/rest-api/nuxeo-rest-api-test/src/test/java/org/nuxeo/ecm/restapi/test/UserGroupTest.java
@@ -360,8 +360,8 @@ public class UserGroupTest extends BaseUserTest {
         // When I call JSON for user1
         JsonNode node = getResponseAsJson(RequestType.GET, "/user/user1");
 
-        // Then it doesn't contain the password
-        assertEquals("", node.get("properties").get("password").getValueAsText());
+        // Then it doesn't contain the password at all
+        assertNull(node.get("properties").get("password"));
 
     }
 

--- a/nuxeo-services/nuxeo-platform-usermanager-core/src/main/java/org/nuxeo/ecm/platform/usermanager/io/NuxeoPrincipalJsonWriter.java
+++ b/nuxeo-services/nuxeo-platform-usermanager-core/src/main/java/org/nuxeo/ecm/platform/usermanager/io/NuxeoPrincipalJsonWriter.java
@@ -131,10 +131,8 @@ public class NuxeoPrincipalJsonWriter extends ExtensibleEntityJsonWriter<NuxeoPr
         jg.writeObjectFieldStart("properties");
         for (Property property : userPart.getChildren()) {
             String localName = property.getField().getName().getLocalName();
-            jg.writeFieldName(localName);
-            if (localName.equals(getPasswordField())) {
-                jg.writeString("");
-            } else {
+            if (!localName.equals(getPasswordField())) {
+                jg.writeFieldName(localName);
                 OutputStream out = new OutputStreamWithJsonWriter(jg);
                 propertyWriter.write(property, Property.class, Property.class, APPLICATION_JSON_TYPE, out);
             }

--- a/nuxeo-services/nuxeo-platform-usermanager-core/src/test/java/org/nuxeo/ecm/platform/usermanager/io/NuxeoPrincipalJsonWriterTest.java
+++ b/nuxeo-services/nuxeo-platform-usermanager-core/src/test/java/org/nuxeo/ecm/platform/usermanager/io/NuxeoPrincipalJsonWriterTest.java
@@ -51,13 +51,12 @@ public class NuxeoPrincipalJsonWriterTest extends
         json.has("id").isEquals("Administrator");
         json.has("isAdministrator").isTrue();
         json.has("isAnonymous").isFalse();
-        JsonAssert model = json.has("properties").properties(8);
+        JsonAssert model = json.has("properties").properties(7);
         model.has("lastName").isEmptyStringOrNull();
         model.has("username").isEquals("Administrator");
         model.has("email").isEquals("devnull@nuxeo.com");
         model.has("company").isEmptyStringOrNull();
         model.has("firstName").isEmptyStringOrNull();
-        model.has("password").isEmptyStringOrNull();
         model.has("groups").contains("administrators");
         JsonAssert exGroup = json.has("extendedGroups").length(1).has(0);
         exGroup.properties(3);


### PR DESCRIPTION
PR created from https://qa2.nuxeo.org/jenkins/job/TestAndPush/job/ondemand-testandpush-fdavid-7.10/17/

This is in order to be able to set password property when creating a user (https://jira.nuxeo.com/browse/JAVACLIENT-111) with the Java Client version 1.2 which runs with Nuxeo 7.10