### PR TITLE
Use exec to launch command in Unix systems

### DIFF
--- a/nuxeo-distribution/nuxeo-launcher/src/main/java/org/nuxeo/launcher/NuxeoLauncher.java
+++ b/nuxeo-distribution/nuxeo-launcher/src/main/java/org/nuxeo/launcher/NuxeoLauncher.java
@@ -871,6 +871,7 @@ public abstract class NuxeoLauncher {
     private List<String> getUnixCommand(List<String> roughCommand) {
         ArrayList<String> osCommand = new ArrayList<>();
         String linearizedCommand = new String();
+        linearizedCommand += "exec";
         for (String commandToken : roughCommand) {
             if (StringUtils.isBlank(commandToken)) {
                 continue;


### PR DESCRIPTION
Launch commands using `/bin/sh -c 'exec ...'` instead of simply `/bin/sh -c '...'`.

This fix an error when using nuxeo with systemd: "Supervising process <pid from nuxeo.pid> which is not our child. We'll most likely not notice when it exits."