### PR TITLE
Update RedisSentinelDescriptor.java

### DIFF
--- a/nuxeo-core/nuxeo-core-redis/src/main/java/org/nuxeo/ecm/core/redis/RedisSentinelDescriptor.java
+++ b/nuxeo-core/nuxeo-core-redis/src/main/java/org/nuxeo/ecm/core/redis/RedisSentinelDescriptor.java
@@ -12,6 +12,7 @@ import java.util.HashSet;
 import java.util.Set;
 
 import org.nuxeo.common.xmap.annotation.XNode;
+import org.nuxeo.common.xmap.annotation.XNodeList;
 import org.nuxeo.common.xmap.annotation.XObject;
 
 import redis.clients.jedis.JedisPoolConfig;
@@ -20,6 +21,9 @@ import redis.clients.jedis.JedisSentinelPool;
 @XObject("sentinel")
 public class RedisSentinelDescriptor extends RedisServerDescriptor {
 
+    @XNodeList(value = "host", type = RedisHostDescriptor[].class, componentType = RedisHostDescriptor.class)
+    public RedisHostDescriptor[] hosts = new RedisHostDescriptor[0];
+    
     @XNode("master")
     public String master = "master";
 


### PR DESCRIPTION
The "host" variable is not set for the class "RedisSentinelDescriptor".

The sentinel mode on Redis for Nuxeo version 6.0 can not work without it.

Can you update the code in the next hotfix ?

Thanks