### PR TITLE
NXP 26002: blob enrichers + appLinks enricher

### DIFF
--- a/nuxeo-core/nuxeo-core-api/src/main/java/org/nuxeo/ecm/core/blob/apps/AppLink.java
+++ b/nuxeo-core/nuxeo-core-api/src/main/java/org/nuxeo/ecm/core/blob/apps/AppLink.java
@@ -18,8 +18,6 @@
  */
 package org.nuxeo.ecm.core.blob.apps;
 
-import java.net.URI;
-
 /**
  * @since 7.3
  */

--- a/nuxeo-core/nuxeo-core-io/src/main/java/org/nuxeo/ecm/core/io/marshallers/json/enrichers/BlobAppLinksJsonEnricher.java
+++ b/nuxeo-core/nuxeo-core-io/src/main/java/org/nuxeo/ecm/core/io/marshallers/json/enrichers/BlobAppLinksJsonEnricher.java
@@ -1,0 +1,91 @@
+/*
+ * (C) Copyright 2018 Nuxeo (http://nuxeo.com/) and others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Contributors:
+ *     Nelson Silva <nsilva@nuxeo.com>
+ */
+
+package org.nuxeo.ecm.core.io.marshallers.json.enrichers;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import org.nuxeo.ecm.core.api.Blob;
+import org.nuxeo.ecm.core.api.DocumentModel;
+import org.nuxeo.ecm.core.api.NuxeoPrincipal;
+import org.nuxeo.ecm.core.blob.BlobManager;
+import org.nuxeo.ecm.core.blob.BlobProvider;
+import org.nuxeo.ecm.core.blob.ManagedBlob;
+import org.nuxeo.ecm.core.blob.apps.AppLink;
+import org.nuxeo.ecm.core.io.marshallers.json.document.DocumentModelJsonWriter;
+import org.nuxeo.ecm.core.io.registry.context.RenderingContext;
+import org.nuxeo.ecm.core.io.registry.reflect.Setup;
+import org.nuxeo.runtime.api.Framework;
+
+import java.io.IOException;
+import java.util.List;
+
+import static org.nuxeo.ecm.core.io.registry.reflect.Instantiations.SINGLETON;
+import static org.nuxeo.ecm.core.io.registry.reflect.Priorities.REFERENCE;
+
+/**
+ * Enrich {@link Blob} json with list of {@link AppLink}.
+ *
+ * Enabled when parameter enrichers-blob=appLinks is present.
+ *
+ * @since 10.3
+ */
+@Setup(mode = SINGLETON, priority = REFERENCE)
+public class BlobAppLinksJsonEnricher extends AbstractJsonEnricher<Blob> {
+
+    public static final String NAME = "appLinks";
+
+    public BlobAppLinksJsonEnricher() {
+        super(NAME);
+    }
+
+    @Override
+    public void write(JsonGenerator jg, Blob blob) throws IOException {
+        if (!(blob instanceof ManagedBlob)) {
+            return;
+        }
+
+        ManagedBlob managedBlob = (ManagedBlob) blob;
+
+        BlobManager blobManager = Framework.getService(BlobManager.class);
+        BlobProvider blobProvider = blobManager.getBlobProvider(managedBlob.getProviderId());
+        if (blobProvider == null) {
+            return;
+        }
+
+        DocumentModel doc = ctx.getParameter(DocumentModelJsonWriter.ENTITY_TYPE);
+        if (doc == null) {
+            return;
+        }
+
+        jg.writeFieldName(NAME);
+        jg.writeStartArray();
+        try (RenderingContext.SessionWrapper wrapper = ctx.getSession(doc)) {
+            NuxeoPrincipal principal = wrapper.getSession().getPrincipal();
+            if (principal != null) {
+                List<AppLink> apps = blobProvider.getAppLinks(principal.getName(), managedBlob);
+                for (AppLink app : apps) {
+                    jg.writeObject(app);
+                }
+            }
+        } finally {
+            jg.writeEndArray();
+        }
+    }
+
+}

--- a/nuxeo-core/nuxeo-core-io/src/main/resources/OSGI-INF/marshallers-contrib.xml
+++ b/nuxeo-core/nuxeo-core-io/src/main/resources/OSGI-INF/marshallers-contrib.xml
@@ -33,5 +33,6 @@
     <register class="org.nuxeo.ecm.core.io.marshallers.json.enrichers.ContextualParametersJsonEnricher" enable="true" />
     <register class="org.nuxeo.ecm.core.io.marshallers.json.enrichers.SubtypesJsonEnricher" enable="true" />
     <register class="org.nuxeo.ecm.core.io.marshallers.json.enrichers.UserVisiblePermissionsJsonEnricher" enable="true" />
+    <register class="org.nuxeo.ecm.core.io.marshallers.json.enrichers.BlobAppLinksJsonEnricher" enable="true" />
   </extension>
 </component>

--- a/nuxeo-core/nuxeo-core-test/src/main/java/org/nuxeo/ecm/core/DummyBlobProvider.java
+++ b/nuxeo-core/nuxeo-core-test/src/main/java/org/nuxeo/ecm/core/DummyBlobProvider.java
@@ -21,7 +21,9 @@ package org.nuxeo.ecm.core;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.Arrays;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicLong;
 
@@ -29,7 +31,9 @@ import org.apache.commons.io.IOUtils;
 import org.nuxeo.ecm.core.api.Blob;
 import org.nuxeo.ecm.core.blob.AbstractBlobProvider;
 import org.nuxeo.ecm.core.blob.BlobInfo;
