### PR TITLE
NXP-24540: added a way to customize Quartz jobs and triggers

### DIFF
--- a/nuxeo-core/nuxeo-core-event/src/main/java/org/nuxeo/ecm/core/scheduler/DefaultEventJobFactory.java
+++ b/nuxeo-core/nuxeo-core-event/src/main/java/org/nuxeo/ecm/core/scheduler/DefaultEventJobFactory.java
@@ -1,0 +1,67 @@
+/*
+ * (C) Copyright 2007-2018 Nuxeo (http://nuxeo.com/) and others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Contributors:
+ *     Florent Munch
+ */
+package org.nuxeo.ecm.core.scheduler;
+
+import java.io.Serializable;
+import java.util.Map;
+
+import org.quartz.CronScheduleBuilder;
+import org.quartz.CronTrigger;
+import org.quartz.JobBuilder;
+import org.quartz.JobDataMap;
+import org.quartz.ScheduleBuilder;
+import org.quartz.TriggerBuilder;
+
+/**
+ * Default implementation of {@link EventJobFactory} instantiating an {@link EventJob} with a {@link CronTrigger}.
+ *
+ * @since 10.2
+ */
+public class DefaultEventJobFactory implements EventJobFactory {
+    @Override
+    public JobBuilder buildJob(Schedule schedule, Map<String, Serializable> parameters) {
+        JobDataMap map = new JobDataMap();
+        if (parameters != null) {
+            map.putAll(parameters);
+        }
+
+        return JobBuilder.newJob(getJobClass())
+                .withIdentity(schedule.getId(), "nuxeo")
+                .usingJobData(map)
+                .usingJobData("eventId", schedule.getEventId())
+                .usingJobData("eventCategory", schedule.getEventCategory())
+                .usingJobData("username", schedule.getUsername());
+    }
+
+    @Override
+    public TriggerBuilder<?> buildTrigger(Schedule schedule) {
+        return TriggerBuilder.newTrigger()
+                .withIdentity(schedule.getId(), "nuxeo")
+                .withSchedule(buildSchedule(schedule));
+    }
+
+    @Override
+    public ScheduleBuilder<?> buildSchedule(Schedule schedule) {
+        return CronScheduleBuilder.cronSchedule(schedule.getCronExpression());
+    }
+
+    protected Class<? extends EventJob> getJobClass() {
+        return EventJob.class;
+    }
+}

--- a/nuxeo-core/nuxeo-core-event/src/main/java/org/nuxeo/ecm/core/scheduler/EventJobFactory.java
+++ b/nuxeo-core/nuxeo-core-event/src/main/java/org/nuxeo/ecm/core/scheduler/EventJobFactory.java
@@ -1,0 +1,66 @@
+/*
+ * (C) Copyright 2007-2018 Nuxeo (http://nuxeo.com/) and others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Contributors:
+ *     Florent Munch
+ */
+package org.nuxeo.ecm.core.scheduler;
+
+import java.io.Serializable;
+import java.util.Map;
+
+import org.quartz.Job;
+import org.quartz.JobBuilder;
+import org.quartz.ScheduleBuilder;
+import org.quartz.Trigger;
+import org.quartz.TriggerBuilder;
+
+/**
+ * Factory instantiating the {@link Job} and the {@link Trigger} of a scheduled event.
+ *
+ * @since 10.2
+ */
+public interface EventJobFactory {
+    /**
+     * Builds the job of the scheduled event.
+     * <p>
+     * Returns a builder to allow extensibility.
+     *
+     * @param schedule Scheduled event contribution.
+     * @param parameters Job parameters (might be {@code null}).
+     * @return An instance of {@link JobBuilder}.
+     */
+    JobBuilder buildJob(Schedule schedule, Map<String, Serializable> parameters);
+
+    /**
+     * Builds the trigger of the scheduled event.
+     * <p>
+     * Returns a builder to allow extensibility.
+     *
+     * @param schedule Scheduled event contribution.
+     * @return An instance of {@link TriggerBuilder}.
+     */
+    TriggerBuilder<?> buildTrigger(Schedule schedule);
+
+    /**
+     * Builds the schedule of the trigger (used by {@link #buildTrigger(Schedule)}).
+     * <p>
+     * Returns a builder to allow extensibility.
+     *
+     * @param schedule Scheduled event contribution.
+     * @return An instance of {@link ScheduleBuilder}.
+     */
+    ScheduleBuilder<?> buildSchedule(Schedule schedule);
+}

