### PR TITLE
NXP-21759: Add a performance option org.nuxeo.core.isLastestVersion.d…

### DIFF
--- a/nuxeo-core/nuxeo-core-storage-dbs/src/main/java/org/nuxeo/ecm/core/storage/dbs/DBSSession.java
+++ b/nuxeo-core/nuxeo-core-storage-dbs/src/main/java/org/nuxeo/ecm/core/storage/dbs/DBSSession.java
@@ -19,6 +19,7 @@
 package org.nuxeo.ecm.core.storage.dbs;
 
 import static java.lang.Boolean.TRUE;
+import static org.nuxeo.ecm.core.api.AbstractSession.DISABLED_ISLATESTVERSION_PROPERTY;
 import static org.nuxeo.ecm.core.storage.dbs.DBSDocument.KEY_ACE_BEGIN;
 import static org.nuxeo.ecm.core.storage.dbs.DBSDocument.KEY_ACE_CREATOR;
 import static org.nuxeo.ecm.core.storage.dbs.DBSDocument.KEY_ACE_END;
@@ -169,6 +170,8 @@ public class DBSSession implements Session {
 
     private long LOG_MIN_DURATION_NS = -1 * 1000000;
 
+    protected boolean isLatestVersionDisabled = false;
+
     public DBSSession(DBSRepository repository) {
         this.repository = repository;
         transaction = new DBSTransactionState(repository, this);
@@ -178,6 +181,7 @@ public class DBSSession implements Session {
         saveTimer = registry.timer(MetricRegistry.name("nuxeo", "repositories", repository.getName(), "saves"));
         queryTimer = registry.timer(MetricRegistry.name("nuxeo", "repositories", repository.getName(), "queries"));
         LOG_MIN_DURATION_NS = Long.parseLong(Framework.getProperty(LOG_MIN_DURATION_KEY, "-1")) * 1000000;
+        isLatestVersionDisabled = Framework.isBooleanPropertyTrue(DISABLED_ISLATESTVERSION_PROPERTY);
     }
 
     @Override
@@ -561,7 +565,10 @@ public class DBSSession implements Session {
         docState.put(KEY_IS_CHECKED_IN, TRUE);
         docState.put(KEY_BASE_VERSION_ID, verId);
 
-        recomputeVersionSeries(id);
+        if (!isLatestVersionDisabled) {
+            recomputeVersionSeries(id);
+        }
+
         transaction.save();
 
         return getDocument(verId);

--- a/nuxeo-core/nuxeo-core/src/main/java/org/nuxeo/ecm/core/api/AbstractSession.java
+++ b/nuxeo-core/nuxeo-core/src/main/java/org/nuxeo/ecm/core/api/AbstractSession.java
@@ -139,6 +139,9 @@ public abstract class AbstractSession implements CoreSession, Serializable {
 
     public static final String TRASH_KEEP_CHECKED_IN_PROPERTY = "org.nuxeo.trash.keepCheckedIn";
 
+    // @since 9.1 disable ecm:isLatestVersion and ecm:isLatestMajorVersion updates for performance purpose
+    public static final String DISABLED_ISLATESTVERSION_PROPERTY = "org.nuxeo.core.isLatestVersion.disabled";
+
     public static final String BINARY_TEXT_SYS_PROP = "fulltextBinary";
 
     private Boolean limitedResults;

--- a/nuxeo-features/nuxeo-elasticsearch/nuxeo-elasticsearch-core/src/test/java/org/nuxeo/elasticsearch/test/TestAutomaticIndexing.java
+++ b/nuxeo-features/nuxeo-elasticsearch/nuxeo-elasticsearch-core/src/test/java/org/nuxeo/elasticsearch/test/TestAutomaticIndexing.java
@@ -35,6 +35,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.nuxeo.common.utils.FileUtils;
 import org.nuxeo.ecm.automation.core.util.DocumentHelper;
+import org.nuxeo.ecm.core.api.AbstractSession;
 import org.nuxeo.ecm.core.api.Blob;
 import org.nuxeo.ecm.core.api.Blobs;
 import org.nuxeo.ecm.core.api.CoreSession;
@@ -714,7 +715,42 @@ public class TestAutomaticIndexing {
     }
 
     @Test
-    public void shoulIndexLatestVersions() throws Exception {
+    public void shouldIndexLatestVersions() throws Exception {
+        createADocumentWith3Versions();
+
+        DocumentModelList ret = ess.query(new NxQueryBuilder(session).nxql("SELECT * FROM Document"));
+        Assert.assertEquals(4, ret.totalSize());
+
+        ret = ess.query(new NxQueryBuilder(session).nxql("SELECT * FROM Document WHERE ecm:isLatestVersion = 1"));
+        Assert.assertEquals(1, ret.totalSize());
+
+        ret = ess.query(new NxQueryBuilder(session).nxql("SELECT * FROM Document WHERE ecm:isLatestMajorVersion = 1"));
+        Assert.assertEquals(1, ret.totalSize());
+        Assert.assertEquals("v3", ret.get(0).getTitle());
+    }
+
+    @Test
+    public void shouldNotIndexLatestVersions() throws Exception {
+        System.setProperty(AbstractSession.DISABLED_ISLATESTVERSION_PROPERTY, "true");
+        try {
+            createADocumentWith3Versions();
+        } finally {
+            System.clearProperty(AbstractSession.DISABLED_ISLATESTVERSION_PROPERTY);
+        }
+
+        DocumentModelList ret = ess.query(new NxQueryBuilder(session).nxql("SELECT * FROM Document"));
+        Assert.assertEquals(4, ret.totalSize());
+
+        // but isLatestVersion and isLatestMajorVersion are not updated
+        ret = ess.query(new NxQueryBuilder(session).nxql("SELECT * FROM Document WHERE ecm:isLatestVersion = 1"));
+        Assert.assertEquals(3, ret.totalSize());
+
+        ret = ess.query(new NxQueryBuilder(session).nxql("SELECT * FROM Document WHERE ecm:isLatestMajorVersion = 1"));
+        Assert.assertEquals(3, ret.totalSize());
+
+    }
+
+    protected void createADocumentWith3Versions() throws Exception {
         startTransaction();
         DocumentModel file1 = new DocumentModelImpl("/", "testfile1", "File");
         file1 = session.createDocument(file1);
@@ -738,16 +774,6 @@ public class TestAutomaticIndexing {
         TransactionHelper.commitOrRollbackTransaction();
         waitForCompletion();
         startTransaction();
-
-        DocumentModelList ret = ess.query(new NxQueryBuilder(session).nxql("SELECT * FROM Document"));
-        Assert.assertEquals(4, ret.totalSize());
-
-        ret = ess.query(new NxQueryBuilder(session).nxql("SELECT * FROM Document WHERE ecm:isLatestVersion = 1"));
-        Assert.assertEquals(1, ret.totalSize());
-
-        ret = ess.query(new NxQueryBuilder(session).nxql("SELECT * FROM Document WHERE ecm:isLatestMajorVersion = 1"));
-        Assert.assertEquals(1, ret.totalSize());
-        Assert.assertEquals("v3", ret.get(0).getTitle());
     }
 
     @Test


### PR DESCRIPTION
…isabled to skip update of the ecm:isLatestVersion and ecm:isMajorLatestVersion flags, because it can be very expensive for document with lots of versoins