### PR TITLE
NXP-24337: Add rvt, dlx to mimetype mappings

### DIFF
--- a/nuxeo-core/nuxeo-core-mimetype/src/main/resources/OSGI-INF/nxmimetype-service.xml
+++ b/nuxeo-core/nuxeo-core-mimetype/src/main/resources/OSGI-INF/nxmimetype-service.xml
@@ -1385,7 +1385,8 @@
     <fileExtension name="key" mimetype="application/vnd.apple.keynote" ambiguous="false" />
     <fileExtension name="numbers" mimetype="application/vnd.apple.numbers" ambiguous="false" />
     <fileExtension name="pages" mimetype="application/vnd.apple.pages" ambiguous="false" />
-
+    <fileExtension name="rvt" mimetype="application/octet-stream" ambiguous="false" />
+    <fileExtension name="dlx" mimetype="application/octet-stream" ambiguous="false" />
   </extension>
 
 </component>

--- a/nuxeo-core/nuxeo-core-mimetype/src/test/java/org/nuxeo/ecm/platform/mimetype/TestMimetypeSniffing.java
+++ b/nuxeo-core/nuxeo-core-mimetype/src/test/java/org/nuxeo/ecm/platform/mimetype/TestMimetypeSniffing.java
@@ -122,6 +122,12 @@ public class TestMimetypeSniffing {
                 mimetypeRegistry.getMimetypeFromFile(getFileFromResource("test-data/hello.vsd")));
     }
 
+    @Test
+    public void testCustomMimetypExtensions() {
+        assertEquals("application/octet-stream", mimetypeRegistry.getMimetypeFromExtension("rvt"));
+        assertEquals("application/octet-stream", mimetypeRegistry.getMimetypeFromExtension("dlx"));
+    }
+
     // CSV file
     @Test
     public void testCsvDocument() throws Exception {


### PR DESCRIPTION
t&p failed on an integration test (due to missing commit) but I am running it again.