### PR TITLE
Fix nxp 23347 cmistests and mongodb prefixes backport 7.10

### DIFF
--- a/nuxeo-core/nuxeo-core-storage-dbs/src/main/java/org/nuxeo/ecm/core/storage/dbs/DBSDocument.java
+++ b/nuxeo-core/nuxeo-core-storage-dbs/src/main/java/org/nuxeo/ecm/core/storage/dbs/DBSDocument.java
@@ -187,6 +187,13 @@ public class DBSDocument extends BaseDocument<State> {
 
     public static final String APPLICATION_OCTET_STREAM = "application/octet-stream";
 
+    public static final String PROP_UID_MAJOR_VERSION = "uid:major_version";
+
+    public static final String PROP_UID_MINOR_VERSION = "uid:minor_version";
+
+    public static final String PROP_MAJOR_VERSION = "major_version";
+
+    public static final String PROP_MINOR_VERSION = "minor_version";
     protected final String id;
 
     protected final DBSDocumentState docState;
@@ -840,9 +847,9 @@ public class DBSDocument extends BaseDocument<State> {
     @Override
     protected String internalName(String name) {
         switch (name) {
-        case "major_version":
+        case PROP_MAJOR_VERSION:
             return KEY_MAJOR_VERSION;
-        case "minor_version":
+        case PROP_MINOR_VERSION:
             return KEY_MINOR_VERSION;
         }
         return name;

--- a/nuxeo-core/nuxeo-core-storage-dbs/src/main/java/org/nuxeo/ecm/core/storage/dbs/DBSSession.java
+++ b/nuxeo-core/nuxeo-core-storage-dbs/src/main/java/org/nuxeo/ecm/core/storage/dbs/DBSSession.java
@@ -1839,6 +1839,12 @@ public class DBSSession implements Session {
             return KEY_FULLTEXT_BINARY;
         case NXQL.ECM_ACL:
             return KEY_ACP;
+        case DBSDocument.PROP_UID_MAJOR_VERSION:
+        case DBSDocument.PROP_MAJOR_VERSION:
+            return DBSDocument.KEY_MAJOR_VERSION;
+        case DBSDocument.PROP_UID_MINOR_VERSION:
+        case DBSDocument.PROP_MINOR_VERSION:
+            return DBSDocument.KEY_MINOR_VERSION;
         case NXQL.ECM_FULLTEXT:
         case NXQL.ECM_TAG:
             throw new UnsupportedOperationException(name);

--- a/nuxeo-core/nuxeo-core-storage-dbs/src/main/java/org/nuxeo/ecm/core/storage/dbs/DBSStateFlattener.java
+++ b/nuxeo-core/nuxeo-core-storage-dbs/src/main/java/org/nuxeo/ecm/core/storage/dbs/DBSStateFlattener.java
@@ -1,0 +1,86 @@
+/*
+ * (C) Copyright 2016 Nuxeo SA (http://nuxeo.com/) and others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Contributors:
+ *     Florent Guillaume
+ *     Kevin Leturc
+ */
+package org.nuxeo.ecm.core.storage.dbs;
+
+import static org.nuxeo.ecm.core.storage.dbs.DBSDocument.KEY_PREFIX;
+
+import java.io.Serializable;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+
+import org.nuxeo.ecm.core.storage.State;
+
+/**
+ * Function to flatten and convert {@link State} into NXQL {@link Map}&lt;{@link String}, {@link Serializable}&gt;.
+ *
+ * @since 8.3
+ */
+public class DBSStateFlattener {
+
+    public static Map<String, Serializable> flatten(State state) {
+        Map<String, Serializable> map = new HashMap<>();
+        flatten(map, state, null);
+        return map;
+    }
+
+    private static void flatten(Map<String, Serializable> map, State state, String prefix) {
+        for (Entry<String, Serializable> en : state.entrySet()) {
+            String key = en.getKey();
+            Serializable value = en.getValue();
+            String name;
+            if (key.startsWith(KEY_PREFIX)) {
+                name = DBSSession.convToNXQL(key);
+                if (name == null) {
+                    // present in state but not returned to caller
+                    continue;
+                }
+            } else {
+                name = key;
+            }
+            name = prefix == null ? name : prefix + name;
+            if (value instanceof State) {
+                flatten(map, (State) value, name + '/');
+            } else if (value instanceof List) {
+                String nameSlash = name + '/';
+                int i = 0;
+                for (Object v : (List<?>) value) {
+                    if (v instanceof State) {
+                        flatten(map, (State) v, nameSlash + i + '/');
+                    } else {
+                        map.put(nameSlash + i, (Serializable) v);
+                    }
+                    i++;
+                }
+            } else if (value instanceof Object[]) {
+                String nameSlash = name + '/';
+                int i = 0;
+                for (Object v : (Object[]) value) {
+                    map.put(nameSlash + i, (Serializable) v);
+                    i++;
+                }
+            } else {
+                map.put(name, value);
+            }
+        }
+    }
+
+}

--- a/nuxeo-core/nuxeo-core-storage-dbs/src/test/java/org/nuxeo/ecm/core/storage/dbs/TestDBSStateFlatter.java
+++ b/nuxeo-core/nuxeo-core-storage-dbs/src/test/java/org/nuxeo/ecm/core/storage/dbs/TestDBSStateFlatter.java
@@ -1,0 +1,122 @@
+/*
+ * (C) Copyright 2016 Nuxeo SA (http://nuxeo.com/) and others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Contributors:
+ *     Kevin Leturc
+ */
+package org.nuxeo.ecm.core.storage.dbs;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.nuxeo.ecm.core.storage.dbs.DBSDocument.KEY_ACP;
+import static org.nuxeo.ecm.core.storage.dbs.DBSDocument.KEY_ID;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Map;
+
+import org.junit.Test;
+import org.nuxeo.ecm.core.query.sql.NXQL;
+import org.nuxeo.ecm.core.storage.State;
+
+public class TestDBSStateFlatter {
+
+    @Test
+    public void testFlatterWithEmptyState() {
+        State state = new State();
+        Map<String, Serializable> flattened = DBSStateFlattener.flatten(state);
+        assertNotNull(flattened);
+        assertTrue(flattened.isEmpty());
+    }
+
+    @Test
+    public void testFlatterWithPropertyNotReturnedToCaller() {
+        State state = new State();
+        state.put(KEY_ACP, "whatever");
+        Map<String, Serializable> flattened = DBSStateFlattener.flatten(state);
+        assertNotNull(flattened);
+        assertTrue(flattened.isEmpty());
+    }
+
+    @Test
+    public void testFlatterWithECMId() {
+        State state = new State();
+        state.put(KEY_ID, "ID");
+        Map<String, Serializable> flattened = DBSStateFlattener.flatten(state);
+        assertNotNull(flattened);
+        assertEquals("ID", flattened.get(NXQL.ECM_UUID));
+    }
+
+    @Test
+    public void testFlatterWithRegularProperty() {
+        State state = new State();
+        state.put("color", "black");
+        Map<String, Serializable> flattened = DBSStateFlattener.flatten(state);
+        assertNotNull(flattened);
+        assertEquals(1, flattened.size());
+        assertEquals("black", flattened.get("color"));
+    }
+
+    @Test
+    public void testFlatterWithSubState() {
+        State state = new State();
+        State subState = new State();
+        subState.put("color", "black");
+        state.put("sub", subState);
+        Map<String, Serializable> flattened = DBSStateFlattener.flatten(state);
+        assertNotNull(flattened);
+        assertEquals("black", flattened.get("sub/color"));
+    }
+
+    @Test
+    public void testFlatterWithArray() {
+        State state = new State();
+        state.put("colors", new String[] { "black", "white" });
+        Map<String, Serializable> flattened = DBSStateFlattener.flatten(state);
+        assertNotNull(flattened);
+        assertEquals(2, flattened.size());
+        assertEquals("black", flattened.get("colors/0"));
+        assertEquals("white", flattened.get("colors/1"));
+    }
+
+    @Test
+    public void testFlatterWithListOfPrimitive() {
+        State state = new State();
+        state.put("colors", new ArrayList<>(Arrays.asList("black", "white")));
+        Map<String, Serializable> flattened = DBSStateFlattener.flatten(state);
+        assertNotNull(flattened);
+        assertEquals(2, flattened.size());
+        assertEquals("black", flattened.get("colors/0"));
+        assertEquals("white", flattened.get("colors/1"));
+    }
+
+    @Test
+    public void testFlatterWithListOfState() {
+        State state = new State();
+        State subState1 = new State();
+        subState1.put("main", "black");
+        State subState2 = new State();
+        subState2.put("main", "white");
+        state.put("colors", new ArrayList<>(Arrays.asList(subState1, subState2)));
+        Map<String, Serializable> flattened = DBSStateFlattener.flatten(state);
+        assertNotNull(flattened);
+        assertEquals(2, flattened.size());
+        assertEquals("black", flattened.get("colors/0/main"));
+        assertEquals("white", flattened.get("colors/1/main"));
+    }
+
+}

--- a/nuxeo-core/nuxeo-core-storage-dbs/src/test/java/org/nuxeo/ecm/core/storage/dbs/TestDBSStateFlatter.java
+++ b/nuxeo-core/nuxeo-core-storage-dbs/src/test/java/org/nuxeo/ecm/core/storage/dbs/TestDBSStateFlatter.java
@@ -27,6 +27,8 @@ import static org.nuxeo.ecm.core.storage.dbs.DBSDocument.KEY_ID;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.Map;
 
 import org.junit.Test;
@@ -38,7 +40,7 @@ public class TestDBSStateFlatter {
     @Test
     public void testFlatterWithEmptyState() {
         State state = new State();
-        Map<String, Serializable> flattened = DBSStateFlattener.flatten(state);
+        Map<String, Serializable> flattened = new DBSStateFlattener().flatten(state);
         assertNotNull(flattened);
         assertTrue(flattened.isEmpty());
     }
@@ -47,7 +49,7 @@ public class TestDBSStateFlatter {
     public void testFlatterWithPropertyNotReturnedToCaller() {
         State state = new State();
         state.put(KEY_ACP, "whatever");
-        Map<String, Serializable> flattened = DBSStateFlattener.flatten(state);
+        Map<String, Serializable> flattened = new DBSStateFlattener().flatten(state);
         assertNotNull(flattened);
         assertTrue(flattened.isEmpty());
     }
@@ -56,7 +58,7 @@ public class TestDBSStateFlatter {
     public void testFlatterWithECMId() {
         State state = new State();
         state.put(KEY_ID, "ID");
-        Map<String, Serializable> flattened = DBSStateFlattener.flatten(state);
+        Map<String, Serializable> flattened = new DBSStateFlattener().flatten(state);
         assertNotNull(flattened);
         assertEquals("ID", flattened.get(NXQL.ECM_UUID));
     }
@@ -65,7 +67,7 @@ public class TestDBSStateFlatter {
     public void testFlatterWithRegularProperty() {
         State state = new State();
         state.put("color", "black");
-        Map<String, Serializable> flattened = DBSStateFlattener.flatten(state);
+        Map<String, Serializable> flattened = new DBSStateFlattener().flatten(state);
         assertNotNull(flattened);
         assertEquals(1, flattened.size());
         assertEquals("black", flattened.get("color"));
@@ -77,7 +79,7 @@ public class TestDBSStateFlatter {
         State subState = new State();
         subState.put("color", "black");
         state.put("sub", subState);
-        Map<String, Serializable> flattened = DBSStateFlattener.flatten(state);
+        Map<String, Serializable> flattened = new DBSStateFlattener().flatten(state);
         assertNotNull(flattened);
         assertEquals("black", flattened.get("sub/color"));
     }
@@ -86,7 +88,7 @@ public class TestDBSStateFlatter {
     public void testFlatterWithArray() {
         State state = new State();
         state.put("colors", new String[] { "black", "white" });
-        Map<String, Serializable> flattened = DBSStateFlattener.flatten(state);
+        Map<String, Serializable> flattened = new DBSStateFlattener().flatten(state);
         assertNotNull(flattened);
         assertEquals(2, flattened.size());
         assertEquals("black", flattened.get("colors/0"));
@@ -94,10 +96,24 @@ public class TestDBSStateFlatter {
     }
 
     @Test
+    public void testFlatterWithMappings() {
+        State state = new State();
+        Map<String, String> mappings = new HashMap<>();
+        mappings.put("king", "queen");
+        state.put("king", "kong");
+        state.put("ping", "pong");
+        Map<String, Serializable> flattened = new DBSStateFlattener(mappings).flatten(state);
+        assertNotNull(flattened);
+        assertEquals(2, flattened.size());
+        assertEquals("kong", flattened.get("queen"));
+        assertEquals("pong", flattened.get("ping"));
+    }
+
+    @Test
     public void testFlatterWithListOfPrimitive() {
         State state = new State();
         state.put("colors", new ArrayList<>(Arrays.asList("black", "white")));
-        Map<String, Serializable> flattened = DBSStateFlattener.flatten(state);
+        Map<String, Serializable> flattened = new DBSStateFlattener().flatten(state);
         assertNotNull(flattened);
         assertEquals(2, flattened.size());
         assertEquals("black", flattened.get("colors/0"));
@@ -112,7 +128,7 @@ public class TestDBSStateFlatter {
         State subState2 = new State();
         subState2.put("main", "white");
         state.put("colors", new ArrayList<>(Arrays.asList(subState1, subState2)));
-        Map<String, Serializable> flattened = DBSStateFlattener.flatten(state);
+        Map<String, Serializable> flattened = new DBSStateFlattener().flatten(state);
         assertNotNull(flattened);
         assertEquals(2, flattened.size());
         assertEquals("black", flattened.get("colors/0/main"));

--- a/nuxeo-core/nuxeo-core-storage-mongodb/src/main/java/org/nuxeo/ecm/core/storage/mongodb/MongoDBQueryBuilder.java
+++ b/nuxeo-core/nuxeo-core-storage-mongodb/src/main/java/org/nuxeo/ecm/core/storage/mongodb/MongoDBQueryBuilder.java
@@ -26,6 +26,10 @@ import static org.nuxeo.ecm.core.storage.dbs.DBSDocument.KEY_FULLTEXT_SCORE;
 import static org.nuxeo.ecm.core.storage.dbs.DBSDocument.KEY_ID;
 import static org.nuxeo.ecm.core.storage.dbs.DBSDocument.KEY_NAME;
 import static org.nuxeo.ecm.core.storage.dbs.DBSDocument.KEY_PARENT_ID;
+import static org.nuxeo.ecm.core.storage.dbs.DBSDocument.PROP_MAJOR_VERSION;
+import static org.nuxeo.ecm.core.storage.dbs.DBSDocument.PROP_MINOR_VERSION;
+import static org.nuxeo.ecm.core.storage.dbs.DBSDocument.PROP_UID_MAJOR_VERSION;
+import static org.nuxeo.ecm.core.storage.dbs.DBSDocument.PROP_UID_MINOR_VERSION;
 import static org.nuxeo.ecm.core.storage.mongodb.MongoDBRepository.MONGODB_ID;
 import static org.nuxeo.ecm.core.storage.mongodb.MongoDBRepository.MONGODB_META;
 import static org.nuxeo.ecm.core.storage.mongodb.MongoDBRepository.MONGODB_TEXT_SCORE;
@@ -129,6 +133,8 @@ public class MongoDBQueryBuilder {
 
     protected DBObject projection;
 
+    protected Map<String, String> propertyKeys;
+
     boolean projectionHasWildcard;
 
     private boolean fulltextSearchDisabled;
@@ -141,6 +147,7 @@ public class MongoDBQueryBuilder {
         this.orderByClause = orderByClause;
         this.pathResolver = pathResolver;
         this.fulltextSearchDisabled = fulltextSearchDisabled;
+        this.propertyKeys = new HashMap<>();
     }
 
     public void walk() {
@@ -207,6 +214,12 @@ public class MongoDBQueryBuilder {
                 throw new QueryParseException("Projection not supported: " + op);
             }
             FieldInfo fieldInfo = walkReference((Reference) op);
+            String propertyField = fieldInfo.prop;
+            if (!propertyField.equals(NXQL.ECM_UUID) &&
+                !propertyField.equals(fieldInfo.projectionField) &&
+                !propertyField.contains("/")) {
+                propertyKeys.put(fieldInfo.projectionField, propertyField);
+            }
             projection.put(fieldInfo.projectionField, ONE);
             if (fieldInfo.hasWildcard) {
                 projectionHasWildcard = true;
@@ -999,6 +1012,12 @@ public class MongoDBQueryBuilder {
                 }
             }
             Type type = field.getType();
+            if (PROP_UID_MAJOR_VERSION.equals(prop) || PROP_UID_MINOR_VERSION.equals(prop)
+                 || PROP_MAJOR_VERSION.equals(prop) || PROP_MINOR_VERSION.equals(prop)) {
+                String fieldName = DBSSession.convToInternal(prop);
+                return new FieldInfo(prop, fieldName, fieldName, fieldName, type, true);
+            }
+
             // canonical name
             parts[0] = field.getName().getPrefixedName();
             // are there wildcards or list indexes?

--- a/nuxeo-core/nuxeo-core-storage-mongodb/src/main/java/org/nuxeo/ecm/core/storage/mongodb/MongoDBRepository.java
+++ b/nuxeo-core/nuxeo-core-storage-mongodb/src/main/java/org/nuxeo/ecm/core/storage/mongodb/MongoDBRepository.java
@@ -29,7 +29,6 @@ import static org.nuxeo.ecm.core.storage.dbs.DBSDocument.KEY_LOCK_CREATED;
 import static org.nuxeo.ecm.core.storage.dbs.DBSDocument.KEY_LOCK_OWNER;
 import static org.nuxeo.ecm.core.storage.dbs.DBSDocument.KEY_NAME;
 import static org.nuxeo.ecm.core.storage.dbs.DBSDocument.KEY_PARENT_ID;
-import static org.nuxeo.ecm.core.storage.dbs.DBSDocument.KEY_PREFIX;
 import static org.nuxeo.ecm.core.storage.dbs.DBSDocument.KEY_PRIMARY_TYPE;
 import static org.nuxeo.ecm.core.storage.dbs.DBSDocument.KEY_PROXY_IDS;
 import static org.nuxeo.ecm.core.storage.dbs.DBSDocument.KEY_PROXY_TARGET_ID;
@@ -44,7 +43,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Calendar;
 import java.util.Date;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -74,7 +72,7 @@ import org.nuxeo.ecm.core.storage.State.StateDiff;
 import org.nuxeo.ecm.core.storage.dbs.DBSDocument;
 import org.nuxeo.ecm.core.storage.dbs.DBSExpressionEvaluator;
 import org.nuxeo.ecm.core.storage.dbs.DBSRepositoryBase;
-import org.nuxeo.ecm.core.storage.dbs.DBSSession;
+import org.nuxeo.ecm.core.storage.dbs.DBSStateFlattener;
 import org.nuxeo.runtime.api.Framework;
 
 import com.mongodb.BasicDBObject;
@@ -762,7 +760,7 @@ public class MongoDBRepository extends DBSRepositoryBase {
                 if (manualProjection) {
                     projections.addAll(evaluator.matches(state));
                 } else {
-                    projections.add(flatten(state));
+                    projections.add(DBSStateFlattener.flatten(state));
                 }
             }
             if (countUpTo == -1) {
@@ -799,56 +797,6 @@ public class MongoDBRepository extends DBSRepositoryBase {
         if (principals != null) {
             DBObject inPrincipals = new BasicDBObject(QueryOperators.IN, new ArrayList<String>(principals));
             query.put(DBSDocument.KEY_READ_ACL, inPrincipals);
-        }
-    }
-
-    /**
-     * Flatten and convert from internal names to NXQL.
-     */
-    protected Map<String, Serializable> flatten(State state) {
-        Map<String, Serializable> map = new HashMap<>();
-        flatten(map, state, null);
-        return map;
-    }
-
-    protected void flatten(Map<String, Serializable> map, State state, String prefix) {
-        for (Entry<String, Serializable> en : state.entrySet()) {
-            String key = en.getKey();
-            Serializable value = en.getValue();
-            String name;
-            if (key.startsWith(KEY_PREFIX)) {
-                name = DBSSession.convToNXQL(key);
-                if (name == null) {
-                    // present in state but not returned to caller
-                    continue;
-                }
-            } else {
-                name = key;
-            }
-            name = prefix == null ? name : prefix + name;
-            if (value instanceof State) {
-                flatten(map, (State) value, name + '/');
-            } else if (value instanceof List) {
-                String nameSlash = name + '/';
-                int i = 0;
-                for (Object v : (List<?>) value) {
-                    if (v instanceof State) {
-                        flatten(map, (State) v, nameSlash + i + '/');
-                    } else {
-                        map.put(nameSlash + i, (Serializable) v);
-                    }
-                    i++;
-                }
-            } else if (value instanceof Object[]) {
-                String nameSlash = name + '/';
-                int i = 0;
-                for (Object v : (Object[]) value) {
-                    map.put(nameSlash + i, (Serializable) v);
-                    i++;
-                }
-            } else {
-                map.put(name, value);
-            }
         }
     }
 

--- a/nuxeo-core/nuxeo-core-storage-mongodb/src/main/java/org/nuxeo/ecm/core/storage/mongodb/MongoDBRepository.java
+++ b/nuxeo-core/nuxeo-core-storage-mongodb/src/main/java/org/nuxeo/ecm/core/storage/mongodb/MongoDBRepository.java
@@ -755,12 +755,13 @@ public class MongoDBRepository extends DBSRepositoryBase {
                 cursor.sort(orderBy);
             }
             projections = new ArrayList<>();
+            DBSStateFlattener flattener = new DBSStateFlattener(builder.propertyKeys);
             for (DBObject ob : cursor) {
                 State state = bsonToState(ob);
                 if (manualProjection) {
                     projections.addAll(evaluator.matches(state));
                 } else {
-                    projections.add(DBSStateFlattener.flatten(state));
+                    projections.add(flattener.flatten(state));
                 }
             }
             if (countUpTo == -1) {


### PR DESCRIPTION
This is a backport of an existing fix.  The first commit is a cherry-pick of Kevin's creation of a DBSStateFlattener class.  The second commit includes my changes to that class.

My test and push passed except for 3 selenium errors.
https://qa2.nuxeo.org/jenkins/view/TestAndPush/job/TestAndPush/job/ondemand-testandpush-gethin-7.10/8/