### PR TITLE
Fix login screen translation

### DIFF
--- a/nuxeo-services/nuxeo-platform-web-common/src/main/java/org/nuxeo/ecm/platform/ui/web/auth/service/LoginScreenConfig.java
+++ b/nuxeo-services/nuxeo-platform-web-common/src/main/java/org/nuxeo/ecm/platform/ui/web/auth/service/LoginScreenConfig.java
@@ -459,16 +459,13 @@ public class LoginScreenConfig implements Serializable {
             defaultLocale = newConfig.defaultLocale;
         }
 
-        boolean append = newConfig.isAppendSupportedLocales();
-        List<String> newLocales = newConfig.getSupportedLocales();
-        Set<String> mergedLocales = new HashSet<String>();
-        if (append && supportedLocales != null) {
-            mergedLocales.addAll(supportedLocales);
+        if (newConfig.supportedLocales != null && newConfig.supportedLocales.size() > 0) {
+            if (supportedLocales != null && newConfig.isAppendSupportedLocales()) {
+                supportedLocales.addAll(newConfig.supportedLocales);
+            } else {
+                supportedLocales = new ArrayList<>(newConfig.supportedLocales);
+            }
         }
-        if (newLocales != null) {
-            mergedLocales.addAll(newLocales);
-        }
-        supportedLocales = new ArrayList<>(mergedLocales);
     }
 
     /**

--- a/nuxeo-services/nuxeo-platform-web-common/src/main/java/org/nuxeo/ecm/platform/ui/web/auth/service/LoginScreenConfig.java
+++ b/nuxeo-services/nuxeo-platform-web-common/src/main/java/org/nuxeo/ecm/platform/ui/web/auth/service/LoginScreenConfig.java
@@ -363,8 +363,8 @@ public class LoginScreenConfig implements Serializable {
         if (supportedLocales != null) {
             res.addAll(supportedLocales);
         }
-        if (!res.contains(getDefaultLocale())) {
-            res.add(getDefaultLocale());
+        if (defaultLocale != null && !res.contains(defaultLocale)) {
+            res.add(defaultLocale);
         }
         return res;
     }


### PR DESCRIPTION
Login screen translation is currently being broken by LoginScreenConfig extensions without a <supportedLocales> section.

Indeed, the merge() function consider an empty array of supportedLocales as a which to remove any item previously configured.
This commit fix this behaviour.
I also added a commit to avoid adding "null" to the returned list of supportedLocales when the default local is not defined.