### PR TITLE
NXP-22321: Get the extension of the conversion from the mimetype

### DIFF
--- a/nuxeo-features/nuxeo-platform-imaging/nuxeo-platform-imaging-core/src/main/java/org/nuxeo/ecm/platform/picture/ImagingComponent.java
+++ b/nuxeo-features/nuxeo-platform-imaging/nuxeo-platform-imaging-core/src/main/java/org/nuxeo/ecm/platform/picture/ImagingComponent.java
@@ -399,8 +399,18 @@ public class ImagingComponent extends DefaultComponent implements ImagingService
 
         Blob viewBlob = callPictureConversionChain(doc, blob, pictureConversion, imageInfo, size, conversionFormat);
 
+        // If the extension of the generated binary is empty, it's fetched from the mimetype
+        String extension = FilenameUtils.getExtension(viewBlob.getFilename());
+        if (StringUtils.isEmpty(extension)) {
+            MimetypeRegistry mimetypeRegistry = Framework.getService(MimetypeRegistry.class);
+            List<String> extensions = mimetypeRegistry.getExtensionsFromMimetypeName(viewBlob.getMimeType());
+            if (extensions != null && !extensions.isEmpty()) {
+                extension = extensions.get(0);
+            }
+        }
+
         String viewFilename = String.format("%s_%s.%s", title, FilenameUtils.getBaseName(blob.getFilename()),
-                FilenameUtils.getExtension(viewBlob.getFilename()));
+                extension);
         viewBlob.setFilename(viewFilename);
         pictureViewMap.put(PictureView.FIELD_FILENAME, viewFilename);
         pictureViewMap.put(PictureView.FIELD_CONTENT, (Serializable) viewBlob);


### PR DESCRIPTION
Get the extension of the conversion from the mimetype if it's empty