### PR TITLE
NXP-25487: Fix Elasticsearch.Index operation on folder

### DIFF
--- a/nuxeo-features/nuxeo-elasticsearch/nuxeo-elasticsearch-automation/src/test/java/org/nuxeo/ecm/automation/elasticsearch/test/TestElasticsearchAutomation.java
+++ b/nuxeo-features/nuxeo-elasticsearch/nuxeo-elasticsearch-automation/src/test/java/org/nuxeo/ecm/automation/elasticsearch/test/TestElasticsearchAutomation.java
@@ -119,6 +119,22 @@ public class TestElasticsearchAutomation {
     }
 
     @Test
+    public void testIndexingFromPath() throws Exception {
+        // first index all
+        OperationContext ctx = new OperationContext(coreSession);
+        automationService.run(ctx, INDEX_CHAIN);
+        waitForIndexing();
+
+        // then reindex from path, so we have a 2 commands: delete + insert
+        ctx.setInput(rootRef);
+        automationService.run(ctx, INDEX_CHAIN);
+        waitForIndexing();
+
+        assertEquals(2, ess.query(new NxQueryBuilder(coreSession).nxql("SELECT * from Document")).totalSize());
+    }
+
+
+    @Test
     public void testIndexingFromNxql() throws Exception {
         OperationContext ctx = new OperationContext(coreSession);
         ctx.setInput("SELECT ecm:uuid FROM Document WHERE ecm:primaryType = 'File'");


### PR DESCRIPTION
By removing concurrency between deletion and insertion commands.