### PR TITLE
10.10-HF/fix-NXP-28719-Fix-Comment-Migration-failure-due-to-versions

### DIFF
--- a/nuxeo-features/nuxeo-platform-comment/nuxeo-platform-comment-api/src/main/java/org/nuxeo/ecm/platform/comment/api/CommentManager.java
+++ b/nuxeo-features/nuxeo-platform-comment/nuxeo-platform-comment-api/src/main/java/org/nuxeo/ecm/platform/comment/api/CommentManager.java
@@ -350,17 +350,4 @@ public interface CommentManager {
      */
      DocumentRef getTopLevelDocumentRef(CoreSession session, DocumentRef commentRef);
 
-    /**
-     * Returns the comments location in repository for the given commented document model.
-     *
-     * @param session the session needs to be privileged
-     * @return the comments location in repository for the given commented document model.
-     * @apiNote This is dedicated to an internal usage (comment service/migration)
-     * @since 11.1
-     */
-    default String getLocationOfCommentCreation(CoreSession session, DocumentModel commentedDocModel) {
-        throw new UnsupportedOperationException();
-    }
-
-
 }

--- a/nuxeo-features/nuxeo-platform-comment/nuxeo-platform-comment/src/main/java/org/nuxeo/ecm/platform/comment/impl/BridgeCommentManager.java
+++ b/nuxeo-features/nuxeo-platform-comment/nuxeo-platform-comment/src/main/java/org/nuxeo/ecm/platform/comment/impl/BridgeCommentManager.java
@@ -224,11 +224,6 @@ public class BridgeCommentManager extends AbstractCommentManager {
         throw new UnsupportedOperationException();
     }
 
-    @Override
-    public String getLocationOfCommentCreation(CoreSession session, DocumentModel documentModel) {
-        return second.getLocationOfCommentCreation(session, documentModel);
-    }
-
     /**
      * Executes the given function for a comment document ref, depending on the type of the provided comment manager {@link #first},
      * {@link #second}.

--- a/nuxeo-features/nuxeo-platform-comment/nuxeo-platform-comment/src/main/java/org/nuxeo/ecm/platform/comment/impl/CommentsMigrator.java
+++ b/nuxeo-features/nuxeo-platform-comment/nuxeo-platform-comment/src/main/java/org/nuxeo/ecm/platform/comment/impl/CommentsMigrator.java
@@ -272,8 +272,11 @@ public class CommentsMigrator extends AbstractRepositoryMigrator {
 
         // Strip ACLs
         ACP acp = session.getACP(commentIdRef);
-        acp.removeACL(LOCAL_ACL);
-        session.setACP(commentIdRef, acp, true);
+        // Case where a comment is on a placeless document which has no acp
+        if (acp != null) {
+            acp.removeACL(LOCAL_ACL);
+            session.setACP(commentIdRef, acp, true);
+        }
 
         session.saveDocument(commentDoc);
         session.save();

--- a/nuxeo-features/nuxeo-platform-comment/nuxeo-platform-comment/src/main/java/org/nuxeo/ecm/platform/comment/impl/CommentsMigrator.java
+++ b/nuxeo-features/nuxeo-platform-comment/nuxeo-platform-comment/src/main/java/org/nuxeo/ecm/platform/comment/impl/CommentsMigrator.java
@@ -52,11 +52,9 @@ import org.nuxeo.ecm.core.api.DocumentModel;
 import org.nuxeo.ecm.core.api.DocumentRef;
 import org.nuxeo.ecm.core.api.IdRef;
 import org.nuxeo.ecm.core.api.NuxeoException;
-import org.nuxeo.ecm.core.api.PathRef;
 import org.nuxeo.ecm.core.api.security.ACP;
 import org.nuxeo.ecm.core.migrator.AbstractRepositoryMigrator;
 import org.nuxeo.ecm.core.repository.RepositoryService;
-import org.nuxeo.ecm.platform.comment.api.CommentManager;
 import org.nuxeo.ecm.platform.comment.service.CommentService;
 import org.nuxeo.ecm.platform.comment.service.CommentServiceConfig;
 import org.nuxeo.ecm.platform.comment.service.CommentServiceHelper;
@@ -201,9 +199,9 @@ public class CommentsMigrator extends AbstractRepositoryMigrator {
         // For migration purpose and to avoid any duplication, we should rely mainly on `TreeCommentManager`
         // For 10.10 (backward compatibility) Framework.getService(CommentManager.class) will return
         // `PropertyCommentManager` the new location should be computed by the `TreeCommentManager`
-        CommentManager commentManager = new TreeCommentManager();
+        TreeCommentManager treeCommentManager = new TreeCommentManager();
         processBatched(migrationContext, BATCH_SIZE, comments,
-                comment -> migrateCommentsFromPropertyToSecured(session, commentManager, new IdRef(comment)),
+                comment -> migrateCommentsFromPropertyToSecured(session, treeCommentManager, new IdRef(comment)),
                 "Migrating comments from Property to Secured");
 
         // All comments were migrated, now we can delete the empty folders
@@ -242,7 +240,7 @@ public class CommentsMigrator extends AbstractRepositoryMigrator {
     /**
      * @since 11.1
      */
