### PR TITLE
NXP-28444: Flush cookies to prevent stickiness of LB

### DIFF
--- a/nuxeo-distribution/nuxeo-server-gatling-tests/src/test/scala/org/nuxeo/cap/bench/Sim25BulkUpdateFolders.scala
+++ b/nuxeo-distribution/nuxeo-server-gatling-tests/src/test/scala/org/nuxeo/cap/bench/Sim25BulkUpdateFolders.scala
@@ -35,6 +35,7 @@ object ScnBulkUpdateFolders {
           .exec(NuxeoBulk.bulkUpdateDocument("SELECT * FROM Document WHERE ecm:path = '" + Constants.GAT_WS_PATH + "/${parentPath}'", "dc:description", "bulk folder")
           .check(jsonPath("$.commandId").saveAs("commandId")))
           .exec(NuxeoBulk.waitForAction("${commandId}"))
+          .exec(flushCookieJar)
           .pause(pause)
       }
     )


### PR DESCRIPTION
Update a Gatling simulation, tested on the CI benchmark Job.