### PR TITLE
NXBT-1998: add depth & unshallow options to optimize cloning duration

### DIFF
--- a/clone.py
+++ b/clone.py
@@ -56,7 +56,13 @@ virtual drive on Windows""")
                           type="string", dest='marketplace_conf', default=None,
                           help="""the Marketplace configuration URL
 (default: None)\n
-If set to '' (empty string), it defaults to '%s'""" % (DEFAULT_MP_CONF_URL))
+If set to '' (empty string), it defaults to '%s'""" % DEFAULT_MP_CONF_URL)
+        parser.add_option('--depth', action="store", type="int", dest='depth', default=None,
+                          help="""Create a shallow clone with a history truncated to the specified number of commits. 
+Default: '%default'""")
+        parser.add_option('--unshallow', action="store_true", dest='unshallow', default=False,
+                          help="""If the source repository is shallow, fetch as much as possible so that the current 
+repository has the same history as the source repository. Default: '%default'""")
         parser.add_option('--mp-only', action="store_true",
                           dest='mp_only', default=False,
                           help="""clone only package repositories (default: %default)""")
@@ -72,9 +78,11 @@ If set to '' (empty string), it defaults to '%s'""" % (DEFAULT_MP_CONF_URL))
             raise ExitException(1, "'version' must be a single argument. "
                                 "See usage with '-h'.")
         if options.mp_only:
-            repo.clone_mp(options.marketplace_conf if options.marketplace_conf else '', options.fallback_branch)
+            repo.clone_mp(options.marketplace_conf if options.marketplace_conf else '', options.fallback_branch,
+                          options.depth, options.unshallow)
         else:
-            repo.clone(version, options.fallback_branch, options.with_optionals, options.marketplace_conf)
+            repo.clone(version, options.fallback_branch, options.with_optionals, options.marketplace_conf,
+                       options.depth, options.unshallow)
     #pylint: disable=C0103
     except ExitException, e:
         if e.message is not None:
@@ -83,6 +91,7 @@ If set to '' (empty string), it defaults to '%s'""" % (DEFAULT_MP_CONF_URL))
     finally:
         if "repo" in locals():
             repo.cleanup()
+
 
 if __name__ == '__main__':
     main()

--- a/scripts/nxutils.py
+++ b/scripts/nxutils.py
@@ -153,7 +153,7 @@ class Repository(object):
             modules = sorted(set(modules))
         return modules
 
-    def git_pull(self, module, version, fallback_branch=None):
+    def git_pull(self, module, version, fallback_branch=None, depth=None, unshallow=False):
         """Git clone or fetch, then update.
 
         'module': the Git module to run on.
@@ -165,9 +165,9 @@ class Repository(object):
         log("[%s]" % module)
         if os.path.isdir(module):
             os.chdir(module)
-            system_with_retries("git fetch %s" % (self.alias))
+            system_with_retries("git fetch %s" % (self.alias + (" --unshallow" if unshallow else "")))
         else:
-            system_with_retries("git clone %s --origin %s" % (repo_url, self.alias))
+            system_with_retries("git clone %s --origin %s" % (repo_url, self.alias + (" --depth %d" % depth if depth else "")))
             os.chdir(module)
         self.git_update(version, fallback_branch)
         os.chdir(cwd)
@@ -316,7 +316,7 @@ class Repository(object):
         log("Configuration saved: " + configfile_path)
         return mp_config
 
-    def clone_mp(self, marketplace_conf, fallback_branch=None):
+    def clone_mp(self, marketplace_conf, fallback_branch=None, depth=None, unshallow=False):
         """Clone or update Nuxeo Package repositories.
 
         Returns the Nuxeo Packages configuration."""
@@ -330,11 +330,11 @@ class Repository(object):
             user_defaults["nuxeo-branch"] = self.get_current_version()
         mp_config = self.get_mp_config(marketplace_conf, user_defaults)
         for marketplace in mp_config.sections():
-            self.git_pull(marketplace, mp_config.get(marketplace, "branch"), fallback_branch=fallback_branch)
+            self.git_pull(marketplace, mp_config.get(marketplace, "branch"), fallback_branch, depth, unshallow)
         return mp_config
 
     def clone(self, version=None, fallback_branch=None, with_optionals=False,
-              marketplace_conf=None):
+              marketplace_conf=None, depth=None, unshallow=False):
         """Clone or update whole Nuxeo repository.
 
         'version': the version to checkout; defaults to current version.
