### PR TITLE
fix-NXP-23845-always-remove-jsessionid-from-downloaded-file-name-backport-8.10

### DIFF
--- a/nuxeo-core/nuxeo-core-io/src/main/java/org/nuxeo/ecm/core/io/download/DownloadServiceImpl.java
+++ b/nuxeo-core/nuxeo-core-io/src/main/java/org/nuxeo/ecm/core/io/download/DownloadServiceImpl.java
@@ -36,6 +36,7 @@ import java.util.Objects;
 import java.util.UUID;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
+import java.util.regex.Pattern;
 
 import javax.script.Invocable;
 import javax.script.ScriptContext;
@@ -103,6 +104,8 @@ public class DownloadServiceImpl extends DefaultComponent implements DownloadSer
     private static final String RUN_FUNCTION = "run";
 
     protected static enum Action {DOWNLOAD, DOWNLOAD_FROM_DOC, INFO};
+
+    private static final Pattern FILENAME_SANITIZATION_REGEX = Pattern.compile(";\\w+=.*");
 
     private DownloadPermissionRegistry registry = new DownloadPermissionRegistry();
 
@@ -217,10 +220,21 @@ public class DownloadServiceImpl extends DefaultComponent implements DownloadSer
         if (xpath != null) {
             sb.append("/").append(xpath);
             if (filename != null) {
+                // make sure filename doesn't contain path separators
+                filename = getSanitizedFilenameWithoutPath(filename);
                 sb.append("/").append(URIUtils.quoteURIPathComponent(filename, true));
             }
         }
         return sb.toString();
+    }
+
+    protected String getSanitizedFilenameWithoutPath(String filename) {
+        int sep = Math.max(filename.lastIndexOf('\\'), filename.lastIndexOf('/'));
+        if (sep != -1) {
+            filename = filename.substring(sep + 1);
+        }
+
+        return FILENAME_SANITIZATION_REGEX.matcher(filename).replaceAll("");
     }
 
     @Override

--- a/nuxeo-core/nuxeo-core-test/src/test/java/org/nuxeo/ecm/core/io/download/TestDownloadService.java
+++ b/nuxeo-core/nuxeo-core-test/src/test/java/org/nuxeo/ecm/core/io/download/TestDownloadService.java
@@ -342,4 +342,21 @@ public class TestDownloadService {
         session.close();
     }
 
+    @Test
+    public void testDownloadUrlWithURLSanitization() throws IOException {
+        String filename = "/home/john/foo.txt;jsessionid=FooBarBaz;otherparam=foobarbaz";
+        String url = downloadService.getDownloadUrl("default", "1234", "file:content", filename);
+        assertEquals("nxfile/default/1234/file:content/foo.txt", url);
+
+        filename = "/home/john/foo.txt;jsessionid=FooBarBaz";
+        url = downloadService.getDownloadUrl("default", "1234", "file:content", filename);
+        assertEquals("nxfile/default/1234/file:content/foo.txt", url);
+    }
+
+    @Test
+    public void testDownloadUrlWithSemiColonInTheFilename() throws IOException {
+        String filename = "/home/john/foo;bar.txt";
+        String url = downloadService.getDownloadUrl("default", "1234", "file:content", filename);
+        assertEquals("nxfile/default/1234/file:content/foo%3Bbar.txt", url);
+    }
 }


### PR DESCRIPTION
PR created from https://qa2.nuxeo.org/jenkins/job/TestAndPush/job/ondemand-testandpush-lduarte-8.10/2/