### PR TITLE
NXP-27273-file-mime-type-is-not-set-when-using-the-import-mode

### DIFF
--- a/nuxeo-services/nuxeo-platform-filemanager-core-listener/src/main/resources/OSGI-INF/filemanager-iconupdater-event-contrib.xml
+++ b/nuxeo-services/nuxeo-platform-filemanager-core-listener/src/main/resources/OSGI-INF/filemanager-iconupdater-event-contrib.xml
@@ -4,8 +4,9 @@
   <extension target="org.nuxeo.ecm.core.event.EventServiceComponent" point="listener">
     <documentation>
       Computes the mimetype of dirty blob fields and updates the document icon if necessary.
-     </documentation>
-    <listener name="mimetypeIconUpdater" async="false" postCommit="false" class="org.nuxeo.ecm.platform.filemanager.core.listener.MimetypeIconUpdater" priority="120">
+    </documentation>
+    <listener name="mimetypeIconUpdater" async="false" postCommit="false"
+              class="org.nuxeo.ecm.platform.filemanager.core.listener.MimetypeIconUpdater" priority="120">
       <event>aboutToCreate</event>
       <event>beforeDocumentModification</event>
     </listener>

--- a/nuxeo-services/nuxeo-platform-filemanager-core-listener/src/main/resources/OSGI-INF/filemanager-iconupdater-event-contrib.xml
+++ b/nuxeo-services/nuxeo-platform-filemanager-core-listener/src/main/resources/OSGI-INF/filemanager-iconupdater-event-contrib.xml
@@ -9,6 +9,7 @@
               class="org.nuxeo.ecm.platform.filemanager.core.listener.MimetypeIconUpdater" priority="120">
       <event>aboutToCreate</event>
       <event>beforeDocumentModification</event>
+      <event>aboutToImport</event>
     </listener>
   </extension>
 

--- a/nuxeo-services/nuxeo-platform-filemanager-core-listener/src/test/java/org/nuxeo/ecm/platform/filemanager/core/listener/tests/TestMimetypeIconUpdater.java
+++ b/nuxeo-services/nuxeo-platform-filemanager-core-listener/src/test/java/org/nuxeo/ecm/platform/filemanager/core/listener/tests/TestMimetypeIconUpdater.java
@@ -138,7 +138,7 @@ public class TestMimetypeIconUpdater {
     }
 
     /**
-     * Ensure that the document blob mime type is normalized if possible, even if the current blob have a mime type.
+     * Ensures that the document blob mime type is normalized if possible, even if the current blob have a mime type.
      * 
      * @since 11.1
      */
@@ -160,7 +160,7 @@ public class TestMimetypeIconUpdater {
     }
 
     /**
-     * Ensure that if we are not able to normalize the document blob mime type (i.e mime type is unknown in Nuxeo), we should keep
+     * Ensures that if we are not able to normalize the document blob mime type (i.e mime type is unknown in Nuxeo), we should keep
      * the original one.
      *
      * @since 11.1


### PR DESCRIPTION
PR created from https://qa.nuxeo.org/jenkins/job/TestAndPush/job/ondemand-testandpush-saouana/77/