### PR TITLE
NXP-21559: Add user check when assigning a permission (fixup)

### DIFF
--- a/nuxeo-features/nuxeo-automation/nuxeo-automation-core/src/main/java/org/nuxeo/ecm/automation/core/operations/document/AddPermission.java
+++ b/nuxeo-features/nuxeo-automation/nuxeo-automation-core/src/main/java/org/nuxeo/ecm/automation/core/operations/document/AddPermission.java
@@ -120,7 +120,7 @@ public class AddPermission {
         } else {
             username = user;
             UserManager userManager = Framework.getService(UserManager.class);
-            if (userManager.getUserModel(username) == null && userManager.getGroup(username) == null) {
+            if (userManager.getUserModel(username) == null && userManager.getGroupModel(username) == null) {
                 String errorMsg = "User or group name '" + username + "' does not exist. Please provide a valid name.";
                 throw new NuxeoException(errorMsg);
             }

--- a/nuxeo-features/nuxeo-automation/nuxeo-automation-core/src/test/java/org/nuxeo/ecm/automation/core/operations/security/PermissionAutomationTest.java
+++ b/nuxeo-features/nuxeo-automation/nuxeo-automation-core/src/test/java/org/nuxeo/ecm/automation/core/operations/security/PermissionAutomationTest.java
@@ -45,7 +45,6 @@ import org.nuxeo.ecm.automation.core.operations.document.ReplacePermission;
 import org.nuxeo.ecm.core.api.CoreSession;
 import org.nuxeo.ecm.core.api.DocumentModel;
 import org.nuxeo.ecm.core.api.impl.DocumentModelImpl;
-import org.nuxeo.ecm.core.api.impl.NuxeoGroupImpl;
 import org.nuxeo.ecm.core.api.security.ACL;
 import org.nuxeo.ecm.core.api.security.ACP;
 import org.nuxeo.ecm.core.api.security.Access;
@@ -99,7 +98,7 @@ public class PermissionAutomationTest {
         src = session.getDocument(src.getRef());
 
         when(userManager.getUserModel("existingUser")).thenReturn(new DocumentModelImpl("user"));
-        when(userManager.getGroup("existingGroup")).thenReturn(new NuxeoGroupImpl("existingGroup"));
+        when(userManager.getGroupModel("existingGroup")).thenReturn(new DocumentModelImpl("group"));
         when(administratorGroupsProvider.getAdministratorsGroups()).thenReturn(
                 Collections.singletonList("administrators"));
     }


### PR DESCRIPTION
This is a fixup PR of #539. It is created seperately because the previous PR was mistakenly merged into master by @nuxeojenkins. I replaced `getGroup` by `getGroupModel` to keep the consistency with existing code.

T&P is successful: https://qa.nuxeo.org/jenkins/view/TestAndPush/job/TestAndPush/job/ondemand-testandpush-mhuang-9/16/