### PR TITLE
 NXP-23722: Prevent directory sessions from modifying their parameters

### DIFF
--- a/nuxeo-features/nuxeo-platform-oauth/src/main/java/org/nuxeo/ecm/platform/oauth/consumers/OAuthConsumerRegistryImpl.java
+++ b/nuxeo-features/nuxeo-platform-oauth/src/main/java/org/nuxeo/ecm/platform/oauth/consumers/OAuthConsumerRegistryImpl.java
@@ -80,9 +80,7 @@ public class OAuthConsumerRegistryImpl extends DefaultComponent implements OAuth
     public NuxeoOAuthConsumer storeConsumer(NuxeoOAuthConsumer consumer) {
         DirectoryService ds = Framework.getService(DirectoryService.class);
         try (Session session = ds.open(DIRECTORY_NAME)) {
-            Map<String, Object> init = new HashMap<String, Object>();
-            init.put("consumerKey", consumer.consumerKey);
-            DocumentModel entry = session.createEntry(init);
+            DocumentModel entry = session.createEntry(Collections.singletonMap("consumerKey", consumer.consumerKey));
             consumer.asDocumentModel(entry);
             session.updateEntry(entry);
             if (entry == null) {

--- a/nuxeo-features/nuxeo-platform-oauth/src/main/java/org/nuxeo/ecm/platform/oauth/tokens/OAuthTokenStoreImpl.java
+++ b/nuxeo-features/nuxeo-platform-oauth/src/main/java/org/nuxeo/ecm/platform/oauth/tokens/OAuthTokenStoreImpl.java
@@ -23,6 +23,7 @@ package org.nuxeo.ecm.platform.oauth.tokens;
 
 import java.io.Serializable;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -159,9 +160,7 @@ public class OAuthTokenStoreImpl extends DefaultComponent implements OAuthTokenS
         try (Session session = ds.open(DIRECTORY_NAME)) {
             DocumentModel entry = session.getEntry(aToken.getToken());
             if (entry == null) {
-                Map<String, Object> init = new HashMap<String, Object>();
-                init.put("token", aToken.getToken());
-                entry = session.createEntry(init);
+                entry = session.createEntry(Collections.singletonMap("token", aToken.getToken()));
             }
 
             aToken.updateEntry(entry);

--- a/nuxeo-features/rest-api/nuxeo-rest-api-test/src/test/java/org/nuxeo/ecm/restapi/test/DirectoryTest.java
+++ b/nuxeo-features/rest-api/nuxeo-rest-api-test/src/test/java/org/nuxeo/ecm/restapi/test/DirectoryTest.java
@@ -243,9 +243,7 @@ public class DirectoryTest extends BaseTest {
     @Test
     public void itCanUpdateADirectoryEntryWithAnIntId() throws IOException {
         try (Session dirSession = ds.open(INT_ID_TEST_DIR_NAME)) {
-            Map<String, Object> entry = new HashMap<>();
-            entry.put("label", "test label");
-            DocumentModel docEntry = dirSession.createEntry(entry);
+            DocumentModel docEntry = dirSession.createEntry(Collections.singletonMap("label", "test label"));
             nextTransaction(); // see committed changes
 
             docEntry.setPropertyValue("intIdSchema:label", "new label");

--- a/nuxeo-services/login/nuxeo-platform-login-shibboleth/src/test/java/org/nuxeo/ecm/platform/shibboleth/computedgroups/TestShibbolethComputedGroup.java
+++ b/nuxeo-services/login/nuxeo-platform-login-shibboleth/src/test/java/org/nuxeo/ecm/platform/shibboleth/computedgroups/TestShibbolethComputedGroup.java
@@ -24,6 +24,7 @@ import static org.junit.Assert.assertNotSame;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -161,9 +162,7 @@ public class TestShibbolethComputedGroup {
     }
 
     protected DocumentModel createUser(String username) throws Exception {
-        Map<String, Object> user = new HashMap<String, Object>();
-        user.put("username", username);
-        DocumentModel doc = userDir.createEntry(user);
+        DocumentModel doc = userDir.createEntry(Collections.singletonMap("username", username));
         return doc;
     }
 

--- a/nuxeo-services/login/nuxeo-platform-login-token/src/test/java/org/nuxeo/ecm/tokenauth/TestDirectorySecurity.java
+++ b/nuxeo-services/login/nuxeo-platform-login-token/src/test/java/org/nuxeo/ecm/tokenauth/TestDirectorySecurity.java
@@ -77,7 +77,7 @@ public class TestDirectorySecurity {
         // as system, create an dummy entry
         login(SYSTEM_USERNAME);
         try (Session session = directoryService.open(DIR_NAME)) {
-            DocumentModel entry = session.createEntry(new HashMap<>(Collections.singletonMap(ID_FIELD, "123")));
+            DocumentModel entry = session.createEntry(Collections.singletonMap(ID_FIELD, "123"));
             entryId = entry.getPropertyValue(SCHEMA_NAME + ":" + ID_FIELD);
         } finally {
             logout();

--- a/nuxeo-services/nuxeo-platform-directory/nuxeo-platform-directory-ldap/src/main/java/org/nuxeo/ecm/directory/ldap/LDAPSession.java
+++ b/nuxeo-services/nuxeo-platform-directory/nuxeo-platform-directory-ldap/src/main/java/org/nuxeo/ecm/directory/ldap/LDAPSession.java
@@ -145,6 +145,9 @@ public class LDAPSession extends BaseSession {
 
     @Override
     protected DocumentModel createEntryWithoutReferences(Map<String, Object> fieldMap) {
+        // Make a copy of fieldMap to avoid modifying it
+        fieldMap = new HashMap<>(fieldMap);
+
         LDAPDirectoryDescriptor descriptor = getDirectory().getDescriptor();
         List<String> referenceFieldList = new LinkedList<>();
         try {

--- a/nuxeo-services/nuxeo-platform-directory/nuxeo-platform-directory-mongodb/src/main/java/org/nuxeo/directory/mongodb/MongoDBSession.java
+++ b/nuxeo-services/nuxeo-platform-directory/nuxeo-platform-directory-mongodb/src/main/java/org/nuxeo/directory/mongodb/MongoDBSession.java
@@ -100,6 +100,9 @@ public class MongoDBSession extends BaseSession {
 
     @Override
     protected DocumentModel createEntryWithoutReferences(Map<String, Object> fieldMap) {
+        // Make a copy of fieldMap to avoid modifying it
+        fieldMap = new HashMap<>(fieldMap);
+
         // Filter out reference fields for creation as we keep it in a different collection
         Map<String, Object> newDocMap = fieldMap.entrySet()
                                                 .stream()

--- a/nuxeo-services/nuxeo-platform-directory/nuxeo-platform-directory-sql/src/main/java/org/nuxeo/ecm/directory/sql/SQLSession.java
+++ b/nuxeo-services/nuxeo-platform-directory/nuxeo-platform-directory-sql/src/main/java/org/nuxeo/ecm/directory/sql/SQLSession.java
@@ -711,6 +711,9 @@ public class SQLSession extends BaseSession {
 
     @Override
     protected DocumentModel createEntryWithoutReferences(Map<String, Object> fieldMap) {
+        // Make a copy of fieldMap to avoid modifying it
+        fieldMap = new HashMap<>(fieldMap);
+
         Map<String, Field> schemaFieldMap = directory.getSchemaFieldMap();
         Field schemaIdField = schemaFieldMap.get(getIdField());
 


### PR DESCRIPTION
Prevent directory sessions from modifying their parameters
in order to be able to use session.createEntry(Collections.singletonMap(k,v))


This code will be used in https://github.com/nuxeo/nuxeo-audit-storage/pull/2 and https://github.com/nuxeo/nuxeo-signature/pull/7