### PR TITLE
NXP-21860: Add the ES query when the backend is ES

### DIFF
--- a/nuxeo-features/nuxeo-platform-audit/nuxeo-platform-audit-api/src/main/java/org/nuxeo/ecm/platform/audit/api/document/DocumentAuditHelper.java
+++ b/nuxeo-features/nuxeo-platform-audit/nuxeo-platform-audit-api/src/main/java/org/nuxeo/ecm/platform/audit/api/document/DocumentAuditHelper.java
@@ -44,7 +44,6 @@ import org.nuxeo.runtime.api.Framework;
  */
 public class DocumentAuditHelper {
 
-    @SuppressWarnings({ "unchecked", "boxing" })
     public static AdditionalDocumentAuditParams getAuditParamsForUUID(String uuid, CoreSession session) {
 
         IdRef ref = new IdRef(uuid);
@@ -87,32 +86,8 @@ public class DocumentAuditHelper {
                 return null;
             }
             result = new AdditionalDocumentAuditParams();
-            Calendar estimatedDate = ((Calendar) doc.getPropertyValue("dc:modified"));
 
-            // We can not directly use the repo timestamp because Audit and VCS can be in separated DB
-            // => try to find the matching TS in Audit
-            StringBuilder queryString = new StringBuilder();
-            queryString.append("from LogEntry log where log.docUUID in (");
-            queryString.append("'" + targetUUID + "'");
-            if (doc.isVersion()) {
-                DocumentModelList proxies = session.getProxies(doc.getRef(), null);
-                for (DocumentModel proxy : proxies) {
-                    queryString.append(",'" + proxy.getId() + "'");
-                }
-            }
-            queryString.append(",'" + doc.getId() + "'");
-            queryString.append(") AND log.eventId IN (");
-            queryString.append("'" + DocumentEventTypes.DOCUMENT_CREATED + "'");
-            queryString.append(",'" + DocumentEventTypes.DOCUMENT_CHECKEDIN + "'");
-            queryString.append(") AND log.eventDate >= :minDate ");
-            queryString.append(" order by log.eventId asc");
-
-            estimatedDate.add(Calendar.MILLISECOND, -500);
-            Map<String, Object> params = new HashMap<String, Object>();
-            params.put("minDate", estimatedDate.getTime());
-
-            List<LogEntry> dateEntries = (List<LogEntry>) reader.nativeQuery(queryString.toString(),
-                    params, 0, 20);
+            List<LogEntry> dateEntries = runNativeQueryForBackend(session, doc, targetUUID, reader);
             if (dateEntries.size() > 0) {
                 result.targetUUID = targetUUID;
                 Calendar maxDate = new GregorianCalendar();
@@ -127,6 +102,65 @@ public class DocumentAuditHelper {
             }
         }
         return result;
+    }
+
+    /**
+     * Fix to generate and run the query based on the backend available for the Audit.
+     *
+     * @return
+     * @since 8.10
+     */
+    @SuppressWarnings("unchecked")
+    protected static List<LogEntry> runNativeQueryForBackend(CoreSession session, DocumentModel doc, String targetUUID,
+            AuditReader reader) {
+        Calendar estimatedDate = ((Calendar) doc.getPropertyValue("dc:modified"));
+
+        // We can not directly use the repo timestamp because Audit and VCS can be in separated DB
+        // => try to find the matching TS in Audit
+        Map<String, Object> params = new HashMap<String, Object>();
+        params.put("minDate", estimatedDate.getTime());
+        estimatedDate.add(Calendar.MILLISECOND, -500);
+
+        StringBuilder queryString = new StringBuilder();
+        // Check if the audit uses elasticsearch as backend
+        boolean isESBackEnd = reader.getClass().getSimpleName().equals("ESAuditBackend");
+        if (isESBackEnd) {
+            queryString.append("{\"query\":{\"bool\":{\"must\": { \"match_all\": {} },"
+                    + "\"filter\": {\"and\" : [{\"terms\": {\"docUUID\": [");
+
+            // Build the list of ids
+            queryString.append("\"" + targetUUID + "\"");
+            if (doc.isVersion()) {
+                DocumentModelList proxies = session.getProxies(doc.getRef(), null);
+                for (DocumentModel proxy : proxies) {
+                    queryString.append(",\"" + proxy.getId() + "\"");
+                }
+            }
+            // Add the events
+            queryString.append("]}}, {\"terms\": {\"eventId\": [");
+            queryString.append("\"" + DocumentEventTypes.DOCUMENT_CREATED + "\"");
+            queryString.append(",\"" + DocumentEventTypes.DOCUMENT_CHECKEDIN + "\"");
+
+            // Add the range date
+            queryString.append("]}},{\"range\": {\"eventDate\": {\"gte\" : \"${minDate}\"}}}]}}},\"sort\":[{\"eventId\": \"asc\"}]}");
+        } else {
+            queryString.append("from LogEntry log where log.docUUID in (");
+            queryString.append("'" + targetUUID + "'");
+            if (doc.isVersion()) {
+                DocumentModelList proxies = session.getProxies(doc.getRef(), null);
+                for (DocumentModel proxy : proxies) {
+                    queryString.append(",'" + proxy.getId() + "'");
+                }
+            }
+            queryString.append(",'" + doc.getId() + "'");
+            queryString.append(") AND log.eventId IN (");
+            queryString.append("'" + DocumentEventTypes.DOCUMENT_CREATED + "'");
+            queryString.append(",'" + DocumentEventTypes.DOCUMENT_CHECKEDIN + "'");
+            queryString.append(") AND log.eventDate >= :minDate ");
+            queryString.append(" order by log.eventId asc");
+        }
+
+        return (List<LogEntry>) reader.nativeQuery(queryString.toString(), params, 0, 20);
     }
 
 }


### PR DESCRIPTION
Quick fix for the branch 8.10 as we cannot add a new API in the AuditReader