### PR TITLE
NXP-24952: no need to post a Jira comment

### DIFF
--- a/integration/Jenkinsfiles/sonar.groovy
+++ b/integration/Jenkinsfiles/sonar.groovy
@@ -83,9 +83,6 @@ Build: $RUN_DISPLAY_URL"""
                                     """
                                 }
                             }
-                            if (BRANCH_NAME == 'master') {
-                                step([$class: 'JiraIssueUpdater', issueSelector: [$class: 'DefaultIssueSelector'], scm: scm])
-                            }
                         } finally {
                             archiveArtifacts '**/target/failsafe-reports/*, **/target/*.png, **/target/**/*.log, **/target/**/log/*'
                             junit testDataPublishers: [[$class: 'ClaimTestDataPublisher']], testResults: '**/target/surefire-reports/*.xml, **/target/failsafe-reports/**/*.xml'


### PR DESCRIPTION
Remove the JiraIssueUpdater that creates redundant comments with https://qa.nuxeo.org/jenkins/job/master/job/nuxeo-master/

See https://jira.nuxeo.com/browse/NXP-27209?focusedCommentId=390106&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-390106