-    protected void migrateCommentsFromPropertyToSecured(CoreSession session, CommentManager commentManager,
+    protected void migrateCommentsFromPropertyToSecured(CoreSession session, TreeCommentManager treeCommentManager,
             IdRef commentIdRef) {
         DocumentModel commentDoc = session.getDocument(commentIdRef);
         String parentId = (String) commentDoc.getPropertyValue(COMMENT_PARENT_ID);
@@ -263,7 +261,7 @@ public class CommentsMigrator extends AbstractRepositoryMigrator {
 
         DocumentModel parentDoc = session.getDocument(parentDocRef);
 
-        DocumentRef destination = new PathRef(commentManager.getLocationOfCommentCreation(session, parentDoc));
+        DocumentRef destination = treeCommentManager.getLocationRefOfCommentCreation(session, parentDoc);
 
         // Move the commentIdRef under the new destination (under the `Comments` folder in the case of the first comment
         // or under the comment itself in the case of reply)

--- a/nuxeo-features/nuxeo-platform-comment/nuxeo-platform-comment/src/main/java/org/nuxeo/ecm/platform/comment/impl/TreeCommentManager.java
+++ b/nuxeo-features/nuxeo-platform-comment/nuxeo-platform-comment/src/main/java/org/nuxeo/ecm/platform/comment/impl/TreeCommentManager.java
@@ -155,9 +155,9 @@ public class TreeCommentManager extends AbstractCommentManager {
         return CoreInstance.doPrivileged(session, s -> {
             DocumentModel commentedDoc = s.getDocument(parentRef);
             // Get the location where comment will be stored
-            String path = getLocationOfCommentCreation(s, commentedDoc);
+            DocumentRef locationDocRef = getLocationRefOfCommentCreation(s, commentedDoc);
 
-            DocumentModel commentDoc = s.createDocumentModel(path, COMMENT_NAME, comment.getDocument().getType());
+            DocumentModel commentDoc = s.newDocumentModel(locationDocRef, COMMENT_NAME, comment.getDocument().getType());
             if (comment.getDocument().hasFacet(EXTERNAL_ENTITY_FACET)) {
                 commentDoc.addFacet(EXTERNAL_ENTITY_FACET);
             }
@@ -181,9 +181,9 @@ public class TreeCommentManager extends AbstractCommentManager {
 
         return CoreInstance.doPrivileged(commentDoc.getCoreSession(), session -> {
             // Get the location to store the comment
-            String path = getLocationOfCommentCreation(session, commentedDoc);
+            DocumentRef locationDocRef = getLocationRefOfCommentCreation(session, commentedDoc);
 
-            DocumentModel commentModelToCreate = session.createDocumentModel(path, COMMENT_NAME, commentDoc.getType());
+            DocumentModel commentModelToCreate = session.newDocumentModel(locationDocRef, COMMENT_NAME, commentDoc.getType());
             commentModelToCreate.copyContent(commentDoc);
 
             // Should compute ancestors and set comment:parentId for backward compatibility
@@ -274,21 +274,26 @@ public class TreeCommentManager extends AbstractCommentManager {
         throw new UnsupportedOperationException(SERVICE_WITHOUT_IMPLEMENTATION_MESSAGE);
     }
 
-    @Override
-    public String getLocationOfCommentCreation(CoreSession session, DocumentModel commentedDoc) {
+    /**
+     * Returns the {@link DocumentRef} of the comments location in repository for the given commented document model.
+     *
+     * @param session the session needs to be privileged
+     * @return the document model container of the comments of the given {@code commentedDoc}
+     * @since 10.10-HF23
+     */
+    protected DocumentRef getLocationRefOfCommentCreation(CoreSession session, DocumentModel commentedDoc) {
         if (commentedDoc.hasSchema(COMMENT_SCHEMA)) {
             // reply case, store the reply under the comment
-            return commentedDoc.getPathAsString();
-        } else {
-            // regular document case, store the comment under a CommentRoot folder under the regular document
-            DocumentModel commentsFolder = session.createDocumentModel(commentedDoc.getPathAsString(),
-                    COMMENTS_DIRECTORY_NAME, COMMENTS_DIRECTORY_TYPE);
-            // no need to notify the creation of the Comments folder
-            commentsFolder.putContextData(DISABLE_NOTIFICATION_SERVICE, TRUE);
-            commentsFolder = session.getOrCreateDocument(commentsFolder);
-            session.save();
-            return commentsFolder.getPathAsString();
+            return commentedDoc.getRef();
         }
+        // regular document case, store the comment under a CommentRoot folder under the regular document
+        DocumentModel commentsFolder = session.newDocumentModel(commentedDoc.getRef(), COMMENTS_DIRECTORY_NAME,
+                COMMENTS_DIRECTORY_TYPE);
+        // no need to notify the creation of the Comments folder
+        commentsFolder.putContextData(DISABLE_NOTIFICATION_SERVICE, TRUE);
+        commentsFolder = session.getOrCreateDocument(commentsFolder);
+        session.save();
+        return commentsFolder.getRef();
     }
 
     @Override
@@ -302,11 +307,12 @@ public class TreeCommentManager extends AbstractCommentManager {
 
     @Override
     protected DocumentModel getTopLevelDocument(CoreSession session, DocumentModel commentDoc) {
-        DocumentModel documentModel = commentDoc;
-        while (documentModel.hasSchema(COMMENT_SCHEMA) || COMMENTS_DIRECTORY_TYPE.equals(documentModel.getType())) {
-            documentModel = session.getDocument(documentModel.getParentRef());
+        DocumentModel docModel = commentDoc;
+        while (docModel.getParentRef() != null
+                && (docModel.hasSchema(COMMENT_SCHEMA) || COMMENTS_DIRECTORY_TYPE.equals(docModel.getType()))) {
+            docModel = session.getDocument(docModel.getParentRef());
         }
-        return documentModel;
+        return docModel;
     }
 
     /**

--- a/nuxeo-features/nuxeo-platform-comment/nuxeo-platform-comment/src/test/java/org/nuxeo/ecm/platform/comment/AbstractTestCommentManager.java
+++ b/nuxeo-features/nuxeo-platform-comment/nuxeo-platform-comment/src/test/java/org/nuxeo/ecm/platform/comment/AbstractTestCommentManager.java
@@ -309,6 +309,34 @@ public abstract class AbstractTestCommentManager {
         assertTrue(comments.isEmpty());
     }
 
+    /*
+     * NXP-28719
+     */
+    @Test
+    public void testCreateCommentsUnderPlacelessDocument() {
+        DocumentModel anyFile = session.createDocumentModel(null, "anyFile", "File");
+        anyFile = session.createDocument(anyFile);
+        transactionalFeature.nextTransaction();
+
+        // first comment
+        String author = "toto";
+        String text = "I am a comment !";
+        Comment comment = new CommentImpl();
+        comment.setAuthor(author);
+        comment.setText(text);
+        comment.setParentId(anyFile.getId());
+
+        comment = commentManager.createComment(session, comment);
+        assertEquals(author, comment.getAuthor());
+        assertEquals(text, comment.getText());
+        DocumentModel commentDocModel = session.getDocument(new IdRef(comment.getId()));
+        assertNotNull(commentDocModel.getParentRef());
+        DocumentModel commentParent = session.getDocument(commentDocModel.getParentRef());
+        assertNotNull(commentParent.getParentRef());
+        assertTrue(commentParent.hasFacet("Folderish"));
+        assertTrue(commentParent.hasFacet("HiddenInNavigation"));
+    }
+
     @Test
     public void testCommentManagerType() {
         assertEquals(getType(), commentManager.getClass());

--- a/nuxeo-features/nuxeo-platform-comment/nuxeo-platform-comment/src/test/java/org/nuxeo/ecm/platform/comment/TestCommentManagerImpl.java
+++ b/nuxeo-features/nuxeo-platform-comment/nuxeo-platform-comment/src/test/java/org/nuxeo/ecm/platform/comment/TestCommentManagerImpl.java
@@ -21,14 +21,15 @@ package org.nuxeo.ecm.platform.comment;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
-import static org.nuxeo.ecm.platform.comment.workflow.utils.CommentsConstants.COMMENT_DOC_TYPE;
 import static org.nuxeo.ecm.core.io.marshallers.json.document.DocumentModelJsonReader.applyDirtyPropertyValues;
+import static org.nuxeo.ecm.platform.comment.workflow.utils.CommentsConstants.COMMENT_DOC_TYPE;
 
 import java.util.Calendar;
 import java.util.List;
 
 import javax.inject.Inject;
 
+import org.junit.Ignore;
 import org.junit.Test;
 import org.nuxeo.ecm.core.api.CloseableCoreSession;
 import org.nuxeo.ecm.core.api.DocumentModel;
@@ -143,6 +144,14 @@ public class TestCommentManagerImpl extends AbstractTestCommentManager {
         assertThat(session.getChildren(new PathRef(FOLDER_COMMENT_CONTAINER)).totalSize()).isEqualTo(1);
 
         assertThat(commentModel.getPathAsString()).contains(FOLDER_COMMENT_CONTAINER);
+    }
+
+    /*
+     * NXP-28719
+     */
+    @Test
+    @Ignore("Ignore this test since the comment implementation behind it is deprecated")
+    public void testCreateCommentsUnderPlacelessDocument() {
     }
 
     @Override


### PR DESCRIPTION
PR created from https://qa2.nuxeo.org/jenkins/job/TestAndPush/job/ondemand-testandpush-saouana-10.10/102/

New T&P launched after taking  into account the code review (OK): https://qa2.nuxeo.org/jenkins/job/TestAndPush/job/ondemand-testandpush-troger-10.10/48/


New T&P after rebasing on 10.10: https://qa2.nuxeo.org/jenkins/job/TestAndPush/job/ondemand-testandpush-saouana-10.10/106/