@@ -346,19 +346,19 @@ class Repository(object):
         cwd = os.getcwd()
         os.chdir(self.basedir)
         log("[.]")
-        system_with_retries("git fetch %s" % (self.alias))
+        system_with_retries("git fetch %s" % (self.alias + (" --unshallow" if unshallow else "")))
         if version is None:
             version = self.get_current_version()
         self.git_update(version, fallback_branch)
         if self.is_nuxeoecm:
-            self.execute_on_modules(lambda module: self.clone_module(module, version, fallback_branch), with_optionals)
-            self.clone_mp(marketplace_conf, fallback_branch)
+            self.execute_on_modules(lambda module: self.clone_module(module, version, fallback_branch, depth, unshallow), with_optionals)
+            self.clone_mp(marketplace_conf, fallback_branch, depth, unshallow)
         os.chdir(cwd)
 
-    def clone_module(self, module, version, fallback_branch):
+    def clone_module(self, module, version, fallback_branch, depth=None, unshallow=False):
         # Ignore modules which are not Git sub-repositories
         if not os.path.isdir(module) or os.path.isdir(os.path.join(module, ".git")):
-            self.git_pull(module, version, fallback_branch)
+            self.git_pull(module, version, fallback_branch, depth, unshallow)
 
     @staticmethod
     def get_current_version():

--- a/scripts/release_mp.py
+++ b/scripts/release_mp.py
@@ -40,9 +40,9 @@ CONNECT_PROD_URL = "https://connect.nuxeo.com/nuxeo"
 class ReleaseMP(object):
     """Nuxeo MP release manager.
 
-    See 'self.perpare()', 'self.perform()'."""
+    See 'self.prepare()', 'self.perform()'."""
     # pylint: disable=R0913
-    def __init__(self, alias, restart_from, default_conf=None, marketplace_conf=None):
+    def __init__(self, alias, restart_from, default_conf=None, marketplace_conf=None, depth=None, unshallow=None):
         self.alias = alias
         self.restart_from = restart_from
         if marketplace_conf == '':
@@ -68,10 +68,12 @@ class ReleaseMP(object):
             for key, value in vars(default_info).iteritems():
                 self.defaults[prefix + "-" + key] = str(value)
         self.mp_config = self.repo.get_mp_config(self.marketplace_conf, self.defaults)
+        self.depth = depth
+        self.unshallow = unshallow
 
     def clone(self):
         cwd = os.getcwd()
-        self.repo.clone_mp(self.marketplace_conf)
+        self.repo.clone_mp(self.marketplace_conf, depth=self.depth, unshallow=self.unshallow)
         os.chdir(cwd)
 
     # pylint: disable=E1103
@@ -108,7 +110,8 @@ class ReleaseMP(object):
                 mp_dir = os.path.join(self.repo.mp_dir, marketplace)
                 if not os.path.isdir(mp_dir):
                     os.chdir(self.repo.mp_dir)
-                    self.repo.git_pull(marketplace, self.mp_config.get(marketplace, "branch"))
+                    self.repo.git_pull(marketplace, self.mp_config.get(marketplace, "branch"),
+                                       self.depth, self.unshallow)
                 else:
                     log("[%s]" % marketplace)
                 os.chdir(mp_dir)
@@ -184,7 +187,8 @@ class ReleaseMP(object):
                 mp_dir = os.path.join(self.repo.mp_dir, marketplace)
                 if not os.path.isdir(mp_dir):
                     os.chdir(self.repo.mp_dir)
-                    self.repo.git_pull(marketplace, self.mp_config.get(marketplace, "branch"))
+                    self.repo.git_pull(marketplace, self.mp_config.get(marketplace, "branch"),
+                                       self.depth, self.unshallow)
                 else:
                     log("[%s]" % marketplace)
                 os.chdir(mp_dir)
@@ -311,9 +315,9 @@ def main():
 
     try:
         usage = ("""usage: %prog <command> [options]
