### PR TITLE
NXP-24756: Fix WebDav file creation on MacOSX

### DIFF
--- a/nuxeo-services/nuxeo-platform-filemanager-api/src/main/java/org/nuxeo/ecm/platform/filemanager/utils/FileManagerUtils.java
+++ b/nuxeo-services/nuxeo-platform-filemanager-api/src/main/java/org/nuxeo/ecm/platform/filemanager/utils/FileManagerUtils.java
@@ -26,6 +26,7 @@ import java.io.InputStream;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.text.Normalizer;
+import java.text.Normalizer.Form;
 
 import org.apache.commons.io.IOUtils;
 import org.nuxeo.common.utils.IdUtils;
@@ -74,7 +75,8 @@ public final class FileManagerUtils {
     // with a \, or a DOS file with a /
     public static String fetchFileName(String fullName) {
         // Fetching filename
-        String ret = fullName;
+        // first normalize input, as unicode can be decomposed (macOS behavior on WebDAV)
+        String ret = Normalizer.normalize(fullName, Form.NFC);
         int lastWinSeparator = fullName.lastIndexOf('\\');
         int lastUnixSeparator = fullName.lastIndexOf('/');
         int lastSeparator = Math.max(lastWinSeparator, lastUnixSeparator);

--- a/nuxeo-services/nuxeo-platform-filemanager-core/src/test/java/org/nuxeo/ecm/platform/filemanager/TestFileManagerService.java
+++ b/nuxeo-services/nuxeo-platform-filemanager-core/src/test/java/org/nuxeo/ecm/platform/filemanager/TestFileManagerService.java
@@ -30,6 +30,7 @@ import java.io.IOException;
 import java.io.Serializable;
 import java.net.URL;
 import java.text.Normalizer;
+import java.text.Normalizer.Form;
 import java.util.List;
 
 import javax.inject.Inject;
@@ -297,10 +298,25 @@ public class TestFileManagerService {
     }
 
     @Test
-    public void testCreateExistingBlobWithNonNFCNormalizedFilename() throws Exception {
+    public void testCreateBlobWithNonNFCNormalizedFilename() throws Exception {
+        // Create doc from non NFC (NFD) normalized filename
+        String fileName = "ÜÜÜ ÓÓÓ.rtf";
+        String nfdNormalizedFileName = Normalizer.normalize(fileName, Normalizer.Form.NFD);
+        Blob blob = Blobs.createBlob("Test content", "text/rtf", null, nfdNormalizedFileName);
+        service.createDocumentFromBlob(coreSession, blob, workspace.getPathAsString(), true, nfdNormalizedFileName);
+        assertNotNull(FileManagerUtils.getExistingDocByFileName(coreSession, workspace.getPathAsString(),
+                                                                nfdNormalizedFileName));
+        // Check existing doc with NFC normalized filename
+        String nfcNormalizedFileName = Normalizer.normalize(fileName, Normalizer.Form.NFC);
+        assertNotNull(FileManagerUtils.getExistingDocByFileName(coreSession, workspace.getPathAsString(),
+                                                                nfcNormalizedFileName));
+    }
+
+    @Test
+    public void testGetExistingBlobWithNonNFCNormalizedFilename() throws Exception {
         // Create doc from NFC normalized filename
         String fileName = "ÜÜÜ ÓÓÓ.rtf";
-        String nfcNormalizedFileName = Normalizer.normalize(fileName, Normalizer.Form.NFC);
+        String nfcNormalizedFileName = Normalizer.normalize(fileName, Form.NFC);
         Blob blob = Blobs.createBlob("Test content", "text/rtf", null, nfcNormalizedFileName);
         service.createDocumentFromBlob(coreSession, blob, workspace.getPathAsString(), true, nfcNormalizedFileName);
         assertNotNull(FileManagerUtils.getExistingDocByFileName(coreSession, workspace.getPathAsString(),


### PR DESCRIPTION
I wasn't able to do a T&P, 5-6 fails with connection error to firefox or on some selenium tests.
Even if tests seem to be the same between the two last run, I wasn't able to reproduce it locally.

Here the three [tests](https://qa2.nuxeo.org/jenkins/job/TestAndPush/job/ondemand-testandpush-kleturc-7.10/58/artifact/nuxeo-distribution/nuxeo-distribution-cap-selenium-tests/target/results/result-suite1.html#testresult24)
- modifyNote
- createSubGroupAdmin
- createSubGroupMembers

Does it ring a bell to someone ? My changes shouldn't affect these tests.
Note: 8.10, 9.10 and on going FT has passed T&P on first try.