### PR TITLE
NXP-22012 fix wrong sentinel configuration (affect 6.0 only)

### DIFF
--- a/nuxeo-distribution/nuxeo-distribution-resources/src/main/resources/templates-tomcat/common-base/nxserver/config/redis-config.xml.nxftl
+++ b/nuxeo-distribution/nuxeo-distribution-resources/src/main/resources/templates-tomcat/common-base/nxserver/config/redis-config.xml.nxftl
@@ -11,7 +11,7 @@
       <failoverTimeout>${nuxeo.redis.ha.timeout}</failoverTimeout>
 <#assign names="${nuxeo.redis.ha.hosts}"?split(",") />
 <#list names as name>
-      <host name="${name}" port="${nuxeo.redis.ha.port}"/>
+      <hap name="${name}" port="${nuxeo.redis.ha.port}"/>
 </#list>
       <password>${nuxeo.redis.password}</password>
       <database>${nuxeo.redis.database}</database>


### PR DESCRIPTION
Didn't test and pushed, that configuration is not covered yet by the integration tests. I successfuly ran a fail over test locally on my host against a docker redis network. 