### PR TITLE
NXP-26167: Swagger Specification: errorResponses does not conform to specification

### DIFF
--- a/nuxeo-features/rest-api/nuxeo-rest-api-server/src/main/resources/skin/views/doc/errorresponses.ftl
+++ b/nuxeo-features/rest-api/nuxeo-rest-api-server/src/main/resources/skin/views/doc/errorresponses.ftl
@@ -1,10 +1,10 @@
-"errorResponses": [
+"responseMessages": [
     {
-        "reason": "Not Authorized to get document",
+        "message": "Not Authorized to get document",
         "code": 401
     },
     {
-        "reason": "Document not found",
+        "message": "Document not found",
         "code": 404
     }
 ]


### PR DESCRIPTION
errorresponses.ftl does not conform to the Swagger specification (https://github.com/OAI/OpenAPI-Specification/blob/master/versions/1.2.md#525-response-message-object).  Apply changes to conform to spec.