### PR TITLE
fix-NXP-23845-always-remove-jsessionid-from-downloaded-file-name-backport-9.10

### DIFF
--- a/nuxeo-core/nuxeo-core-io/src/main/java/org/nuxeo/ecm/core/io/download/DownloadServiceImpl.java
+++ b/nuxeo-core/nuxeo-core-io/src/main/java/org/nuxeo/ecm/core/io/download/DownloadServiceImpl.java
@@ -36,6 +36,7 @@ import java.util.Objects;
 import java.util.UUID;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
+import java.util.regex.Pattern;
 
 import javax.script.Invocable;
 import javax.script.ScriptContext;
@@ -103,6 +104,8 @@ public class DownloadServiceImpl extends DefaultComponent implements DownloadSer
     private static final String REDIRECT_RESOLVER = "redirectResolver";
 
     private static final String RUN_FUNCTION = "run";
+
+    private static final Pattern FILENAME_SANITIZATION_REGEX = Pattern.compile(";\\w+=.*");
 
     protected static enum Action {
         DOWNLOAD, DOWNLOAD_FROM_DOC, INFO, BLOBSTATUS
@@ -220,19 +223,20 @@ public class DownloadServiceImpl extends DefaultComponent implements DownloadSer
             sb.append("/").append(xpath);
             if (filename != null) {
                 // make sure filename doesn't contain path separators
-                filename = getFilenameWithoutPath(filename);
+                filename = getSanitizedFilenameWithoutPath(filename);
                 sb.append("/").append(URIUtils.quoteURIPathComponent(filename, true));
             }
         }
         return sb.toString();
     }
 
-    protected String getFilenameWithoutPath(String filename) {
+    protected String getSanitizedFilenameWithoutPath(String filename) {
         int sep = Math.max(filename.lastIndexOf('\\'), filename.lastIndexOf('/'));
         if (sep != -1) {
             filename = filename.substring(sep + 1);
         }
-        return filename;
+
+        return FILENAME_SANITIZATION_REGEX.matcher(filename).replaceAll("");
     }
 
     @Override

--- a/nuxeo-core/nuxeo-core-test/src/test/java/org/nuxeo/ecm/core/io/download/TestDownloadService.java
+++ b/nuxeo-core/nuxeo-core-test/src/test/java/org/nuxeo/ecm/core/io/download/TestDownloadService.java
@@ -534,4 +534,21 @@ public class TestDownloadService {
         assertEquals(blobValue, out.toString()); // decode with system default
     }
 
+    @Test
+    public void testDownloadUrlWithURLSanitization() throws IOException {
+        String filename = "/home/john/foo.txt;jsessionid=FooBarBaz;otherparam=foobarbaz";
+        String url = downloadService.getDownloadUrl("default", "1234", "file:content", filename);
+        assertEquals("nxfile/default/1234/file:content/foo.txt", url);
+
+        filename = "/home/john/foo.txt;jsessionid=FooBarBaz";
+        url = downloadService.getDownloadUrl("default", "1234", "file:content", filename);
+        assertEquals("nxfile/default/1234/file:content/foo.txt", url);
+    }
+
+    @Test
+    public void testDownloadUrlWithSemiColonInTheFilename() throws IOException {
+        String filename = "/home/john/foo;bar.txt";
+        String url = downloadService.getDownloadUrl("default", "1234", "file:content", filename);
+        assertEquals("nxfile/default/1234/file:content/foo%3Bbar.txt", url);
+    }
 }


### PR DESCRIPTION
PR created from https://qa.nuxeo.org/jenkins/job/TestAndPush/job/ondemand-testandpush-lduarte/13/