### PR TITLE
Tag selection widget broken by latest hot-fixes 

### DIFF
--- a/nuxeo-features/nuxeo-platform-tag-service/nuxeo-platform-tag-web/src/main/resources/web/nuxeo.war/scripts/tags2Formatter.js
+++ b/nuxeo-features/nuxeo-platform-tag-service/nuxeo-platform-tag-web/src/main/resources/web/nuxeo.war/scripts/tags2Formatter.js
@@ -3,8 +3,8 @@ var nuxeo = nuxeo || {};
 function createNewTag(term, data) {
     return {
         // sanitize the term for the new tag
-        id : sanitizeTag(term, true),
-        displayLabel : sanitizeTag(term, true),
+        id : sanitizeTag(term),
+        displayLabel : sanitizeTag(term),
         newTag : true
     };
 }
@@ -35,17 +35,12 @@ function formatSelectedTags(tag) {
 
 /*
 This `sanitize` function is based on the cleanup done by TagServiceImpl#cleanLabel:
-- lowercase
 - no space
 - no slash
 - no antislash
 - no quote
 - no percent
 */
-function sanitizeTag(tag, ignoreCase) {
-    if (ignoreCase) {
-        return tag.replace(/[\/'% \\]/g, '').toLowerCase();
-    } else {
-        return tag.replace(/[\/'% \\]/g, '');
-    }
+function sanitizeTag(tag) {
+    return tag.replace(/[\/'% \\]/g, '');    
 }


### PR DESCRIPTION
Tag selection widget( from nuxeo studio) could be used for regular fields with case sensitive values.
We use it to make search by custom schema field by multiple values form tag form.
Recent hot-fixes for 8.10 version, broke search for us. Part of search query looks like this "AND CustomShema:field IN ('val1', 'VAL2',)" so toLowerCase() function broke search. 
I suggest to remove .toLowerCase() and return default behavior to Tag selection widget
