### PR TITLE
NXP-25396 xmlbeans 3.0.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2266,13 +2266,7 @@
       <dependency>
         <groupId>org.apache.xmlbeans</groupId>
         <artifactId>xmlbeans</artifactId>
-        <version>2.6.0</version>
-        <exclusions>
-          <exclusion>
-            <groupId>stax</groupId>
-            <artifactId>stax-api</artifactId>
-          </exclusion>
-        </exclusions>
+        <version>3.0.0</version>
       </dependency>
       <dependency>
         <groupId>org.apache.directory.shared</groupId>


### PR DESCRIPTION
Has just bug fixes - but removes stax jar dependency and fixes issues with a number of issues - https://xmlbeans.apache.org/