### PR TITLE
NXP-26166: invalid parameter reference in path

### DIFF
--- a/nuxeo-features/rest-api/nuxeo-rest-api-server/src/main/resources/skin/views/doc/oauth2.ftl
+++ b/nuxeo-features/rest-api/nuxeo-rest-api-server/src/main/resources/skin/views/doc/oauth2.ftl
@@ -91,7 +91,7 @@
   },
 
   {
-    "path": "/oauth2/token/provider/{oauth2ProviderId}/user/{username}",
+    "path": "/oauth2/token/provider/{oauth2ProviderId}/user/{userName}",
     "description": "Gets, updates and deletes OAuth2 provider tokens.",
     "operations" : [
       {
@@ -135,7 +135,7 @@
   },
 
   {
-    "path": "/oauth2/token/client/{oauth2ClientId}/user/{username}",
+    "path": "/oauth2/token/client/{oauth2ClientId}/user/{userName}",
     "description": "Retrieves updates, and deletes OAuth2 client tokens.",
     "operations" : [
       {


### PR DESCRIPTION
The definition in 'paramtypes/username.ftl' defines 'userName'. 'oauth2.ftl' path references are broken, they should be changed from 'username' to 'userName'. Other endpoints use this paramtype - oauth2.ftl is the only template that incorrectly uses this parameter.