### PR TITLE
fix-NXP-23845-always-remove-jsessionid-from-downloaded-file-name-backport-7.10

### DIFF
--- a/nuxeo-core/nuxeo-core-test/src/test/java/org/nuxeo/ecm/core/io/download/TestDownloadService.java
+++ b/nuxeo-core/nuxeo-core-test/src/test/java/org/nuxeo/ecm/core/io/download/TestDownloadService.java
@@ -310,4 +310,21 @@ public class TestDownloadService {
         session.close();
     }
 
+    @Test
+    public void testDownloadUrlWithURLSanitization() throws IOException {
+        String filename = "/home/john/foo.txt;jsessionid=FooBarBaz;otherparam=foobarbaz";
+        String url = downloadService.getDownloadUrl("default", "1234", "file:content", filename);
+        assertEquals("nxfile/default/1234/file:content/foo.txt", url);
+
+        filename = "/home/john/foo.txt;jsessionid=FooBarBaz";
+        url = downloadService.getDownloadUrl("default", "1234", "file:content", filename);
+        assertEquals("nxfile/default/1234/file:content/foo.txt", url);
+    }
+
+    @Test
+    public void testDownloadUrlWithSemiColonInTheFilename() throws IOException {
+        String filename = "/home/john/foo;bar.txt";
+        String url = downloadService.getDownloadUrl("default", "1234", "file:content", filename);
+        assertEquals("nxfile/default/1234/file:content/foo%3Bbar.txt", url);
+    }
 }


### PR DESCRIPTION
PR created from https://qa2.nuxeo.org/jenkins/job/TestAndPush/job/ondemand-testandpush-lduarte-7.10/4/