### PR TITLE
NXP-21574 entry values loading mechanism in SQL session

### DIFF
--- a/nuxeo-features/nuxeo-automation/nuxeo-automation-features/src/test/java/org/nuxeo/ecm/automation/core/test/directory/DirectoryOperationsTest.java
+++ b/nuxeo-features/nuxeo-automation/nuxeo-automation-features/src/test/java/org/nuxeo/ecm/automation/core/test/directory/DirectoryOperationsTest.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright 2006-2012 Nuxeo SA (http://nuxeo.com/) and others.
+ * (C) Copyright 2006-2017 Nuxeo (http://nuxeo.com/) and others.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -80,7 +80,7 @@ public class DirectoryOperationsTest {
     protected DirectoryService directoryService;
 
     protected void createEntry(String id, String label, int obsolete) {
-        Map<String, Object> m = new HashMap<String, Object>();
+        Map<String, Object> m = new HashMap<>();
         m.put("id", id);
         m.put("label", label);
         m.put("obsolete", obsolete);
@@ -92,10 +92,10 @@ public class DirectoryOperationsTest {
 
     @Test
     public void shouldCreateNewEntries() throws Exception {
-        String newEntries = "[{\"id\": \"newContinent\"," + "\"label\": \"newLabel\"," + "\"obsolete\": 0},"
-                + "{\"id\": \"anotherContinent\"," + "\"label\": \"anotherLabel\"," + "\"obsolete\": 0}]";
+        String newEntries = "[{\"id\": \"newContinent\", \"label\": \"newLabel\", \"obsolete\": 0},"
+                + "{\"id\": \"anotherContinent\", \"label\": \"anotherLabel\", \"obsolete\": 0}]";
 
-        Map<String, Object> params = new HashMap<String, Object>();
+        Map<String, Object> params = new HashMap<>();
         params.put("directoryName", "continent");
         params.put("entries", newEntries);
         OperationParameters oparams = new OperationParameters(CreateDirectoryEntries.ID, params);
@@ -125,9 +125,9 @@ public class DirectoryOperationsTest {
 
     @Test
     public void shouldNotCreateNewEntryIFEntryAlreadyExsists() throws Exception {
-        String newEntries = "[{\"id\": \"europe\"," + "\"label\": \"europe\"," + "\"obsolete\": 0}]";
+        String newEntries = "[{\"id\": \"europe\", \"label\": \"europe\", \"obsolete\": 0}]";
 
-        Map<String, Object> params = new HashMap<String, Object>();
+        Map<String, Object> params = new HashMap<>();
         params.put("directoryName", "continent");
         params.put("entries", newEntries);
         OperationParameters oparams = new OperationParameters(CreateDirectoryEntries.ID, params);
@@ -151,7 +151,7 @@ public class DirectoryOperationsTest {
     public void shouldDeleteEntries() throws Exception {
         createEntry("entryToDelete", "entryToDeleteLabel", 0);
 
-        Map<String, Object> params = new HashMap<String, Object>();
+        Map<String, Object> params = new HashMap<>();
         params.put("directoryName", "continent");
         params.put("entries", "[\"entryToDelete\"]");
         OperationParameters oparams = new OperationParameters(DeleteDirectoryEntries.ID, params);
@@ -177,7 +177,7 @@ public class DirectoryOperationsTest {
     public void shouldMarkEntriesAsObsolete() throws Exception {
         createEntry("entryToMarkAsObsolete", "entryToMarkAsObsoleteLabel", 0);
 
-        Map<String, Object> params = new HashMap<String, Object>();
+        Map<String, Object> params = new HashMap<>();
         params.put("directoryName", "continent");
         params.put("markObsolete", true);
         params.put("entries", "[\"entryToMarkAsObsolete\"]");
@@ -206,10 +206,9 @@ public class DirectoryOperationsTest {
     public void shouldUpdateEntries() throws Exception {
         createEntry("entryToUpdate", "entryToUpdateLabel", 0);
 
-        String entriesToUpdate = "[{\"id\": \"entryToUpdate\"," + "\"label\": \"newEntryToUpdateLabel\","
-                + "\"obsolete\": 0}]";
+        String entriesToUpdate = "[{\"id\": \"entryToUpdate\", \"label\": \"newEntryToUpdateLabel\", \"obsolete\": 0}]";
 
-        Map<String, Object> params = new HashMap<String, Object>();
+        Map<String, Object> params = new HashMap<>();
         params.put("directoryName", "continent");
         params.put("entries", entriesToUpdate);
         OperationParameters oparams = new OperationParameters(UpdateDirectoryEntries.ID, params);
@@ -237,7 +236,7 @@ public class DirectoryOperationsTest {
     public void shouldReadEntries() throws Exception {
         String entriesToRead = "[\"europe\", \"asia\", \"oceania\"]";
 
-        Map<String, Object> params = new HashMap<String, Object>();
+        Map<String, Object> params = new HashMap<>();
         params.put("directoryName", "continent");
         params.put("entries", entriesToRead);
         OperationParameters oparams = new OperationParameters(ReadDirectoryEntries.ID, params);

--- a/nuxeo-features/nuxeo-automation/nuxeo-automation-features/src/test/java/org/nuxeo/ecm/automation/core/test/directory/DirectoryOperationsTest.java
+++ b/nuxeo-features/nuxeo-automation/nuxeo-automation-features/src/test/java/org/nuxeo/ecm/automation/core/test/directory/DirectoryOperationsTest.java
@@ -15,6 +15,7 @@
  *
  * Contributors:
  *     Thomas Roger <troger@nuxeo.com>
+ *     Mincong Huang <mhuang@nuxeo.com>
  */
 
 package org.nuxeo.ecm.automation.core.test.directory;
@@ -24,6 +25,8 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.fail;
 
+import java.io.Serializable;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -46,6 +49,7 @@ import org.nuxeo.ecm.automation.core.operations.services.directory.UpdateDirecto
 import org.nuxeo.ecm.core.api.Blob;
 import org.nuxeo.ecm.core.api.CoreSession;
 import org.nuxeo.ecm.core.api.DocumentModel;
+import org.nuxeo.ecm.core.api.DocumentModelList;
 import org.nuxeo.ecm.core.test.CoreFeature;
 import org.nuxeo.ecm.core.test.DefaultRepositoryInit;
 import org.nuxeo.ecm.core.test.annotations.RepositoryConfig;
@@ -91,9 +95,44 @@ public class DirectoryOperationsTest {
     }
 
     @Test
-    public void shouldCreateNewEntries() throws Exception {
+    public void shouldCreateNewEntriesIfAllParamsFilled() throws Exception {
         String newEntries = "[{\"id\": \"newContinent\", \"label\": \"newLabel\", \"obsolete\": 0},"
                 + "{\"id\": \"anotherContinent\", \"label\": \"anotherLabel\", \"obsolete\": 0}]";
+
+        Map<String, Object> params = new HashMap<>();
+        params.put("directoryName", "continent");
+        params.put("entries", newEntries);
+        OperationParameters oparams = new OperationParameters(CreateDirectoryEntries.ID, params);
+
+        OperationContext ctx = new OperationContext(session);
+        OperationChain chain = new OperationChain("fakeChain");
+        chain.add(oparams);
+        Blob result = (Blob) service.run(ctx, chain);
+        assertNotNull(result);
+
+        ObjectMapper mapper = new ObjectMapper();
+        List<String> createdIds = mapper.readValue(result.getString(), new TypeReference<List<String>>() {
+        });
+
+        assertEquals(2, createdIds.size());
+        assertEquals("newContinent", createdIds.get(0));
+        assertEquals("anotherContinent", createdIds.get(1));
+
+        try (Session directorySession = directoryService.open("continent")) {
+            try {
+                assertEntriesIn(directorySession);
+            } finally {
+                // tear down
+                createdIds.forEach(directorySession::deleteEntry);
+            }
+        }
+    }
+
+    @Test
+    public void shouldCreateNewEntriesIfSomeParamsMissing() throws Exception {
+        // Field 'obsolete' is missing on purpose.
+        String newEntries = "[{\"id\": \"newContinent\", \"label\": \"newLabel\"},"
+                + "{\"id\": \"anotherContinent\", \"label\": \"anotherLabel\"}]";
 
         Map<String, Object> params = new HashMap<>();
         params.put("directoryName", "continent");
@@ -114,13 +153,30 @@ public class DirectoryOperationsTest {
         assertEquals("anotherContinent", createdIds.get(1));
 
         try (Session directorySession = directoryService.open("continent")) {
-            DocumentModel entry = directorySession.getEntry("newContinent");
-            assertNotNull(entry);
-            assertEquals("newLabel", entry.getProperty("vocabulary", "label"));
-            entry = directorySession.getEntry("anotherContinent");
-            assertNotNull(entry);
-            assertEquals("anotherLabel", entry.getProperty("vocabulary", "label"));
+            try {
+                assertEntriesIn(directorySession);
+            } finally {
+                // tear down
+                createdIds.forEach(directorySession::deleteEntry);
+            }
         }
+    }
+
+    private void assertEntriesIn(Session directorySession) {
+        // assert using method 'Session#getEntry'
+        DocumentModel entry = directorySession.getEntry("newContinent");
+        assertEquals("newLabel", entry.getProperty("vocabulary", "label"));
+        assertEquals(0L, entry.getProperty("vocabulary", "obsolete"));
+
+        entry = directorySession.getEntry("anotherContinent");
+        assertEquals("anotherLabel", entry.getProperty("vocabulary", "label"));
+        assertEquals(0L, entry.getProperty("vocabulary", "obsolete"));
+
+        // assert using method 'Session#query'
+        Map<String, Serializable> filter = new HashMap<>();
+        filter.put("obsolete", 0L);
+        DocumentModelList docs = directorySession.query(filter, Collections.emptySet(), Collections.emptyMap(), false);
+        assertEquals(9, docs.size());
     }
 
     @Test

--- a/nuxeo-services/nuxeo-platform-directory/nuxeo-platform-directory-sql/src/main/java/org/nuxeo/ecm/directory/sql/SQLSession.java
+++ b/nuxeo-services/nuxeo-platform-directory/nuxeo-platform-directory-sql/src/main/java/org/nuxeo/ecm/directory/sql/SQLSession.java
@@ -220,14 +220,15 @@ public class SQLSession extends BaseSession implements EntrySource {
 
         List<Column> columnList = new ArrayList<>(table.getColumns());
         Column idColumn = null;
-        for (Iterator<Column> i = columnList.iterator(); i.hasNext();) {
-            Column column = i.next();
+        for (Column column : columnList) {
             if (column.isIdentity()) {
                 idColumn = column;
             }
-            String prefixField = schemaFieldMap.get(column.getKey()).getName().getPrefixedName();
-            if (fieldMap.get(prefixField) == null) {
-                i.remove();
+            String localFieldName = schemaFieldMap.get(column.getKey()).getName().getLocalName();
+
+            if (!fieldMap.containsKey(localFieldName)) {
+                Field field = schemaFieldMap.get(localFieldName);
+                fieldMap.put(localFieldName, field.getDefaultValue());
             }
         }
         Insert insert = new Insert(table);


### PR DESCRIPTION
When dealing with JIRA ticket [NXP-21574][NXP-21574]: vocabulary entries created with `Directory.CreateEntries` are not visible in widgets, I found the origin of the problem—the entry values loading mechanism was incorrect in `org.nuxeo.ecm.directory.sql.SQLSession`. Previously, we removed candidat columns from the SQL if they were not defined by user via operation chain. Here's the [excerpt][excerpt] of commit ff8295d about how it worked:

```java
for (Iterator<Column> i = columnList.iterator(); i.hasNext();) {
    ...
    String prefixField = schemaFieldMap.get(column.getKey()).getName().getPrefixedName();
    if (fieldMap.get(prefixField) == null) {
        i.remove();
    }
}
```

A better loading mechanism is to use default values, defined in the XSD, instead of removing them. So here's the correction:

```java
for (Column column : columnList) {
    ...
    String localFieldName = schemaFieldMap.get(column.getKey()).getName().getLocalName();
    if (!fieldMap.containsKey(localFieldName)) {
        Field field = schemaFieldMap.get(localFieldName);
        fieldMap.put(localFieldName, field.getDefaultValue());
    }
}
```

The rest of code in this PR is just for testing. See also:

- The JIRA ticket: https://jira.nuxeo.com/browse/NXP-21574
- Successful Jenkins T&P: https://qa.nuxeo.org/jenkins/view/TestAndPush/job/TestAndPush/job/ondemand-testandpush-mhuang-9/13/

[NXP-21574]: https://jira.nuxeo.com/browse/NXP-21574
[excerpt]: https://github.com/nuxeo/nuxeo/blob/708b56b41c825f638751b9b1cfb0b5fbe7b69fb3/nuxeo-services/nuxeo-platform-directory/nuxeo-platform-directory-sql/src/main/java/org/nuxeo/ecm/directory/sql/SQLSession.java#L228-L231