### PR TITLE
NXP-27536: Relax dublincore secured properties

### DIFF
--- a/nuxeo-core/nuxeo-core/src/main/resources/OSGI-INF/CoreExtensions.xml
+++ b/nuxeo-core/nuxeo-core/src/main/resources/OSGI-INF/CoreExtensions.xml
@@ -31,11 +31,11 @@
     <schema name="collectionMember" src="schema/collectionMember.xsd"
       prefix="collectionMember" isVersionWritable="true"/>
 
-    <property schema="dublincore" name="created" secured="true" />
-    <property schema="dublincore" name="modified" secured="true" />
-    <property schema="dublincore" name="creator" secured="true" />
-    <property schema="dublincore" name="contributors" secured="true" />
-    <property schema="dublincore" name="lastContributor" secured="true" />
+    <property schema="dublincore" name="created" secured="false" />
+    <property schema="dublincore" name="modified" secured="false" />
+    <property schema="dublincore" name="creator" secured="false" />
+    <property schema="dublincore" name="contributors" secured="false" />
+    <property schema="dublincore" name="lastContributor" secured="false" />
   </extension>
 
   <extension target="org.nuxeo.ecm.core.schema.TypeService"


### PR DESCRIPTION
For backward compatibility purpose, disable the dublincore secured properties configured by https://github.com/nuxeo/nuxeo/pull/3135.