### PR TITLE
NXP-22362: use Java 7 version of PostgreSQL driver

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2842,7 +2842,7 @@
       <dependency>
         <groupId>org.postgresql</groupId>
         <artifactId>postgresql</artifactId>
-        <version>42.1.1</version>
+        <version>42.1.1.jre7</version>
       </dependency>
       <dependency>
         <groupId>mysql</groupId>


### PR DESCRIPTION
Following job is failing because wrong compiled version of PostgreSQL driver is used for 6.0:
https://qa2.nuxeo.org/jenkins/job/6.0/job/FT-nuxeo-6.0-selenium-cap-tomcat-multidb-linux/Slave=MULTIDB_LINUX_710,dbprofile=pgsql,jdk=java-7-openjdk/114/
