### PR TITLE
fix-NXP-24114-elastic-versionVersionableId-backport-8.10

### DIFF
--- a/nuxeo-features/nuxeo-automation/nuxeo-automation-io/src/main/java/org/nuxeo/ecm/automation/jaxrs/io/documents/JsonESDocumentWriter.java
+++ b/nuxeo-features/nuxeo-automation/nuxeo-automation-io/src/main/java/org/nuxeo/ecm/automation/jaxrs/io/documents/JsonESDocumentWriter.java
@@ -141,6 +141,7 @@ public class JsonESDocumentWriter implements MessageBodyWriter<DocumentModel> {
         }
         jg.writeStringField("ecm:currentLifeCycleState", doc.getCurrentLifeCycleState());
         jg.writeStringField("ecm:versionLabel", doc.getVersionLabel());
+        jg.writeStringField("ecm:versionVersionableId", doc.getVersionSeriesId());
         jg.writeBooleanField("ecm:isCheckedIn", !doc.isCheckedOut());
         jg.writeBooleanField("ecm:isProxy", doc.isProxy());
         jg.writeBooleanField("ecm:isVersion", doc.isVersion());

--- a/nuxeo-features/nuxeo-elasticsearch/nuxeo-elasticsearch-core/src/test/java/org/nuxeo/elasticsearch/test/TestAutomaticIndexing.java
+++ b/nuxeo-features/nuxeo-elasticsearch/nuxeo-elasticsearch-core/src/test/java/org/nuxeo/elasticsearch/test/TestAutomaticIndexing.java
@@ -790,6 +790,10 @@ public class TestAutomaticIndexing {
         ret = ess.query(new NxQueryBuilder(session).nxql("SELECT * FROM Document WHERE ecm:isLatestMajorVersion = 1"));
         Assert.assertEquals(1, ret.totalSize());
         Assert.assertEquals("v3", ret.get(0).getTitle());
+        String versionSeriesId = ret.get(0).getVersionSeriesId();
+        
+        ret = ess.query(new NxQueryBuilder(session).nxql("SELECT * FROM Document WHERE ecm:versionVersionableId = '" + versionSeriesId + "'"));
+        Assert.assertEquals(4, ret.totalSize());
     }
 
     @Test


### PR DESCRIPTION
PR created from https://qa2.nuxeo.org/jenkins/job/TestAndPush/job/ondemand-testandpush-gethin-8.10/18/