### PR TITLE
fix-NXP-25178-missing-id-when-update-9.10

### DIFF
--- a/nuxeo-features/rest-api/nuxeo-rest-api-server/src/main/java/org/nuxeo/ecm/restapi/server/jaxrs/directory/DirectoryEntryObject.java
+++ b/nuxeo-features/rest-api/nuxeo-rest-api-server/src/main/java/org/nuxeo/ecm/restapi/server/jaxrs/directory/DirectoryEntryObject.java
@@ -77,10 +77,13 @@ public class DirectoryEntryObject extends DefaultObject {
 
             @Override
             DirectoryEntry run(Session session) {
-                DocumentModel docEntry = entry.getDocumentModel();
-                session.updateEntry(docEntry);
-                return new DirectoryEntry(directory.getName(), session.getEntry(docEntry.getId()));
-
+                try {
+                    DocumentModel docEntry = entry.getDocumentModel();
+                    session.updateEntry(docEntry);
+                    return new DirectoryEntry(directory.getName(), session.getEntry(docEntry.getId()));
+                } catch (DirectoryException e) {
+                    throw new NuxeoException(e.getMessage(), SC_BAD_REQUEST);
+                }
             }
         });
     }

--- a/nuxeo-features/rest-api/nuxeo-rest-api-test/src/test/java/org/nuxeo/ecm/restapi/test/DirectoryTest.java
+++ b/nuxeo-features/rest-api/nuxeo-rest-api-test/src/test/java/org/nuxeo/ecm/restapi/test/DirectoryTest.java
@@ -238,6 +238,17 @@ public class DirectoryTest extends BaseTest {
         nextTransaction(); // see committed changes
         docEntry = dirSession.getEntry(docEntry.getId());
         assertEquals("another label", docEntry.getPropertyValue("vocabulary:label"));
+
+        // The document should not be updated if the id is missing at the root and in the properties
+        String missingIdEntry = "{\"entity-type\":\"directoryEntry\",\"directoryName\":\"testdir\",\"properties\":{\"label\":\"different label\"}}";
+        try (CloseableClientResponse response = getResponse(RequestType.PUT,
+                "/directory/" + TESTDIRNAME + "/" + docEntry.getId(), missingIdEntry)) {
+            assertEquals(Response.Status.BAD_REQUEST.getStatusCode(), response.getStatus());
+        }
+
+        nextTransaction(); // see committed changes
+        docEntry = dirSession.getEntry(docEntry.getId());
+        assertEquals("another label", docEntry.getPropertyValue("vocabulary:label"));
     }
 
     @Test

--- a/nuxeo-services/nuxeo-platform-directory/nuxeo-platform-directory-api/src/main/java/org/nuxeo/ecm/directory/BaseSession.java
+++ b/nuxeo-services/nuxeo-platform-directory/nuxeo-platform-directory-api/src/main/java/org/nuxeo/ecm/directory/BaseSession.java
@@ -395,6 +395,11 @@ public abstract class BaseSession implements Session, EntrySource {
     public void updateEntry(DocumentModel docModel) throws DirectoryException {
         checkPermission(SecurityConstants.WRITE);
 
+        String id = docModel.getId();
+        if (id == null) {
+            throw new DirectoryException("The document cannot be updated because its id is missing");
+        }
+
         // Retrieve the references to update in the document model, and update the rest
         List<String> referenceFieldList = updateEntryWithoutReferences(docModel);
 


### PR DESCRIPTION
PR created from https://qa2.nuxeo.org/jenkins/job/TestAndPush/job/ondemand-testandpush-fdavid-9.10/20/