### PR TITLE
NXP-28688: Retrieve the blob size for items returned by NuxeoDrive.GetChildren

### DIFF
--- a/addons/nuxeo-drive-server/nuxeo-drive-core/src/main/java/org/nuxeo/drive/adapter/FileItem.java
+++ b/addons/nuxeo-drive-server/nuxeo-drive-core/src/main/java/org/nuxeo/drive/adapter/FileItem.java
@@ -15,6 +15,7 @@
  *
  * Contributors:
  *     Antoine Taillefer <ataillefer@nuxeo.com>
+ *     Mickaël Schoentgen <mschoentgen@nuxeo.com>
  */
 package org.nuxeo.drive.adapter;
 
@@ -43,6 +44,9 @@ public interface FileItem extends FileSystemItem {
     String getDigestAlgorithm();
 
     String getDigest();
+
+    /** @since 11.1 */
+    long getSize();
 
     boolean getCanUpdate();
 

--- a/addons/nuxeo-drive-server/nuxeo-drive-core/src/main/java/org/nuxeo/drive/adapter/impl/DocumentBackedFileItem.java
+++ b/addons/nuxeo-drive-server/nuxeo-drive-core/src/main/java/org/nuxeo/drive/adapter/impl/DocumentBackedFileItem.java
@@ -15,6 +15,7 @@
  *
  * Contributors:
  *     Antoine Taillefer <ataillefer@nuxeo.com>
+ *     Mickaël Schoentgen <mschoentgen@nuxeo.com>
  */
 package org.nuxeo.drive.adapter.impl;
 
@@ -46,6 +47,9 @@ public class DocumentBackedFileItem extends AbstractDocumentBackedFileSystemItem
     protected String digestAlgorithm;
 
     protected String digest;
+
+    /** @since 11.1 */
+    protected long size;
 
     protected boolean canUpdate;
 
@@ -194,6 +198,12 @@ public class DocumentBackedFileItem extends AbstractDocumentBackedFileSystemItem
         return canUpdate;
     }
 
+    /** @since 11.1 */
+    @Override
+    public long getSize() {
+        return size;
+    }
+
     @Override
     public void setBlob(Blob blob) {
         try (CloseableCoreSession session = CoreInstance.openCoreSession(repositoryName, principal)) {
@@ -216,6 +226,7 @@ public class DocumentBackedFileItem extends AbstractDocumentBackedFileSystemItem
             /* Update FileSystemItem attributes */
             updateLastModificationDate(doc);
             updateDigest(getBlob(doc));
+            updateSize(blob);
         }
     }
 
@@ -249,6 +260,7 @@ public class DocumentBackedFileItem extends AbstractDocumentBackedFileSystemItem
         folder = false;
         updateDownloadURL();
         updateDigest(blob);
+        updateSize(blob);
         if (digest == null) {
             digestAlgorithm = null;
         }
@@ -313,6 +325,12 @@ public class DocumentBackedFileItem extends AbstractDocumentBackedFileSystemItem
         }
     }
 
+    /** @since 11.1 */
+    protected void updateSize(Blob blob) {
+        long length = blob.getLength();
+        size = length > 0 ? length : 0;
+    }
+
     protected NuxeoDriveManager getNuxeoDriveManager() {
         return Framework.getService(NuxeoDriveManager.class);
     }
@@ -332,6 +350,11 @@ public class DocumentBackedFileItem extends AbstractDocumentBackedFileSystemItem
 
     protected void setCanUpdate(boolean canUpdate) {
         this.canUpdate = canUpdate;
+    }
+
+    /** @since 11.1 */
+    protected void setSize(long size) {
+        this.size = size;
     }
 
 }

--- a/addons/nuxeo-drive-server/nuxeo-drive-core/src/main/java/org/nuxeo/drive/adapter/impl/SimpleFileSystemItem.java
+++ b/addons/nuxeo-drive-server/nuxeo-drive-core/src/main/java/org/nuxeo/drive/adapter/impl/SimpleFileSystemItem.java
@@ -15,6 +15,7 @@
  *
  * Contributors:
  *     Florent Guillaume
+ *     Mickaël Schoentgen
  */
 package org.nuxeo.drive.adapter.impl;
 
