### PR TITLE
NXP-26168 Swagger Specification: convertAdapter.ftl

### DIFF
--- a/nuxeo-features/rest-api/nuxeo-rest-api-server/src/main/resources/skin/views/doc/convertAdapter.ftl
+++ b/nuxeo-features/rest-api/nuxeo-rest-api-server/src/main/resources/skin/views/doc/convertAdapter.ftl
@@ -26,7 +26,7 @@
         "method":"GET",
         "nickname":"convertDocumentBlobByPath",
         "type":"documents",
-        <@params names = ["docpath", "convertName", "convertType", "convertFormat"]/>,
+        <@params names = ["docpath", "blobxpath", "convertName", "convertType", "convertFormat"]/>,
         "summary":"Convert the Blob at the given xpath of the document",
         "notes": "One of the 'name', 'type' or 'format' parameters must be passed.",
         <#include "views/doc/errorresponses.ftl"/>
@@ -51,14 +51,14 @@
   },
 
   {
-    "path": "/path/{docId}/@blob/{blobXpath}/@convert",
+    "path": "/id/{docId}/@blob/{blobXpath}/@convert",
     "description": "Convert the Blob at the given xpath of the document",
     "operations" : [
       {
         "method":"GET",
         "nickname":"convertDocumentBlobById",
         "type":"documents",
-        <@params names = ["docid", "convertName", "convertType", "convertFormat"]/>,
+        <@params names = ["docid", "blobxpath", "convertName", "convertType", "convertFormat"]/>,
         "summary":"Convert the Blob at the given xpath of the document",
         "notes": "One of the 'name', 'type' or 'format' parameters must be passed.",
         <#include "views/doc/errorresponses.ftl"/>

--- a/nuxeo-features/rest-api/nuxeo-rest-api-server/src/main/resources/skin/views/doc/paramtypes/blobxpath.ftl
+++ b/nuxeo-features/rest-api/nuxeo-rest-api-server/src/main/resources/skin/views/doc/paramtypes/blobxpath.ftl
@@ -1,0 +1,7 @@
+{
+  "paramType": "path",
+  "name": "blobXpath",
+  "description": "XPath of the blob",
+  "dataType": "string",
+  "required": true
+}


### PR DESCRIPTION
Swagger Specification: convertAdapter.ftl definition contains multiple errors

The convertAdapter.ftl specification contains missing references and a duplicate entry.

'blobXPath' parameter is not defined (lines: 22, 54)
Line 54 path should begin with '/id/' instead of '/path/'. Entry is duplicate of line 6.

Parameter and file names follow the convention for the doc & paramtypes directories.