### PR TITLE
NXP-23412: Fixes duplicate labels introduced by PR #1460

### DIFF
--- a/nuxeo-features/nuxeo-platform-lang/src/main/resources/web/nuxeo.war/WEB-INF/classes/messages_en_US.properties
+++ b/nuxeo-features/nuxeo-platform-lang/src/main/resources/web/nuxeo.war/WEB-INF/classes/messages_en_US.properties
@@ -967,7 +967,7 @@ document_review_serial=Serial workflow
 document_review_approbation=Approval workflow
 
 workflowAbandoned=Workflow abandoned
-workflowProcessCanceled=Workflow canceled
+workflowProcessCanceled=Workflow process canceled
 workflowDocumentModificationAllowed=Modification allowed
 workflowDocumentModificationNotAllowed=Modification not allowed
 workflowDocumentVersioningAuto=Automatic increment


### PR DESCRIPTION
> I'm creating this PR manually as suggested by @kevinleturc

This pull request aims at fixing synchronization with crowdin for translations since PR #1460 introduced duplicated text which is forbidden and couldn't be foreseen with standard test and push process.

Resolution is to rename the older duplicate to a name that matches more what it should represent.