### PR TITLE
Obey the MIME-TYPE on multipart file upload if set via the X-File-Type

### DIFF
--- a/nuxeo-features/rest-api/nuxeo-rest-api-server/src/main/java/org/nuxeo/ecm/restapi/server/jaxrs/BatchUploadObject.java
+++ b/nuxeo-features/rest-api/nuxeo-rest-api-server/src/main/java/org/nuxeo/ecm/restapi/server/jaxrs/BatchUploadObject.java
@@ -169,7 +169,10 @@ public class BatchUploadObject extends AbstractResource<ResourceTypeImpl> {
                     if (!UPLOAD_TYPE_CHUNKED.equals(uploadType)) {
                         fileName = blob.getFilename();
                     }
-                    mimeType = blob.getMimeType();
+                    // Don't change the mime-type if it was forced via the X-File-Type header
+                    if (mimeType == null || mimeType.isEmpty()) {
+                        mimeType = blob.getMimeType();
+                    }
                     uploadedSize = String.valueOf(blob.getLength());
                 }
             } else {


### PR DESCRIPTION
On multipart upload (/api/v1/upload/ endpoint), the X-File-Type header is not respected. 

This is a problem when trying to set the correct mime-type for svg, css, json and other files that are not recognised in the Nuxeo backend.