### PR TITLE
fix-NXP-25549-Picture.Resize-does-not-work-with-Document-as-input-10.10

### DIFF
--- a/nuxeo-features/nuxeo-platform-imaging/nuxeo-platform-imaging-core/src/main/java/org/nuxeo/ecm/platform/picture/operation/PictureResize.java
+++ b/nuxeo-features/nuxeo-platform-imaging/nuxeo-platform-imaging-core/src/main/java/org/nuxeo/ecm/platform/picture/operation/PictureResize.java
@@ -33,6 +33,7 @@ import org.nuxeo.ecm.core.api.DocumentModel;
 import org.nuxeo.ecm.core.api.blobholder.BlobHolder;
 import org.nuxeo.ecm.core.api.blobholder.SimpleBlobHolder;
 import org.nuxeo.ecm.core.convert.api.ConversionService;
+import org.nuxeo.ecm.platform.picture.api.PictureView;
 import org.nuxeo.ecm.platform.picture.api.adapters.MultiviewPicture;
 
 /**
@@ -66,8 +67,14 @@ public class PictureResize {
         Blob pictureBlob = null;
         MultiviewPicture mvp = doc.getAdapter(MultiviewPicture.class);
         if (mvp != null) {
-            pictureBlob = mvp.getView(mvp.getOrigin()).getBlob();
-        } else {
+            // picture:origin is not always set.
+            PictureView pv = mvp.getView(mvp.getOrigin());
+            if (pv != null) {
+                pictureBlob = pv.getBlob();
+            }
+        }
+        
+        if (pictureBlob == null) {
             BlobHolder bh = doc.getAdapter(BlobHolder.class);
             if (bh != null) {
                 pictureBlob = bh.getBlob();

--- a/nuxeo-features/nuxeo-platform-imaging/nuxeo-platform-imaging-core/src/test/java/org/nuxeo/ecm/platform/picture/core/test/TestPictureResize.java
+++ b/nuxeo-features/nuxeo-platform-imaging/nuxeo-platform-imaging-core/src/test/java/org/nuxeo/ecm/platform/picture/core/test/TestPictureResize.java
@@ -19,6 +19,7 @@
 package org.nuxeo.ecm.platform.picture.core.test;
 
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assume.assumeFalse;
 
 import java.io.Serializable;
 import java.util.HashMap;
@@ -26,6 +27,7 @@ import java.util.Map;
 
 import javax.inject.Inject;
 
+import org.apache.commons.lang3.SystemUtils;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.nuxeo.common.utils.FileUtils;

--- a/nuxeo-features/nuxeo-platform-imaging/nuxeo-platform-imaging-core/src/test/java/org/nuxeo/ecm/platform/picture/core/test/TestPictureResize.java
+++ b/nuxeo-features/nuxeo-platform-imaging/nuxeo-platform-imaging-core/src/test/java/org/nuxeo/ecm/platform/picture/core/test/TestPictureResize.java
@@ -20,6 +20,7 @@ package org.nuxeo.ecm.platform.picture.core.test;
 
 import static org.junit.Assert.assertNotNull;
 
+import java.io.Serializable;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -36,10 +37,13 @@ import org.nuxeo.ecm.automation.test.AutomationFeature;
 import org.nuxeo.ecm.core.api.Blob;
 import org.nuxeo.ecm.core.api.Blobs;
 import org.nuxeo.ecm.core.api.CoreSession;
+import org.nuxeo.ecm.core.api.DocumentModel;
+import org.nuxeo.ecm.core.event.EventService;
 import org.nuxeo.ecm.platform.picture.operation.PictureResize;
 import org.nuxeo.runtime.test.runner.Deploy;
 import org.nuxeo.runtime.test.runner.Features;
 import org.nuxeo.runtime.test.runner.FeaturesRunner;
+import org.nuxeo.runtime.transaction.TransactionHelper;
 
 @RunWith(FeaturesRunner.class)
 @Features(AutomationFeature.class)
@@ -47,10 +51,15 @@ import org.nuxeo.runtime.test.runner.FeaturesRunner;
 @Deploy("org.nuxeo.ecm.platform.picture.convert")
 @Deploy("org.nuxeo.ecm.platform.picture.core")
 @Deploy("org.nuxeo.ecm.platform.commandline.executor")
+@Deploy("org.nuxeo.ecm.platform.tag")
+@Deploy("org.nuxeo.ecm.platform.rendition.core")
 public class TestPictureResize {
 
     @Inject
     AutomationService service;
+
+    @Inject
+    protected EventService eventService;
 
     @Inject
     CoreSession session;
@@ -67,6 +76,38 @@ public class TestPictureResize {
         params.put("maxWidth", 150);
         params.put("maxHeight", 300);
         OperationChain chain = new OperationChain("fakeChain");
+        OperationParameters oparams = new OperationParameters(PictureResize.ID, params);
+        chain.add(oparams);
+
+        Blob result = (Blob) service.run(ctx, chain);
+
+        assertNotNull(result);
+    }
+
+    @Test
+    public void testResizerForDoc() throws Exception{
+        // TODO: NXP-27622
+        assumeFalse(SystemUtils.IS_OS_MAC);
+
+        DocumentModel pictureDoc = session.createDocumentModel("/", "testpicture", "Picture");
+        Blob source = Blobs.createBlob(FileUtils.getResourceFileFromContext("images/test.jpg"), "image/jpeg");
+        pictureDoc.setPropertyValue("file:content", (Serializable) source);
+        pictureDoc = session.createDocument(pictureDoc);
+
+        session.save();
+        TransactionHelper.commitOrRollbackTransaction();
+        TransactionHelper.startTransaction();
+
+        eventService.waitForAsyncCompletion();
+
+        OperationContext ctx = new OperationContext(session);
+
+        ctx.setInput(pictureDoc);
+
+        Map<String, Object> params = new HashMap<>();
+        params.put("maxWidth", 150);
+        params.put("maxHeight", 300);
+        OperationChain chain = new OperationChain("fakeChain2");
         OperationParameters oparams = new OperationParameters(PictureResize.ID, params);
         chain.add(oparams);
 


### PR DESCRIPTION
PR created from https://qa2.nuxeo.org/jenkins/job/TestAndPush/job/ondemand-testandpush-atchertchian-10.10/9/