### PR TITLE
NXP-28689: skip maven-enforcer-plugin by default

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -135,6 +135,8 @@
     <scala-maven-plugin.version>3.3.2</scala-maven-plugin.version>
     <jgiven.version>0.18.2</jgiven.version>
 
+    <nuxeo.skip.enforcer>true</nuxeo.skip.enforcer>
+
     <!-- Tests properties -->
     <!-- for use integration/vcstests.xml and org.nuxeo:nuxeo-ftest -->
     <!-- (related profiles: customdb, default, pgsql, oracle10g, oracle11g, oracle12c, oracle18c, mysql, mongodb) -->
@@ -5027,12 +5029,14 @@
               <goal>enforce</goal>
             </goals>
             <configuration>
+              <skip>${nuxeo.skip.enforcer}</skip>
               <rules>
                 <requireReleaseDeps>
                   <message>No Snapshots Allowed!</message>
                   <onlyWhenRelease>false</onlyWhenRelease>
                   <failWhenParentIsSnapshot>false</failWhenParentIsSnapshot>
                   <excludes>
+                    <exclude>com.nuxeo*</exclude>
                     <exclude>org.nuxeo*</exclude>
                   </excludes>
                 </requireReleaseDeps>
@@ -5045,6 +5049,7 @@
               <goal>enforce</goal>
             </goals>
             <configuration>
+              <skip>${nuxeo.skip.enforcer}</skip>
               <rules>
                 <requireReleaseDeps>
                   <message>No Snapshots Allowed!</message>
@@ -6216,6 +6221,9 @@
           <value>true</value>
         </property>
       </activation>
+      <properties>
+        <nuxeo.skip.enforcer>false</nuxeo.skip.enforcer>
+      </properties>
       <build>
         <pluginManagement>
           <plugins>


### PR DESCRIPTION
Enabled with release profile or by setting the
property "nuxeo.skip.enforcer" to true