-       %prog clone [-r alias] [-m URL] [-d PATH]
-       %prog branch [-r alias] [-m URL] [-d PATH] [--rf package] [--dryrun]
-       %prog prepare [-r alias] [-m URL] [-d PATH] [--rf package] [--dryrun]
+       %prog clone [-r alias] [-m URL] [-d PATH] [--depth N] [--unshallow]
+       %prog branch [-r alias] [-m URL] [-d PATH] [--depth N] [--unshallow] [--rf package] [--dryrun]
+       %prog prepare [-r alias] [-m URL] [-d PATH] [--depth N] [--unshallow] [--rf package] [--dryrun]
        %prog perform [-r alias] [-m URL] [-d PATH] [--rf package] [--dryrun]
 \nCommands:
        clone: Clone or update Nuxeo Package repositories.
@@ -347,6 +351,12 @@ Default: '%default'""")
                           default=None, help="""The Nuxeo Packages configuration URL (usually named 'marketplace.ini').
 You can use a local file URL ('file://').\n
 If set to '' (empty string), then it will default to '""" + DEFAULT_MP_CONF_URL + """'. Default: '%default'""")
+        parser.add_option('--depth', action="store", type="int", dest='depth', default=None,
+                          help="""Create a shallow clone with a history truncated to the specified number of commits. 
+Default: '%default'""")
+        parser.add_option('--unshallow', action="store_true", dest='unshallow', default=False,
+                          help="""If the source repository is shallow, fetch as much as possible so that the current 
+repository has the same history as the source repository. Default: '%default'""")
         parser.add_option('-i', '--interactive', action="store_true", dest='interactive', default=False,
                           help="""Not implemented (TODO NXP-8573). Interactive mode. Default: '%default'""")
         parser.add_option('--rf', '--restart-from', action="store", dest='restart_from', default=None,
@@ -359,7 +369,7 @@ If set to '' (empty string), then it will default to '""" + DEFAULT_MP_CONF_URL 
         elif len(args) > 1:
             raise ExitException(1, "'command' must be a single argument. See usage with '-h'.")
         full_release = ReleaseMP(options.remote_alias, options.restart_from, options.default_conf,
-                                 options.marketplace_conf)
+                                 options.marketplace_conf, options.depth, options.unshallow)
         if "command" not in locals():
             raise ExitException(1, "Missing command. See usage with '-h'.")
         elif command == "clone":
@@ -378,6 +388,7 @@ If set to '' (empty string), then it will default to '""" + DEFAULT_MP_CONF_URL 
         if e.message is not None:
             log("[ERROR] %s" % e.message, sys.stderr)
         sys.exit(e.return_code)
+
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
Usage:
`./clone.py --depth 1` or
`./scripts/release_mp.py clone --depth 1`
Will only checkout last commits, then you can fetch back the whole history if needed:
`./clone.py --unshallow` or
`./scripts/release_mp.py clone --unshallow`

See [Git Beyond the Basics: Using Shallow Clones](https://www.perforce.com/blog/git-beyond-basics-using-shallow-clones):
> With v1.9 and later, however, Git has been improved to support pull and push operations even with shallow clones. This allows changes to be made and committed/pushed back to the source repository if needed as part of automated build operations.

Also Git reference manual for [clone --depth](https://www.git-scm.com/docs/git-clone#git-clone---depthltdepthgt) and [fetch --unshallow](https://www.git-scm.com/docs/git-fetch#git-fetch---unshallow)

PR ongoing for backward compat https://qa.nuxeo.org/jenkins/job/TestAndPush/job/ondemand-testandpush-pgmillon/5/
