### PR TITLE
NXP-27887: Add Kafka 2.2.1 and 2.3.0 docker compose for CI

### DIFF
--- a/integration/Jenkinsfiles/docker-compose-kafka-2.2.1.yml
+++ b/integration/Jenkinsfiles/docker-compose-kafka-2.2.1.yml
@@ -1,0 +1,28 @@
+version: '2'
+services:
+  zookeeper:
+    image: zookeeper:3.4.14
+
+  kafka:
+    image: wurstmeister/kafka:2.12-2.2.1
+    environment:
+      KAFKA_ADVERTISED_HOST_NAME: kafka
+      KAFKA_ADVERTISED_PORT: 9092
+      KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
+      KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: 10
+      KAFKA_OFFSETS_RETENTION_MINUTES: 20160
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+
+  tests:
+    build:
+       context: jenkins-slave-kafka
+       dockerfile: Dockerfile
+    volumes:
+      - $WORKSPACE:$WORKSPACE
+      - /var/run/docker.sock:/var/run/docker.sock:rw
+    environment:
+      KAFKA_ADVERTISED_HOST_NAME: kafka
+      KAFKA_ADVERTISED_PORT: 9092
+      KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
+    command: /sbin/my_init -- su - jenkins -c "$TESTS_COMMAND"

--- a/integration/Jenkinsfiles/docker-compose-kafka-2.3.0.yml
+++ b/integration/Jenkinsfiles/docker-compose-kafka-2.3.0.yml
@@ -1,0 +1,28 @@
+version: '2'
+services:
+  zookeeper:
+    image: zookeeper:3.5.5
+
+  kafka:
+    image: wurstmeister/kafka:2.12-2.3.0
+    environment:
+      KAFKA_ADVERTISED_HOST_NAME: kafka
+      KAFKA_ADVERTISED_PORT: 9092
+      KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
+      KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: 10
+      KAFKA_OFFSETS_RETENTION_MINUTES: 20160
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+
+  tests:
+    build:
+       context: jenkins-slave-kafka
+       dockerfile: Dockerfile
+    volumes:
+      - $WORKSPACE:$WORKSPACE
+      - /var/run/docker.sock:/var/run/docker.sock:rw
+    environment:
+      KAFKA_ADVERTISED_HOST_NAME: kafka
+      KAFKA_ADVERTISED_PORT: 9092
+      KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
+    command: /sbin/my_init -- su - jenkins -c "$TESTS_COMMAND"

--- a/integration/Jenkinsfiles/utest.groovy
+++ b/integration/Jenkinsfiles/utest.groovy
@@ -19,7 +19,7 @@
 
 currentBuild.setDescription("Branch: $BRANCH -> $PARENT_BRANCH, DB: $DBPROFILE, VERSION: $DBVERSION")
 
-node('SLAVE') {
+node('IT1010&&STATIC') { // Must be a static slave to share the workspace in docker compose
     tool name: 'ant-1.9', type: 'ant'
     tool name: 'java-8-openjdk', type: 'hudson.model.JDK'
     tool name: 'maven-3', type: 'hudson.tasks.Maven$MavenInstallation'


### PR DESCRIPTION
Theses docker-compose files are only used by a specific CI Job, t&p is useless.