### PR TITLE
NXP-21707: SleepWork with the same id should have the same duration w…

### DIFF
--- a/nuxeo-core/nuxeo-core-event/src/main/java/org/nuxeo/ecm/core/work/WorkManagerImpl.java
+++ b/nuxeo-core/nuxeo-core-event/src/main/java/org/nuxeo/ecm/core/work/WorkManagerImpl.java
@@ -816,7 +816,7 @@ public class WorkManagerImpl extends DefaultComponent implements WorkManager {
         SequenceTracer.start("awaitCompletion on " + ((queueId == null) ? "all queues" : queueId));
         long durationInMs = TimeUnit.MILLISECONDS.convert(duration, unit);
         long deadline = getTimestampAfter(durationInMs);
-        int pause = (int) Math.min(duration, 500L);
+        int pause = (int) Math.min(durationInMs, 500L);
         log.debug("awaitForCompletion " + durationInMs + " ms");
         do {
             if (noScheduledOrRunningWork(queueId)) {

--- a/nuxeo-core/nuxeo-core-event/src/test/java/org/nuxeo/ecm/core/work/WorkManagerTest.java
+++ b/nuxeo-core/nuxeo-core-event/src/test/java/org/nuxeo/ecm/core/work/WorkManagerTest.java
@@ -428,7 +428,7 @@ public class WorkManagerTest extends NXRuntimeTestCase {
         assertMetrics(0, 0, 1, 0);
 
         // Schedule a first work
-        int durationMS = 2000;
+        int durationMS = 3000;
         String workId = "1234";
         SleepWork work = new SleepWork(durationMS, false, workId);
         service.schedule(work);
@@ -438,8 +438,8 @@ public class WorkManagerTest extends NXRuntimeTestCase {
         assertMetrics(0, 1, 1, 0);
 
         // schedule another work with the same workId
-        int durationBisMS = 1000;
-        SleepWork workbis = new SleepWork(durationBisMS, false, workId);
+        // don't try to put a different duration, same work id means same work serializatoin
+        SleepWork workbis = new SleepWork(durationMS, false, workId);
         service.schedule(workbis);
 
         // wait a bit, the first work is still running, the scheduled work should wait
@@ -448,7 +448,7 @@ public class WorkManagerTest extends NXRuntimeTestCase {
         assertMetrics(1, 1, 1, 0);
 
         // wait enough so the first work is done and the second should be running
-        Thread.sleep(durationMS / 3 + durationBisMS / 2);
+        Thread.sleep(durationMS);
         assertMetrics(0, 1, 2, 0);
 
         assertTrue(service.awaitCompletion(2 * durationMS, TimeUnit.MILLISECONDS));


### PR DESCRIPTION
…hen scheduled concurrently, at least when using redis, also fixing  awaitForCompletion when using non millisecond unit