### PR TITLE
NXP-21810: bind gatling.skip on skipITs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5654,6 +5654,9 @@
           <groupId>io.gatling</groupId>
           <artifactId>gatling-maven-plugin</artifactId>
           <version>${gatling.version}</version>
+          <configuration>
+            <skip>${skipITs}</skip>
+          </configuration>
         </plugin>
         <plugin>
           <groupId>net.alchim31.maven</groupId>


### PR DESCRIPTION
Default gatling-maven-plugin configuration which will skip the Gatling tests if `skipITs=true`.

https://jira.nuxeo.com/browse/NXP-21810