@@ -34,6 +35,9 @@ public class SimpleFileSystemItem extends AbstractFileSystemItem {
 
     protected String digest;
 
+    /** @since 11.1 */
+    protected long size;
+
     protected boolean canUpdate;
 
     protected boolean canCreateChild;
@@ -50,6 +54,11 @@ public class SimpleFileSystemItem extends AbstractFileSystemItem {
 
     public String getDigest() {
         return digest;
+    }
+
+    /** @since 11.1 */
+    public long getSize() {
+        return size;
     }
 
     public boolean getCanUpdate() {
@@ -74,6 +83,11 @@ public class SimpleFileSystemItem extends AbstractFileSystemItem {
 
     public void setDigest(String digest) {
         this.digest = digest;
+    }
+
+    /** @since 11.1 */
+    public void setSize(long size) {
+        this.size = size;
     }
 
     public void setCanUpdate(boolean canUpdate) {

--- a/addons/nuxeo-drive-server/nuxeo-drive-core/src/test/java/org/nuxeo/drive/fixtures/DefaultFileSystemItemFactoryFixture.java
+++ b/addons/nuxeo-drive-server/nuxeo-drive-core/src/test/java/org/nuxeo/drive/fixtures/DefaultFileSystemItemFactoryFixture.java
@@ -587,6 +587,12 @@ public class DefaultFileSystemItemFactoryFixture {
                 ((FileItem) defaultFileSystemItemFactory.getFileSystemItem(custom)).getDigest());
 
         // ------------------------------------------------------------
+        // FileItem#size
+        // ------------------------------------------------------------
+        assertEquals("Content of Joe's file.".length(), fileItem.getSize());
+        assertEquals("Content of Bob's note.".length(), noteItem.getSize());
+
+        // ------------------------------------------------------------
         // FileItem#getCanUpdate
         // ------------------------------------------------------------
         // As Administrator

--- a/addons/nuxeo-drive-server/nuxeo-drive-core/src/test/java/org/nuxeo/drive/service/adapter/TestFileSystemItemManagerService.java
+++ b/addons/nuxeo-drive-server/nuxeo-drive-core/src/test/java/org/nuxeo/drive/service/adapter/TestFileSystemItemManagerService.java
@@ -245,6 +245,7 @@ public class TestFileSystemItemManagerService {
         assertEquals("nxfile/test/" + file.getId() + "/blobholder:0/Joe.odt", fileFsItem.getDownloadURL()); // NOSONAR
         assertEquals("MD5", fileFsItem.getDigestAlgorithm());
         assertEquals(file.getAdapter(BlobHolder.class).getBlob().getDigest(), fileFsItem.getDigest());
+        assertEquals(file.getAdapter(BlobHolder.class).getBlob().getLength(), fileFsItem.getSize());
         Blob fileItemBlob = fileFsItem.getBlob();
         assertEquals("Joe.odt", fileItemBlob.getFilename());
         assertEquals("Content of Joe's file.", fileItemBlob.getString());
@@ -478,6 +479,7 @@ public class TestFileSystemItemManagerService {
         assertEquals("nxfile/test/" + newFile.getId() + "/blobholder:0/New%20file.odt", fileItem.getDownloadURL());
         assertEquals("MD5", fileItem.getDigestAlgorithm());
         assertEquals(newFileBlob.getDigest(), fileItem.getDigest());
+        assertEquals(newFileBlob.getLength(), fileItem.getSize());
 
         // NXP-21854: Check overwrite parameter
         // Test overwrite=false
@@ -527,6 +529,7 @@ public class TestFileSystemItemManagerService {
         assertEquals("nxfile/test/" + updatedFile.getId() + "/blobholder:0/New%20file.odt", fileItem.getDownloadURL());
         assertEquals("MD5", fileItem.getDigestAlgorithm());
         assertEquals(updatedFileBlob.getDigest(), fileItem.getDigest());
+        assertEquals(updatedFileBlob.getLength(), fileItem.getSize());
 
         // ------------------------------------------------------
         // Check #delete
@@ -570,6 +573,7 @@ public class TestFileSystemItemManagerService {
         assertEquals("nxfile/test/" + file.getId() + "/blobholder:0/File%20new%20name.odt", fileItem.getDownloadURL());
         assertEquals("MD5", fileItem.getDigestAlgorithm());
         assertEquals(fileBlob.getDigest(), fileItem.getDigest());
+        assertEquals(fileBlob.getLength(), fileItem.getSize());
 
         // File rename with title == filename
         // => should rename filename and title
@@ -592,6 +596,7 @@ public class TestFileSystemItemManagerService {
                 fileItem.getDownloadURL());
         assertEquals("MD5", fileItem.getDigestAlgorithm());
         assertEquals(newFileBlob.getDigest(), fileItem.getDigest());
+        assertEquals(newFileBlob.getLength(), fileItem.getSize());
 
         // ------------------------------------------------------
         // Check #move

--- a/addons/nuxeo-drive-server/nuxeo-drive-operations/src/test/java/org/nuxeo/drive/hierarchy/permission/TestPermissionHierarchy.java
+++ b/addons/nuxeo-drive-server/nuxeo-drive-operations/src/test/java/org/nuxeo/drive/hierarchy/permission/TestPermissionHierarchy.java
@@ -756,6 +756,8 @@ public class TestPermissionHierarchy {
         assertEquals("MD5", fileItem.getDigestAlgorithm());
         assertEquals(((org.nuxeo.ecm.core.api.Blob) doc.getPropertyValue("file:content")).getDigest(),
                 fileItem.getDigest());
+        assertEquals(((org.nuxeo.ecm.core.api.Blob) doc.getPropertyValue("file:content")).getLength(),
+                fileItem.getSize());
     }
 
     protected void checkFolderItem(FolderItem folderItem, String folderItemIdPrefix, DocumentModel doc, String parentId,

--- a/addons/nuxeo-drive-server/nuxeo-drive-operations/src/test/java/org/nuxeo/drive/hierarchy/userworkspace/TestUserWorkspaceHierarchy.java
+++ b/addons/nuxeo-drive-server/nuxeo-drive-operations/src/test/java/org/nuxeo/drive/hierarchy/userworkspace/TestUserWorkspaceHierarchy.java
@@ -301,7 +301,8 @@ public class TestUserWorkspaceHierarchy {
         // Check top level folder: "Nuxeo Drive"
         // ---------------------------------------------
         UserWorkspaceTopLevelFolderItem topLevelFolder = clientSession1.newRequest(NuxeoDriveGetTopLevelFolder.ID) //
-                .executeReturning(UserWorkspaceTopLevelFolderItem.class);
+                                                                       .executeReturning(
+                                                                               UserWorkspaceTopLevelFolderItem.class);
         assertNotNull(topLevelFolder);
         assertEquals(userWorkspace1ItemId, topLevelFolder.getId());
         assertNull(topLevelFolder.getParentId());
@@ -358,8 +359,8 @@ public class TestUserWorkspaceHierarchy {
 
         // Get children
         List<DefaultSyncRootFolderItem> syncRoots = clientSession1.newRequest(NuxeoDriveGetChildren.ID)
-                .set("id", syncRootParent.getId())
-                .executeReturning(LIST_DEFAULT_SYNC_ROOT_FOLDER_ITEM);
+                                                                  .set("id", syncRootParent.getId())
+                                                                  .executeReturning(LIST_DEFAULT_SYNC_ROOT_FOLDER_ITEM);
         assertNotNull(syncRoots);
         assertEquals(2, syncRoots.size());
         Collections.sort(syncRoots);

--- a/addons/nuxeo-drive-server/nuxeo-drive-operations/src/test/java/org/nuxeo/drive/hierarchy/userworkspace/TestUserWorkspaceHierarchy.java
+++ b/addons/nuxeo-drive-server/nuxeo-drive-operations/src/test/java/org/nuxeo/drive/hierarchy/userworkspace/TestUserWorkspaceHierarchy.java
@@ -471,6 +471,8 @@ public class TestUserWorkspaceHierarchy {
         assertEquals("MD5", fileItem.getDigestAlgorithm());
         assertEquals(((org.nuxeo.ecm.core.api.Blob) doc.getPropertyValue("file:content")).getDigest(),
                 fileItem.getDigest());
+        assertEquals(((org.nuxeo.ecm.core.api.Blob) doc.getPropertyValue("file:content")).getLength(),
+                fileItem.getSize());
     }
 
     protected void checkFolderItem(FolderItem folderItem, String folderItemIdPrefix, DocumentModel doc, String parentId,

--- a/addons/nuxeo-drive-server/nuxeo-drive-operations/src/test/java/org/nuxeo/drive/operations/TestFileSystemItemOperations.java
+++ b/addons/nuxeo-drive-server/nuxeo-drive-operations/src/test/java/org/nuxeo/drive/operations/TestFileSystemItemOperations.java
@@ -347,6 +347,7 @@ public class TestFileSystemItemOperations {
         assertEquals("nxfile/test/" + file1.getId() + "/blobholder:0/First%20file.odt", fileItem.getDownloadURL()); // NOSONAR
         assertEquals("MD5", fileItem.getDigestAlgorithm());
         assertEquals(((Blob) file1.getPropertyValue(FILE_CONTENT)).getDigest(), fileItem.getDigest());
+        assertEquals(((Blob) file1.getPropertyValue(FILE_CONTENT)).getLength(), fileItem.getSize());
 
         // Get deleted file
         trashService.trashDocument(file1);
@@ -491,6 +492,7 @@ public class TestFileSystemItemOperations {
         assertEquals("nxfile/test/" + newFileDoc.getId() + "/blobholder:0/New%20file.odt", newFile.getDownloadURL());
         assertEquals("MD5", newFile.getDigestAlgorithm());
         assertEquals(newFileBlob.getDigest(), newFile.getDigest());
+        assertEquals(newFileBlob.getLength(), newFile.getSize());
     }
 
     @Test
@@ -528,6 +530,7 @@ public class TestFileSystemItemOperations {
                 updatedFile.getDownloadURL());
         assertEquals("MD5", updatedFile.getDigestAlgorithm());
         assertEquals(updatedFileBlob.getDigest(), updatedFile.getDigest());
+        assertEquals(updatedFileBlob.getLength(), updatedFile.getSize());
     }
 
     @Test
@@ -597,6 +600,7 @@ public class TestFileSystemItemOperations {
                 renamedFileItem.getDownloadURL());
         assertEquals("MD5", renamedFileItem.getDigestAlgorithm());
         assertEquals(renamedFileBlob.getDigest(), renamedFileItem.getDigest());
+        assertEquals(renamedFileBlob.getLength(), renamedFileItem.getSize());
 
         // ------------------------------------------------------
         // Folder
@@ -813,6 +817,7 @@ public class TestFileSystemItemOperations {
         assertEquals("First file.odt", movedFileBlob.getFilename());
         assertEquals("MD5", movedFileItem.getDigestAlgorithm());
         assertEquals(movedFileBlob.getDigest(), movedFileItem.getDigest());
+        assertEquals(movedFileBlob.getLength(), movedFileItem.getSize());
     }
 
     /**
@@ -921,6 +926,7 @@ public class TestFileSystemItemOperations {
                             fsItem.getDownloadURL());
                     assertEquals("MD5", fsItem.getDigestAlgorithm());
                     assertEquals(((Blob) file3.getPropertyValue(FILE_CONTENT)).getDigest(), fsItem.getDigest());
+                    assertEquals(((Blob) file3.getPropertyValue(FILE_CONTENT)).getLength(), fsItem.getSize());
                     isChild1Found = true;
                     childrenCount++;
                 }
@@ -940,6 +946,7 @@ public class TestFileSystemItemOperations {
                             fsItem.getDownloadURL());
                     assertEquals("MD5", fsItem.getDigestAlgorithm());
                     assertEquals(((Blob) file4.getPropertyValue(FILE_CONTENT)).getDigest(), fsItem.getDigest());
+                    assertEquals(((Blob) file4.getPropertyValue(FILE_CONTENT)).getLength(), fsItem.getSize());
                 }
             } else {
                 fail(String.format("FileSystemItem %s doesn't match any expected.", fsItem.getId()));


### PR DESCRIPTION
The test and push worked the 1st time but not the 2nd one because of a failure on "Nuxeo 3D Package JSF UI Functional Tests". So I think this is still safe to open the PR.

cf https://qa.nuxeo.org/jenkins/job/TestAndPush/job/ondemand-testandpush-mschoentgen/2.