### PR TITLE
fix-NXP-26131-NPE-in-Binary.recomputeFile-while-migrating-Audit-910

### DIFF
--- a/nuxeo-core/nuxeo-core-api/src/main/java/org/nuxeo/ecm/core/blob/binary/Binary.java
+++ b/nuxeo-core/nuxeo-core-api/src/main/java/org/nuxeo/ecm/core/blob/binary/Binary.java
@@ -25,6 +25,8 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.Serializable;
 
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 import org.nuxeo.ecm.core.blob.BlobManager;
 import org.nuxeo.ecm.core.blob.BlobProvider;
 import org.nuxeo.runtime.api.Framework;
@@ -38,6 +40,8 @@ import org.nuxeo.runtime.api.Framework;
 public class Binary implements Serializable {
 
     private static final long serialVersionUID = 1L;
+
+    private static final Log log = LogFactory.getLog(Binary.class);
 
     protected final String digest;
 
@@ -125,7 +129,12 @@ public class Binary implements Serializable {
     protected File recomputeFile() {
         BlobManager bm = Framework.getService(BlobManager.class);
         BlobProvider bp = bm.getBlobProvider(blobProviderId);
-        return bp.getBinaryManager().getBinary(digest).file;
+        Binary binary = bp.getBinaryManager().getBinary(digest);
+        if (binary == null) {
+            log.warn("Cannot fetch binary with digest " + digest);
+            return null;
+        }
+        return binary.file;
     }
 
 }


### PR DESCRIPTION
PR created from https://qa2.nuxeo.org/jenkins/job/TestAndPush/job/ondemand-testandpush-pabgrall-9.10/6/