+import org.nuxeo.ecm.core.blob.ManagedBlob;
 import org.nuxeo.ecm.core.blob.SimpleManagedBlob;
+import org.nuxeo.ecm.core.blob.apps.AppLink;
 
 /**
  * Dummy storage in memory.
@@ -76,6 +80,14 @@ public class DummyBlobProvider extends AbstractBlobProvider {
         String k = String.valueOf(counter.incrementAndGet());
         blobs.put(k, bytes);
         return k;
+    }
+
+    public List<AppLink> getAppLinks(String user, ManagedBlob blob) {
+        AppLink link = new AppLink();
+        link.setAppName("dummyApp");
+        link.setIcon("dummyIcon");
+        link.setLink("dummyLink");
+        return Arrays.asList(link);
     }
 
 }

--- a/nuxeo-core/nuxeo-core-test/src/test/java/org/nuxeo/ecm/core/io/marshallers/json/enrichers/BlobAppLinksJsonEnricherTest.java
+++ b/nuxeo-core/nuxeo-core-test/src/test/java/org/nuxeo/ecm/core/io/marshallers/json/enrichers/BlobAppLinksJsonEnricherTest.java
@@ -1,0 +1,87 @@
+/*
+ * (C) Copyright 2018 Nuxeo (http://nuxeo.com/) and others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Contributors:
+ *     Nelson Silva <nsilva@nuxeo.com>
+ */
+
+package org.nuxeo.ecm.core.io.marshallers.json.enrichers;
+
+import javax.inject.Inject;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.nuxeo.ecm.core.api.Blob;
+import org.nuxeo.ecm.core.api.Blobs;
+import org.nuxeo.ecm.core.api.CoreSession;
+import org.nuxeo.ecm.core.api.DocumentModel;
+import org.nuxeo.ecm.core.api.PathRef;
+import org.nuxeo.ecm.core.blob.BlobInfo;
+import org.nuxeo.ecm.core.blob.BlobManager;
+import org.nuxeo.ecm.core.blob.SimpleManagedBlob;
+import org.nuxeo.ecm.core.io.marshallers.json.AbstractJsonWriterTest;
+import org.nuxeo.ecm.core.io.marshallers.json.JsonAssert;
+import org.nuxeo.ecm.core.io.marshallers.json.document.DocumentModelJsonWriter;
+import org.nuxeo.ecm.core.io.registry.context.RenderingContext;
+import org.nuxeo.ecm.core.io.registry.context.RenderingContext.CtxBuilder;
+import org.nuxeo.ecm.core.test.CoreFeature;
+import org.nuxeo.runtime.test.runner.Deploy;
+import org.nuxeo.runtime.test.runner.Features;
+
+import java.io.IOException;
+import java.io.Serializable;
+
+@Features(CoreFeature.class)
+@Deploy("org.nuxeo.ecm.core.test.tests:OSGI-INF/test-dummy-blob-provider.xml")
+public class BlobAppLinksJsonEnricherTest extends AbstractJsonWriterTest.Local<DocumentModelJsonWriter, DocumentModel> {
+
+    @Inject
+    protected BlobManager blobManager;
+
+    @Inject
+    private CoreSession session;
+
+    public BlobAppLinksJsonEnricherTest() {
+        super(DocumentModelJsonWriter.class, DocumentModel.class);
+    }
+
+    @Before
+    public void setup() throws IOException {
+        Blob b = Blobs.createBlob("foo", "video/mp4");
+        String key = blobManager.getBlobProvider("dummy").writeBlob(b);
+        key = "dummy:" + key;
+
+        DocumentModel doc = session.createDocumentModel("/", "doc", "File");
+        BlobInfo blobInfo = new BlobInfo();
+        blobInfo.key = key;
+        blobInfo.mimeType = "video/mp4";
+        Blob blob = new SimpleManagedBlob(blobInfo);
+        doc.setPropertyValue("file:content", (Serializable) blob);
+        session.createDocument(doc);
+        session.save();
+    }
+
+    @Test
+    public void test() throws Exception {
+        DocumentModel doc = session.getDocument(new PathRef("/doc"));
+        RenderingContext ctx = CtxBuilder.properties("*").enrich("blob", "appLinks").get();
+        JsonAssert json = jsonAssert(doc, ctx);
+        json = json.has("properties").has("file:content");
+        json = json.has("appLinks").isArray().length(1).get(0);
+        json.has("appName").isEquals("dummyApp");
+        json.has("link").isEquals("dummyLink");
+        json.has("icon").isEquals("dummyIcon");
+    }
+}

--- a/nuxeo-core/nuxeo-core-test/src/test/resources/OSGI-INF/test-dummy-blob-provider.xml
+++ b/nuxeo-core/nuxeo-core-test/src/test/resources/OSGI-INF/test-dummy-blob-provider.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0"?>
+<component name="org.nuxeo.ecm.core.blob.test-dummy-blob-provider" version="1.0.0">
+  <extension target="org.nuxeo.ecm.core.blob.BlobManager" point="configuration">
+    <blobprovider name="dummy">
+      <class>org.nuxeo.ecm.core.DummyBlobProvider</class>
+    </blobprovider>
+  </extension>
+</component>


### PR DESCRIPTION
Quick experiment with `enrichers.blob: appLinks` returning `"file:content":{"name":"...", ..., "appLinks": [{...}]}`. Feedback's welcome