--- a/nuxeo-core/nuxeo-core-event/src/main/java/org/nuxeo/ecm/core/scheduler/Schedule.java
+++ b/nuxeo-core/nuxeo-core-event/src/main/java/org/nuxeo/ecm/core/scheduler/Schedule.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright 2007-2010 Nuxeo SA (http://nuxeo.com/) and others.
+ * (C) Copyright 2007-2018 Nuxeo SA (http://nuxeo.com/) and others.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,6 +15,7 @@
  *
  * Contributors:
  *     Florent Guillaume
+ *     Florent Munch
  */
 package org.nuxeo.ecm.core.scheduler;
 
@@ -34,6 +35,14 @@ public interface Schedule extends Serializable {
      * @return the schedule job id.
      */
     String getId();
+
+    /**
+     * Returns an instance of the {@link EventJobFactory} ({@link DefaultEventJobFactory} by default).
+     *
+     * @since 10.2
+     * @return An instance of {@link EventJobFactory}.
+     */
+    EventJobFactory getJobFactory();
 
     /**
      * Returns the event id.

--- a/nuxeo-core/nuxeo-core-event/src/main/java/org/nuxeo/ecm/core/scheduler/ScheduleImpl.java
+++ b/nuxeo-core/nuxeo-core-event/src/main/java/org/nuxeo/ecm/core/scheduler/ScheduleImpl.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright 2007-2010 Nuxeo SA (http://nuxeo.com/) and others.
+ * (C) Copyright 2007-2018 Nuxeo SA (http://nuxeo.com/) and others.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,11 +15,13 @@
  *
  * Contributors:
  *     Florent Guillaume
+ *     Florent Munch
  */
 package org.nuxeo.ecm.core.scheduler;
 
 import org.nuxeo.common.xmap.annotation.XNode;
 import org.nuxeo.common.xmap.annotation.XObject;
+import org.nuxeo.ecm.core.api.NuxeoException;
 
 /**
  * ScheduleImpl extension definition.
@@ -31,6 +33,12 @@ public class ScheduleImpl implements Schedule {
 
     @XNode("@id")
     public String id;
+
+    /**
+     * @since 10.2
+     */
+    @XNode("@jobFactoryClass")
+    public Class<? extends EventJobFactory> jobFactoryClass = DefaultEventJobFactory.class;
 
     @XNode("event")
     public String eventId;
@@ -60,6 +68,15 @@ public class ScheduleImpl implements Schedule {
     @Override
     public String getId() {
         return id;
+    }
+
+    @Override
+    public EventJobFactory getJobFactory() {
+        try {
+            return jobFactoryClass.getDeclaredConstructor().newInstance();
+        } catch (ReflectiveOperationException e) {
+            throw new NuxeoException("Failed to instantiate job factory " + jobFactoryClass, e);
+        }
     }
 
     @Override

--- a/nuxeo-core/nuxeo-core-event/src/main/resources/OSGI-INF/scheduler-service.xml
+++ b/nuxeo-core/nuxeo-core-event/src/main/resources/OSGI-INF/scheduler-service.xml
@@ -25,7 +25,7 @@
       <p/>
       For instance :
       <code>
-        <schedule id="mySchedule">
+        <schedule id="mySchedule" jobFactoryClass="org.nuxeo.ecm.core.scheduler.DefaultEventJobFactory">
           <username>Administrator</username>
           <event>myEvent</event>
           <eventCategory>default</eventCategory>
@@ -33,8 +33,10 @@
           <cronExpression>0 0 3 1 * ?</cronExpression>
         </schedule>
       </code>
+      jobFactoryClass is optional and defaults to org.nuxeo.ecm.core.scheduler.DefaultEventJobFactory.
 
       @see org.quartz.CronTrigger
+      @see org.nuxeo.ecm.core.scheduler.EventJobFactory
       @see http://www.quartz-scheduler.org/docs/api/1.8.1/org/quartz/CronExpression.html
       @see http://www.quartz-scheduler.org/docs/tutorials/crontrigger.html
     </documentation>

--- a/nuxeo-core/nuxeo-core-event/src/test/java/org/nuxeo/ecm/core/scheduler/EventJobFactoryTest.java
+++ b/nuxeo-core/nuxeo-core-event/src/test/java/org/nuxeo/ecm/core/scheduler/EventJobFactoryTest.java
@@ -1,0 +1,68 @@
+/*
+ * (C) Copyright 2007-2018 Nuxeo (http://nuxeo.com/) and others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Contributors:
+ *     Florent Munch
+ */
+package org.nuxeo.ecm.core.scheduler;
+
+import javax.inject.Inject;
+import java.lang.reflect.Field;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.nuxeo.runtime.test.runner.Deploy;
+import org.nuxeo.runtime.test.runner.Features;
+import org.nuxeo.runtime.test.runner.FeaturesRunner;
+import org.nuxeo.runtime.test.runner.RuntimeFeature;
+import org.quartz.JobDetail;
+import org.quartz.JobKey;
+import org.quartz.Scheduler;
+import org.quartz.SchedulerException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests {@link EventJobFactory} by contributing a job using {@link org.quartz.DisallowConcurrentExecution}.
+ *
+ * @since 10.2
+ */
+@RunWith(FeaturesRunner.class)
+@Features(RuntimeFeature.class)
+@Deploy("org.nuxeo.ecm.core.event")
+@Deploy("org.nuxeo.ecm.core.event.test:test-jobfactory.xml") // jobs
+public class EventJobFactoryTest {
+    @Inject
+    private SchedulerService schedulerService;
+
+    @Test
+    public void test() throws ReflectiveOperationException, SchedulerException {
+        Field schedulerField = SchedulerServiceImpl.class.getDeclaredField("scheduler");
+        schedulerField.setAccessible(true);
+        Scheduler scheduler = (Scheduler) schedulerField.get(schedulerService);
+
+        // job without the DisallowConcurrentExecution annotation
+        JobKey jobKey = new JobKey("testSchedulerMultipleExecutions", "nuxeo");
+        JobDetail jobDetail = scheduler.getJobDetail(jobKey);
+        assertThat(jobDetail).isNotNull();
+        assertThat(jobDetail.isConcurrentExectionDisallowed()).isFalse();
+
+        // job with the DisallowConcurrentExecution annotation
+        jobKey = new JobKey("testSchedulerSingleExecution", "nuxeo");
+        jobDetail = scheduler.getJobDetail(jobKey);
+        assertThat(jobDetail).isNotNull();
+        assertThat(jobDetail.isConcurrentExectionDisallowed()).isTrue();
+    }
+}

--- a/nuxeo-core/nuxeo-core-event/src/test/java/org/nuxeo/ecm/core/scheduler/SingleExecutionEventJob.java
+++ b/nuxeo-core/nuxeo-core-event/src/test/java/org/nuxeo/ecm/core/scheduler/SingleExecutionEventJob.java
@@ -1,0 +1,31 @@
+/*
+ * (C) Copyright 2007-2018 Nuxeo (http://nuxeo.com/) and others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Contributors:
+ *     Florent Munch
+ */
+package org.nuxeo.ecm.core.scheduler;
+
+import org.quartz.DisallowConcurrentExecution;
+
+/**
+ * Quartz job extending {@link EventJob} by adding {@link DisallowConcurrentExecution}.
+ *
+ * @since 10.2
+ */
+@DisallowConcurrentExecution
+public class SingleExecutionEventJob extends EventJob {
+
+}

--- a/nuxeo-core/nuxeo-core-event/src/test/java/org/nuxeo/ecm/core/scheduler/SingleExecutionEventJobFactory.java
+++ b/nuxeo-core/nuxeo-core-event/src/test/java/org/nuxeo/ecm/core/scheduler/SingleExecutionEventJobFactory.java
@@ -1,0 +1,31 @@
+/*
+ * (C) Copyright 2007-2018 Nuxeo (http://nuxeo.com/) and others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Contributors:
+ *     Florent Munch
+ */
+package org.nuxeo.ecm.core.scheduler;
+
+/**
+ * Factory using {@link SingleExecutionEventJob} as the Quartz job class.
+ *
+ * @since 10.2
+ */
+public class SingleExecutionEventJobFactory extends DefaultEventJobFactory {
+    @Override
+    protected Class<? extends EventJob> getJobClass() {
+        return SingleExecutionEventJob.class;
+    }
+}

--- a/nuxeo-core/nuxeo-core-event/src/test/resources/test-jobfactory.xml
+++ b/nuxeo-core/nuxeo-core-event/src/test/resources/test-jobfactory.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component name="test-jobfactory" version="1.0">
+
+  <extension target="org.nuxeo.ecm.core.scheduler.SchedulerService" point="schedule">
+
+    <schedule id="testSchedulerMultipleExecutions">
+      <event>testSchedulerMultipleExecutions</event>
+      <cronExpression>0 * * * * ?</cronExpression>
+    </schedule>
+
+    <schedule id="testSchedulerSingleExecution"
+        jobFactoryClass="org.nuxeo.ecm.core.scheduler.SingleExecutionEventJobFactory">
+      <event>testSchedulerSingleExecution</event>
+      <cronExpression>0 * * * * ?</cronExpression>
+    </schedule>
+
+  </extension>
+
+</component>


### PR DESCRIPTION
Added an optional `jobFactoryClass` attribute to the `schedule` extension
point of `SchedulerService` to allow a custom Quartz job and trigger to be
used.

Allows for example the use of `@DisallowConcurrentExecution` on the job or
`withMisfireHandlingInstructionIgnoreMisfires()` on the trigger.

See https://answers.nuxeo.com/general/q/497114904ba6475d9426ca61c9423b51/Feature-Custom-Quartz-Job-and-Trigger