### PR TITLE
NXP-26607: enable long processing

### DIFF
--- a/nuxeo-distribution/nuxeo-nxr-server/src/main/resources/templates/common-base/nuxeo.defaults
+++ b/nuxeo-distribution/nuxeo-nxr-server/src/main/resources/templates/common-base/nuxeo.defaults
@@ -149,11 +149,13 @@ elasticsearch.restClient.keystoreType=
 kafka.enabled=false
 kafka.bootstrap.servers=localhost:9092
 kafka.topicPrefix=nuxeo-
-kafka.request.timeout.ms=65000
-kafka.max.poll.interval.ms=60000
+# must be greater than poll.interval
+kafka.request.timeout.ms=3605000
+# max duration of processing
+kafka.max.poll.interval.ms=3600000
 kafka.session.timeout.ms=50000
 kafka.heartbeat.interval.ms=2000
-kafka.max.poll.records=5
+kafka.max.poll.records=2
 
 # SASL
 kafka.sasl.enabled=false


### PR DESCRIPTION
Increasing the poll interval so long computation don't block the processing.
Use 1h limit and poll only 2 records.