### PR TITLE
NXP-25887: Dynamic digest in PORTAL_AUTH

### DIFF
--- a/nuxeo-services/login/nuxeo-platform-login-portal-sso/src/main/java/org/nuxeo/ecm/platform/ui/web/auth/portal/PortalAuthenticator.java
+++ b/nuxeo-services/login/nuxeo-platform-login-portal-sso/src/main/java/org/nuxeo/ecm/platform/ui/web/auth/portal/PortalAuthenticator.java
@@ -15,6 +15,7 @@
  *
  * Contributors:
  *     Nuxeo - initial API and implementation
+ *     Florent Munch
  *
  * $Id: JOOoConvertPluginImpl.java 18651 2007-05-13 20:28:53Z sfermigier $
  */
@@ -33,12 +34,16 @@ import javax.servlet.http.HttpServletResponse;
 
 import org.nuxeo.ecm.platform.api.login.UserIdentificationInfo;
 import org.nuxeo.ecm.platform.ui.web.auth.interfaces.NuxeoAuthenticationPlugin;
+import org.nuxeo.runtime.api.Framework;
+import org.nuxeo.runtime.services.config.ConfigurationService;
 
 public class PortalAuthenticator implements NuxeoAuthenticationPlugin {
 
     public static final String SECRET_KEY_NAME = "secret";
 
     public static final String MAX_AGE_KEY_NAME = "maxAge";
+
+    private static final String DIGEST_ALGORITHM_PROPERTY = "nuxeo.auth.portal.digest.algorithm";
 
     private static final String TS_HEADER = "NX_TS";
 
@@ -100,12 +105,16 @@ public class PortalAuthenticator implements NuxeoAuthenticationPlugin {
     }
 
     protected Boolean validateToken(String ts, String random, String token, String userName) {
+        // determine the digest
+        ConfigurationService configurationService = Framework.getService(ConfigurationService.class);
+        String digest = configurationService.getProperty(DIGEST_ALGORITHM_PROPERTY);
+
         // reconstruct the token
         String clearToken = ts + TOKEN_SEP + random + TOKEN_SEP + secret + TOKEN_SEP + userName;
 
         byte[] hashedToken;
         try {
-            hashedToken = MessageDigest.getInstance("MD5").digest(clearToken.getBytes());
+            hashedToken = MessageDigest.getInstance(digest).digest(clearToken.getBytes());
         } catch (NoSuchAlgorithmException e) {
             return false;
         }

--- a/nuxeo-services/login/nuxeo-platform-login-portal-sso/src/main/resources/META-INF/MANIFEST.MF
+++ b/nuxeo-services/login/nuxeo-platform-login-portal-sso/src/main/resources/META-INF/MANIFEST.MF
@@ -4,4 +4,5 @@ Bundle-Name: Nuxeo protal SSO Login Module extension
 Bundle-SymbolicName: org.nuxeo.ecm.platform.login.portal;singleton:=true
 Bundle-Version: 1.0.0
 Require-Bundle: org.nuxeo.ecm.platform.login
-Nuxeo-Component: OSGI-INF/Portal-authentication-contrib.xml
+Nuxeo-Component: OSGI-INF/Portal-authentication-contrib.xml,
+ OSGI-INF/properties-contrib.xml

--- a/nuxeo-services/login/nuxeo-platform-login-portal-sso/src/main/resources/OSGI-INF/properties-contrib.xml
+++ b/nuxeo-services/login/nuxeo-platform-login-portal-sso/src/main/resources/OSGI-INF/properties-contrib.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0"?>
+<component name="org.nuxeo.ecm.platform.login.portal.properties">
+
+  <extension target="org.nuxeo.runtime.ConfigurationService" point="configuration">
+
+    <documentation>
+      Digest algorithm used to generate the token during a portal authentication.
+
+      @since 10.3
+    </documentation>
+
+    <property name="nuxeo.auth.portal.digest.algorithm">MD5</property>
+
+  </extension>
+
+</component>

--- a/nuxeo-services/login/nuxeo-platform-login-portal-sso/src/test/java/org/nuxeo/ecm/platform/ui/web/auth/portal/TestPortalAuthenticator.java
+++ b/nuxeo-services/login/nuxeo-platform-login-portal-sso/src/test/java/org/nuxeo/ecm/platform/ui/web/auth/portal/TestPortalAuthenticator.java
@@ -15,6 +15,7 @@
  *
  * Contributors:
  *     Florent Guillaume
+ *     Florent Munch
  */
 package org.nuxeo.ecm.platform.ui.web.auth.portal;
 
@@ -24,29 +25,92 @@ import java.util.HashMap;
 import java.util.Map;
 
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.nuxeo.runtime.test.runner.Deploy;
+import org.nuxeo.runtime.test.runner.Features;
+import org.nuxeo.runtime.test.runner.FeaturesRunner;
+import org.nuxeo.runtime.test.runner.RuntimeFeature;
 
+@RunWith(FeaturesRunner.class)
+@Features(RuntimeFeature.class)
+@Deploy("org.nuxeo.ecm.platform.login.portal")
+@Deploy("org.nuxeo.ecm.platform.login.portal:fake-pluggableauthenticationservice.xml")
 public class TestPortalAuthenticator {
+
+    private static final String SOME_TS = "1538167025822";
+
+    private static final String SOME_RANDOM = "31415abcdef";
+
+    private static final String SOME_USER = "bob";
 
     private static final String SOME_SECRET = "some_secret";
 
     @Test
-    public void testValidateToken() {
+    public void testValidateTokenWithDefaultDigestAlgorithm() {
+        doTestValidateToken(Boolean.FALSE, SOME_TS, SOME_RANDOM, SOME_USER, "q0kweBvLv2/fPAuCrJkBmQ==");
+        doTestValidateToken(Boolean.TRUE, SOME_TS, SOME_RANDOM, SOME_USER, "13/PMDal0Bzq3LnyICLcfQ==");
+    }
+
+    @Test
+    @Deploy("org.nuxeo.ecm.platform.login.portal.test:properties-digest-md5-contrib.xml")
+    public void testValidateTokenWithMd5() {
+        doTestValidateToken(Boolean.FALSE, SOME_TS, SOME_RANDOM, SOME_USER, "q0kweBvLv2/fPAuCrJkBmQ==");
+        doTestValidateToken(Boolean.TRUE, SOME_TS, SOME_RANDOM, SOME_USER, "13/PMDal0Bzq3LnyICLcfQ==");
+    }
+
+    @Test
+    @Deploy("org.nuxeo.ecm.platform.login.portal.test:properties-digest-sha-contrib.xml")
+    public void testValidateTokenWithSha() {
+        doTestValidateToken(Boolean.FALSE, SOME_TS, SOME_RANDOM, SOME_USER, "w7/p23JaEIg1aUWPl/3UUnlJLio=");
+        doTestValidateToken(Boolean.TRUE, SOME_TS, SOME_RANDOM, SOME_USER, "0d2699yAx8Oz8jKq3m/ntI+Nhgs=");
+    }
+
+    @Test
+    @Deploy("org.nuxeo.ecm.platform.login.portal.test:properties-digest-sha256-contrib.xml")
+    public void testValidateTokenWithSha256() {
+        doTestValidateToken(Boolean.FALSE, SOME_TS, SOME_RANDOM, SOME_USER,
+                "8SZI0nZmEThFUifkr5X0VFixaMbQIIZQuMUAFPwqYbw=");
+        doTestValidateToken(Boolean.TRUE, SOME_TS, SOME_RANDOM, SOME_USER,
+                "aQWWi7TPe9HOT/Hws7WfPvNuiDzgsiluVbloZWvvl2E=");
+    }
+
+    @Test
+    @Deploy("org.nuxeo.ecm.platform.login.portal.test:properties-digest-sha512-contrib.xml")
+    public void testValidateTokenWithSha512() {
+        doTestValidateToken(Boolean.FALSE, SOME_TS, SOME_RANDOM, SOME_USER,
+                "AxpXhL2+mG7DmfdE1xQ1b2LIH1HGpDqTLMGaX9B8zBhGfHHbm80u7NbhliQne4UU/Z1A2L6iuOUn+NtfTcxg7w==");
+        doTestValidateToken(Boolean.TRUE, SOME_TS, SOME_RANDOM, SOME_USER,
+                "yS+e7Gb/FK9cxFjPyrxXLHfm6BLtXESO0xk+lTGWbcReqXvQZq4/bKtvBoGKR8VIw4KDlehnNzD/zICnw5JCKg==");
+    }
+
+    @Test
+    public void testValidateTokenWithMaxAge() {
         doTestValidateTokenWithMaxAge(Boolean.TRUE, String.valueOf(Long.MAX_VALUE));
         doTestValidateTokenWithMaxAge(Boolean.FALSE, "3600");
     }
 
+    public void doTestValidateToken(Boolean expected, String ts, String random, String user, String token) {
+        PortalAuthenticator portalAuthenticator = getPortalAuthenticator(String.valueOf(Long.MAX_VALUE));
+
+        assertEquals(expected, portalAuthenticator.validateToken(ts, random, token, user));
+    }
+
     public void doTestValidateTokenWithMaxAge(Boolean expected, String maxAge) {
+        PortalAuthenticator portalAuthenticator = getPortalAuthenticator(maxAge);
+
+        String ts = "0"; // in the far past
+        String token = "A1A27eeSJo8bigVhWB6mMw==";
+        assertEquals(expected, portalAuthenticator.validateToken(ts, SOME_RANDOM, token, SOME_USER));
+    }
+
+    private PortalAuthenticator getPortalAuthenticator(String maxAge) {
         PortalAuthenticator portalAuthenticator = new PortalAuthenticator();
         Map<String, String> params = new HashMap<>();
         params.put(PortalAuthenticator.SECRET_KEY_NAME, SOME_SECRET);
         params.put(PortalAuthenticator.MAX_AGE_KEY_NAME, maxAge);
         portalAuthenticator.initPlugin(params);
 
-        String ts = "0"; // in the far past
-        String random = "31415abcdef";
-        String userName = "bob";
-        String token = "A1A27eeSJo8bigVhWB6mMw==";
-        assertEquals(expected, portalAuthenticator.validateToken(ts, random, token, userName));
+        return portalAuthenticator;
     }
 
 }

--- a/nuxeo-services/login/nuxeo-platform-login-portal-sso/src/test/resources/META-INF/MANIFEST.MF
+++ b/nuxeo-services/login/nuxeo-platform-login-portal-sso/src/test/resources/META-INF/MANIFEST.MF
@@ -1,0 +1,3 @@
+Manifest-Version: 1.0
+Bundle-ManifestVersion: 2
+Bundle-SymbolicName: org.nuxeo.ecm.platform.login.portal.test

--- a/nuxeo-services/login/nuxeo-platform-login-portal-sso/src/test/resources/fake-pluggableauthenticationservice.xml
+++ b/nuxeo-services/login/nuxeo-platform-login-portal-sso/src/test/resources/fake-pluggableauthenticationservice.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0"?>
+<component name="org.nuxeo.ecm.platform.ui.web.auth.service.PluggableAuthenticationService">
+
+  <extension-point name="authenticators" />
+
+</component>

--- a/nuxeo-services/login/nuxeo-platform-login-portal-sso/src/test/resources/properties-digest-md5-contrib.xml
+++ b/nuxeo-services/login/nuxeo-platform-login-portal-sso/src/test/resources/properties-digest-md5-contrib.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0"?>
+<component name="org.nuxeo.ecm.platform.login.portal.properties.digest.md5.test">
+
+  <require>org.nuxeo.ecm.platform.login.portal.properties</require>
+
+  <extension target="org.nuxeo.runtime.ConfigurationService" point="configuration">
+
+    <property name="nuxeo.auth.portal.digest.algorithm">MD5</property>
+
+  </extension>
+
+</component>

--- a/nuxeo-services/login/nuxeo-platform-login-portal-sso/src/test/resources/properties-digest-sha-contrib.xml
+++ b/nuxeo-services/login/nuxeo-platform-login-portal-sso/src/test/resources/properties-digest-sha-contrib.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0"?>
+<component name="org.nuxeo.ecm.platform.login.portal.properties.digest.sha.test">
+
+  <require>org.nuxeo.ecm.platform.login.portal.properties</require>
+
+  <extension target="org.nuxeo.runtime.ConfigurationService" point="configuration">
+
+    <property name="nuxeo.auth.portal.digest.algorithm">SHA</property>
+
+  </extension>
+
+</component>

--- a/nuxeo-services/login/nuxeo-platform-login-portal-sso/src/test/resources/properties-digest-sha256-contrib.xml
+++ b/nuxeo-services/login/nuxeo-platform-login-portal-sso/src/test/resources/properties-digest-sha256-contrib.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0"?>
+<component name="org.nuxeo.ecm.platform.login.portal.properties.digest.sha256.test">
+
+  <require>org.nuxeo.ecm.platform.login.portal.properties</require>
+
+  <extension target="org.nuxeo.runtime.ConfigurationService" point="configuration">
+
+    <property name="nuxeo.auth.portal.digest.algorithm">SHA-256</property>
+
+  </extension>
+
+</component>

--- a/nuxeo-services/login/nuxeo-platform-login-portal-sso/src/test/resources/properties-digest-sha512-contrib.xml
+++ b/nuxeo-services/login/nuxeo-platform-login-portal-sso/src/test/resources/properties-digest-sha512-contrib.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0"?>
+<component name="org.nuxeo.ecm.platform.login.portal.properties.digest.sha512.test">
+
+  <require>org.nuxeo.ecm.platform.login.portal.properties</require>
+
+  <extension target="org.nuxeo.runtime.ConfigurationService" point="configuration">
+
+    <property name="nuxeo.auth.portal.digest.algorithm">SHA-512</property>
+
+  </extension>
+
+</component>


### PR DESCRIPTION
Allows the use of other (more robust) digests in PORTAL_AUTH while still falling back to MD5.