### PR TITLE
10.10-HF/fix-NXP-28274-Don-t-assume-picture-dimensions-prior-to-conversion

### DIFF
--- a/nuxeo-features/nuxeo-platform-imaging/nuxeo-platform-imaging-core/src/main/java/org/nuxeo/ecm/platform/picture/ImagingComponent.java
+++ b/nuxeo-features/nuxeo-platform-imaging/nuxeo-platform-imaging-core/src/main/java/org/nuxeo/ecm/platform/picture/ImagingComponent.java
@@ -398,9 +398,6 @@ public class ImagingComponent extends DefaultComponent implements ImagingService
             size = ImageResizer.scaleToMax(size.x, size.y, pictureConversion.getMaxSize());
         }
 
-        pictureViewMap.put(PictureView.FIELD_WIDTH, size.x);
-        pictureViewMap.put(PictureView.FIELD_HEIGHT, size.y);
-
         // Use the registered conversion format
         String conversionFormat = getConfigurationValue(CONVERSION_FORMAT, JPEG_CONVERSATION_FORMAT);
 
@@ -419,10 +416,14 @@ public class ImagingComponent extends DefaultComponent implements ImagingService
         String viewFilename = String.format("%s_%s.%s", title, FilenameUtils.getBaseName(blob.getFilename()),
                 extension);
         viewBlob.setFilename(viewFilename);
+        ImageInfo viewBlobImageInfo = getImageInfo(viewBlob);
         pictureViewMap.put(PictureView.FIELD_FILENAME, viewFilename);
         pictureViewMap.put(PictureView.FIELD_CONTENT, (Serializable) viewBlob);
-        pictureViewMap.put(PictureView.FIELD_INFO, getImageInfo(viewBlob));
-
+        pictureViewMap.put(PictureView.FIELD_INFO, viewBlobImageInfo);
+        if (viewBlobImageInfo != null) {
+            pictureViewMap.put(PictureView.FIELD_WIDTH, viewBlobImageInfo.getWidth());
+            pictureViewMap.put(PictureView.FIELD_HEIGHT, viewBlobImageInfo.getHeight());
+        }
         return new PictureViewImpl(pictureViewMap);
     }
 

--- a/nuxeo-features/nuxeo-platform-imaging/nuxeo-platform-imaging-core/src/test/java/org/nuxeo/ecm/platform/picture/core/test/TestImagingAdapter.java
+++ b/nuxeo-features/nuxeo-platform-imaging/nuxeo-platform-imaging-core/src/test/java/org/nuxeo/ecm/platform/picture/core/test/TestImagingAdapter.java
@@ -187,5 +187,14 @@ public class TestImagingAdapter {
         assertNotEquals(0, info.getDepth());
         assertNotNull(info.getColorSpace());
         assertNotNull(info.getFormat());
+
+        // check size info
+        view = mvp.getView("Medium");
+        ImageInfo imageBlobInfo = imagingService.getImageInfo(view.getBlob());
+        info = view.getImageInfo();
+        assertEquals(imageBlobInfo.getWidth(), info.getWidth());
+        assertEquals(imageBlobInfo.getWidth(), view.getWidth());
+        assertEquals(imageBlobInfo.getHeight(), info.getHeight());
+        assertEquals(imageBlobInfo.getHeight(), view.getHeight());
     }
 }


### PR DESCRIPTION
PR created from https://qa2.nuxeo.org/jenkins/job/TestAndPush/job/ondemand-testandpush-tcasanova-10.10/14/