### PR TITLE
10.10-HF/fix-NXP-27836-quartz-mongodb-ssl

### DIFF
--- a/nuxeo-distribution/nuxeo-nxr-server/src/main/resources/templates/mongodb/nxserver/config/quartz.properties.nxftl
+++ b/nuxeo-distribution/nuxeo-nxr-server/src/main/resources/templates/mongodb/nxserver/config/quartz.properties.nxftl
@@ -27,4 +27,12 @@ org.quartz.jobStore.dbName=${nuxeo.mongodb.dbname}
 org.quartz.jobStore.collectionPrefix=quartz
 org.quartz.jobStore.jobDataAsBase64=false
 
+org.quartz.jobStore.mongoOptionEnableSSL=${nuxeo.mongodb.ssl}
+org.quartz.jobStore.mongoOptionTrustStorePath=${nuxeo.mongodb.truststore.path}
+org.quartz.jobStore.mongoOptionTrustStorePassword=${nuxeo.mongodb.truststore.password}
+org.quartz.jobStore.mongoOptionTrustStoreType=${nuxeo.mongodb.truststore.type}
+org.quartz.jobStore.mongoOptionKeyStorePath=${nuxeo.mongodb.keystore.path}
+org.quartz.jobStore.mongoOptionKeyStorePassword=${nuxeo.mongodb.keystore.password}
+org.quartz.jobStore.mongoOptionKeyStoreType=${nuxeo.mongodb.keystore.type}
+
 org.quartz.scheduler.mongoOptionWriteConcernTimeoutMillis=5000

--- a/owasp-dependency-suppression.xml
+++ b/owasp-dependency-suppression.xml
@@ -244,7 +244,7 @@
 </suppress>
 <suppress>
    <notes><![CDATA[
-   file name: quartz-mongodb-2.0.0-NX2.jar (MongoDB not included in Nuxeo)
+   file name: quartz-mongodb-2.0.0-NX3.jar (MongoDB not included in Nuxeo)
    ]]></notes>
    <gav regex="true">^com\.novemberain:quartz-mongodb:.*$</gav>
    <cpe>cpe:/a:mongodb:mongodb</cpe>

--- a/pom.xml
+++ b/pom.xml
@@ -227,7 +227,7 @@
 
     <!-- MongoDB -->
     <mongo.java.driver.version>3.8.1</mongo.java.driver.version>
-    <quartz.mongodb.version>2.0.0-NX2</quartz.mongodb.version>
+    <quartz.mongodb.version>2.0.0-NX3</quartz.mongodb.version>
 
     <kafka.version>2.1.0</kafka.version>
     <confluent.version>5.0.0</confluent.version>

--- a/scripts/licenses-unknown.txt
+++ b/scripts/licenses-unknown.txt
@@ -54,7 +54,7 @@
      (AL 2.0) standard (taglibs:standard:1.1.2 - no url defined)
      (AL 2.0) chronicle-queue (net.openhft:chronicle-queue:4.6.44 - no url defined)
      (AL 2.0) zookeeper (org.apache.zookeeper:zookeeper:3.4.8 - no url defined)
-     (AL 2.0) quartz-mongodb (com.novemberain:quartz-mongodb:2.0.0-NX2 - https://github.com/michaelklishin/quartz-mongodb)
+     (AL 2.0) quartz-mongodb (com.novemberain:quartz-mongodb:2.0.0-NX3 - https://github.com/michaelklishin/quartz-mongodb)
      (AL 2.0) metrics-statsd-common (com.readytalk:metrics-statsd-common:4.2.0 - https://github.com/ReadyTalk/metrics-statsd)
      (AL 2.0) metrics3-statsd (com.readytalk:metrics3-statsd:4.2.0 - https://github.com/ReadyTalk/metrics-statsd)
      (AL 2.0) kafka-avro-serializer (io.confluent:kafka-avro-serializer:5.0.0 - https://github.com/confluentinc/schema-registry)


### PR DESCRIPTION
By upgrading quartz-mongodb to patched version 2.1.0-NX1 including SSL support, see https://github.com/nuxeo/quartz-mongodb/pull/1.

Waiting for customer feedback to run a T&P.