### PR TITLE
10.10-HF/fix-NXP-28784-Record-management-Missing-abels-in-the-audit-for-retention-events

### DIFF
--- a/addons/nuxeo-retention/nuxeo-retention-core/src/main/resources/OSGI-INF/retention-audit.xml
+++ b/addons/nuxeo-retention/nuxeo-retention-core/src/main/resources/OSGI-INF/retention-audit.xml
@@ -1,5 +1,15 @@
 <component name="org.nuxeo.retention.audit" version="1.0">
   <extension target="org.nuxeo.ecm.platform.audit.service.NXAuditEventsService" point="event">
     <event name="retentionRuleAttached" />
+    <event name="afterSetRetention">
+      <extendedInfos>
+        <extendedInfo expression="${message.properties.retainUntil}" key="retainUntil" />
+      </extendedInfos>
+    </event>
+    <event name="afterExtendRetention">
+      <extendedInfos>
+        <extendedInfo expression="${message.properties.retainUntil}" key="retainUntil" />
+      </extendedInfos>
+    </event>
   </extension>
 </component>

--- a/addons/nuxeo-retention/nuxeo-retention-core/src/test/java/org/nuxeo/retention/test/TestRetentionEvents.java
+++ b/addons/nuxeo-retention/nuxeo-retention-core/src/test/java/org/nuxeo/retention/test/TestRetentionEvents.java
@@ -21,6 +21,7 @@ package org.nuxeo.retention.test;
 
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
+import static org.nuxeo.ecm.core.api.CoreSession.RETAIN_UNTIL_INDETERMINATE;
 
 import java.util.Calendar;
 
@@ -83,8 +84,8 @@ public class TestRetentionEvents extends RetentionTestCase {
                 DocumentEventTypes.AFTER_EXTEND_RETENTION);
 
         // current retention is indeterminate
-        session.setRetainUntil(file.getRef(), CoreSession.RETAIN_UNTIL_INDETERMINATE, null);
-        transactionalFeature.nextTransaction();
+        setRetentionAndCheckEvents(RETAIN_UNTIL_INDETERMINATE, DocumentEventTypes.BEFORE_EXTEND_RETENTION,
+                DocumentEventTypes.AFTER_EXTEND_RETENTION);
 
         // modify an indeterminate once
         retainUntil = Calendar.getInstance();
@@ -100,7 +101,8 @@ public class TestRetentionEvents extends RetentionTestCase {
 
             String[] eventsNames = listener.streamCapturedEvents().map(Event::getName).toArray(String[]::new);
             assertArrayEquals(expectedEvents, eventsNames);
-            String expectedComment = retainUntil.toInstant().toString();
+            String expectedComment = RETAIN_UNTIL_INDETERMINATE.compareTo(retainUntil) == 0 ? ""
+                    : retainUntil.toInstant().toString();
             listener.streamCapturedEvents()
                     .forEach(ev -> assertEquals("Event: " + ev.getName(), expectedComment,
                             ev.getContext().getProperties().get("comment")));

--- a/addons/nuxeo-retention/nuxeo-retention-core/src/test/java/org/nuxeo/retention/test/TestRetentionEvents.java
+++ b/addons/nuxeo-retention/nuxeo-retention-core/src/test/java/org/nuxeo/retention/test/TestRetentionEvents.java
@@ -1,0 +1,126 @@
+/*
+ * (C) Copyright 2020 Nuxeo (http://nuxeo.com/) and others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Contributors:
+ *     Salem Aouana
+ */
+
+package org.nuxeo.retention.test;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+
+import java.util.Calendar;
+
+import javax.inject.Inject;
+
+import org.junit.Test;
+import org.nuxeo.ecm.core.api.CoreSession;
+import org.nuxeo.ecm.core.api.event.DocumentEventTypes;
+import org.nuxeo.ecm.core.event.Event;
+import org.nuxeo.ecm.core.event.test.CapturingEventListener;
+import org.nuxeo.runtime.test.runner.TransactionalFeature;
+
+/**
+ * @since 11.1
+ */
+public class TestRetentionEvents extends RetentionTestCase {
+
+    @Inject
+    protected TransactionalFeature transactionalFeature;
+
+    @Test
+    public void shouldNotifyEventsWhenModifyLegalHold() {
+        session.makeRecord(file.getRef());
+
+        setLegalHoldAndCheckEvents(true, "I put the legal hold", DocumentEventTypes.BEFORE_SET_LEGAL_HOLD,
+                DocumentEventTypes.AFTER_SET_LEGAL_HOLD);
+
+        setLegalHoldAndCheckEvents(false, "I remove the legal hold", DocumentEventTypes.BEFORE_REMOVE_LEGAL_HOLD,
+                DocumentEventTypes.AFTER_REMOVE_LEGAL_HOLD);
+
+    }
+
+    protected void setLegalHoldAndCheckEvents(boolean hold, String comment, String... expectedEvents) {
+        try (CapturingEventListener listener = new CapturingEventListener(expectedEvents)) {
+            session.setLegalHold(file.getRef(), hold, comment);
+            transactionalFeature.nextTransaction();
+
+            String[] eventsNames = listener.streamCapturedEvents().map(Event::getName).toArray(String[]::new);
+            assertArrayEquals(expectedEvents, eventsNames);
+            listener.streamCapturedEvents()
+                    .forEach(ev -> assertEquals("Event: " + ev.getName(), comment,
+                            ev.getContext().getProperties().get("comment")));
+        }
+    }
+
+    @Test
+    public void shouldNotifyEventsWhenModifyRetention() {
+        session.makeRecord(file.getRef());
+        Calendar retainUntil = Calendar.getInstance();
+        retainUntil.add(Calendar.DAY_OF_MONTH, 5);
+
+        // current retention is null
+        setRetentionAndCheckEvents(retainUntil, DocumentEventTypes.BEFORE_SET_RETENTION,
+                DocumentEventTypes.AFTER_SET_RETENTION);
+
+        // extend the retention
+        retainUntil = Calendar.getInstance();
+        retainUntil.add(Calendar.DAY_OF_MONTH, 25);
+        setRetentionAndCheckEvents(retainUntil, DocumentEventTypes.BEFORE_EXTEND_RETENTION,
+                DocumentEventTypes.AFTER_EXTEND_RETENTION);
+
+        // current retention is indeterminate
+        session.setRetainUntil(file.getRef(), CoreSession.RETAIN_UNTIL_INDETERMINATE, null);
+        transactionalFeature.nextTransaction();
+
+        // modify an indeterminate once
+        retainUntil = Calendar.getInstance();
+        retainUntil.add(Calendar.DAY_OF_MONTH, 10);
+        setRetentionAndCheckEvents(retainUntil, DocumentEventTypes.BEFORE_SET_RETENTION,
+                DocumentEventTypes.AFTER_SET_RETENTION);
+    }
+
+    protected void setRetentionAndCheckEvents(Calendar retainUntil, String... expectedEvents) {
+        try (CapturingEventListener listener = new CapturingEventListener(expectedEvents)) {
+            session.setRetainUntil(file.getRef(), retainUntil, null);
+            transactionalFeature.nextTransaction();
+
+            String[] eventsNames = listener.streamCapturedEvents().map(Event::getName).toArray(String[]::new);
+            assertArrayEquals(expectedEvents, eventsNames);
+            String expectedComment = retainUntil.toInstant().toString();
+            listener.streamCapturedEvents()
+                    .forEach(ev -> assertEquals("Event: " + ev.getName(), expectedComment,
+                            ev.getContext().getProperties().get("comment")));
+        }
+    }
+
+    @Test
+    public void shouldNotNotifyEventsWhenNoRetentionModified() {
+        session.makeRecord(file.getRef());
+        setRetentionAndCheckEvents(CoreSession.RETAIN_UNTIL_INDETERMINATE, DocumentEventTypes.BEFORE_SET_RETENTION,
+                DocumentEventTypes.AFTER_SET_RETENTION);
+
+        // update the retainUnitl with the same value, no event should occur
+        String[] events = { DocumentEventTypes.BEFORE_SET_RETENTION, DocumentEventTypes.AFTER_SET_RETENTION,
+                DocumentEventTypes.BEFORE_EXTEND_RETENTION, DocumentEventTypes.AFTER_EXTEND_RETENTION };
+        try (CapturingEventListener listener = new CapturingEventListener(events)) {
+            session.setRetainUntil(file.getRef(), CoreSession.RETAIN_UNTIL_INDETERMINATE, null);
+            transactionalFeature.nextTransaction();
+            assertEquals(0, listener.streamCapturedEvents().count());
+        }
+    }
+
+}

--- a/nuxeo-core/nuxeo-core-api/src/main/java/org/nuxeo/ecm/core/api/event/CoreEventConstants.java
+++ b/nuxeo-core/nuxeo-core-api/src/main/java/org/nuxeo/ecm/core/api/event/CoreEventConstants.java
@@ -127,20 +127,13 @@ public final class CoreEventConstants {
     public static final String RESET_CREATOR = "resetCreator";
 
     /**
-     * Passed with {@value DocumentEventTypes#BEFORE_SET_RETENTION} and {@value DocumentEventTypes#AFTER_SET_RETENTION}
-     * events, the retention datetime (a {@link Calendar} object).
+     * Passed with {@value DocumentEventTypes#BEFORE_SET_RETENTION},{@value DocumentEventTypes#BEFORE_EXTEND_RETENTION},
+     * {@value DocumentEventTypes#AFTER_SET_RETENTION} and {@value DocumentEventTypes#AFTER_EXTEND_RETENTION} events,
+     * the retention datetime (a {@link java.util.Calendar} object).
      *
      * @since 11.1
      */
     public static final String RETAIN_UNTIL = "retainUntil";
-
-    /**
-     * Passed with {@value DocumentEventTypes#BEFORE_SET_LEGAL_HOLD} and
-     * {@value DocumentEventTypes#AFTER_SET_LEGAL_HOLD} events, the legal hold status (a {@link Boolean} object).
-     *
-     * @since 11.1
-     */
-    public static final String LEGAL_HOLD = "legalHold";
 
     /**
      * Passed with retentionActiveChanged event, status of the retention (active or not, a Boolean).

--- a/nuxeo-core/nuxeo-core-api/src/main/java/org/nuxeo/ecm/core/api/event/DocumentEventTypes.java
+++ b/nuxeo-core/nuxeo-core-api/src/main/java/org/nuxeo/ecm/core/api/event/DocumentEventTypes.java
@@ -183,22 +183,40 @@ public final class DocumentEventTypes {
     public static final String AFTER_MAKE_RECORD = "afterMakeRecord";
 
     /**
-     * Event triggered when a retention is about to be set or updated on a document.
+     * Event triggered when a retention is about to be set on a document.
      * <p>
-     * The event's options map contains {@link CoreEventConstants#RETAIN_UNTIL} (a {@link Calendar} object).
+     * The event's options map contains {@link CoreEventConstants#RETAIN_UNTIL} (a {@link java.util.Calendar} object).
      *
      * @since 11.1
      */
     public static final String BEFORE_SET_RETENTION = "beforeSetRetention";
 
     /**
-     * Event triggered after a retention has been set or updated on a document.
+     * Event triggered when a retention is about to be extended on a document.
      * <p>
-     * The event's options map contains {@link CoreEventConstants#RETAIN_UNTIL} (a {@link Calendar} object).
+     * The event's options map contains {@link CoreEventConstants#RETAIN_UNTIL} (a {@link java.util.Calendar} object).
+     *
+     * @since 11.1
+     */
+    public static final String BEFORE_EXTEND_RETENTION = "beforeExtendRetention";
+
+    /**
+     * Event triggered after a retention has been set on a document.
+     * <p>
+     * The event's options map contains {@link CoreEventConstants#RETAIN_UNTIL} (a {@link java.util.Calendar} object).
      *
      * @since 11.1
      */
     public static final String AFTER_SET_RETENTION = "afterSetRetention";
+
+    /**
+     * Event triggered after a retention has been extended on a document.
+     * <p>
+     * The event's options map contains {@link CoreEventConstants#RETAIN_UNTIL} (a {@link java.util.Calendar} object).
+     *
+     * @since 11.1
+     */
+    public static final String AFTER_EXTEND_RETENTION = "afterExtendRetention";
 
     /**
      * Event triggered (some time) after the retention of a document has expired.
@@ -211,22 +229,32 @@ public final class DocumentEventTypes {
     public static final String RETENTION_EXPIRED = "retentionExpired";
 
     /**
-     * Event triggered when a legal hold is about to be set or removed on a document.
-     * <p>
-     * The event's options map contains {@link CoreEventConstants#LEGAL_HOLD} (a {@link Boolean} object).
+     * Event triggered when a legal hold is about to be set on a document.
      *
      * @since 11.1
      */
     public static final String BEFORE_SET_LEGAL_HOLD = "beforeSetLegalHold";
 
     /**
-     * Event triggered after a legal hold has been set or removed on a document.
-     * <p>
-     * The event's options map contains {@link CoreEventConstants#LEGAL_HOLD} (a {@link Boolean} object).
+     * Event triggered when a legal hold is about to be removed on a document.
+     *
+     * @since 11.1
+     */
+    public static final String BEFORE_REMOVE_LEGAL_HOLD = "beforeRemoveLegalHold";
+
+    /**
+     * Event triggered after a legal hold has been set on a document.
      *
      * @since 11.1
      */
     public static final String AFTER_SET_LEGAL_HOLD = "afterSetLegalHold";
+
+    /**
+     * Event triggered after a legal hold has been removed on a document.
+     *
+     * @since 11.1
+     */
+    public static final String AFTER_REMOVE_LEGAL_HOLD = "afterRemoveLegalHold";
 
     /**
      * Event triggered when the active state of the retention changes.

--- a/nuxeo-core/nuxeo-core/src/main/java/org/nuxeo/ecm/core/api/AbstractSession.java
+++ b/nuxeo-core/nuxeo-core/src/main/java/org/nuxeo/ecm/core/api/AbstractSession.java
@@ -2087,7 +2087,9 @@ public abstract class AbstractSession implements CoreSession, Serializable {
         checkPermission(doc, SET_RETENTION);
         Map<String, Serializable> options = new HashMap<>();
         options.put(CoreEventConstants.RETAIN_UNTIL, retainUntil);
-        options.put("comment", retainUntil == null ? "" : retainUntil.toInstant().toString());
+        boolean retainUntilIndeterminate = retainUntil == null
+                || RETAIN_UNTIL_INDETERMINATE.compareTo(retainUntil) == 0;
+        options.put("comment", retainUntilIndeterminate ? "" : retainUntil.toInstant().toString());
         DocumentModel docModel = readModel(doc);
         boolean currentIndeterminate = current == null || RETAIN_UNTIL_INDETERMINATE.compareTo(current) == 0;
         String beforeRetentionEvent = currentIndeterminate ? DocumentEventTypes.BEFORE_SET_RETENTION

--- a/nuxeo-core/nuxeo-core/src/main/java/org/nuxeo/ecm/core/api/AbstractSession.java
+++ b/nuxeo-core/nuxeo-core/src/main/java/org/nuxeo/ecm/core/api/AbstractSession.java
@@ -57,10 +57,10 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
-import java.util.Objects;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
+import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.nuxeo.ecm.core.CoreService;
@@ -2080,25 +2080,24 @@ public abstract class AbstractSession implements CoreSession, Serializable {
             throw new PropertyException("Document is not a record");
         }
         Calendar current = doc.getRetainUntil();
-        if (Objects.equals(current, retainUntil)) {
+        if (current!=null && retainUntil!=null && current.compareTo(retainUntil) == 0) {
             // unchanged, don't do anything
             return;
         }
         checkPermission(doc, SET_RETENTION);
         Map<String, Serializable> options = new HashMap<>();
         options.put(CoreEventConstants.RETAIN_UNTIL, retainUntil);
-        String commentStart = retainUntil == null ? null : retainUntil.toInstant().toString();
-        if (comment == null) {
-            comment = commentStart;
-        } else if (commentStart != null) {
-            comment = commentStart + " " + comment;
-        }
-        options.put("comment", comment);
+        options.put("comment", retainUntil == null ? "" : retainUntil.toInstant().toString());
         DocumentModel docModel = readModel(doc);
-        notifyEvent(DocumentEventTypes.BEFORE_SET_RETENTION, docModel, options, null, null, true, false);
+        boolean currentIndeterminate = current == null || RETAIN_UNTIL_INDETERMINATE.compareTo(current) == 0;
+        String beforeRetentionEvent = currentIndeterminate ? DocumentEventTypes.BEFORE_SET_RETENTION
+                : DocumentEventTypes.BEFORE_EXTEND_RETENTION;
+        notifyEvent(beforeRetentionEvent, docModel, options, null, null, true, false);
         doc.setRetainUntil(retainUntil);
         docModel = readModel(doc);
-        notifyEvent(DocumentEventTypes.AFTER_SET_RETENTION, docModel, options, null, null, true, false);
+        String afterRetentionEvent = currentIndeterminate ? DocumentEventTypes.AFTER_SET_RETENTION
+                : DocumentEventTypes.AFTER_EXTEND_RETENTION;
+        notifyEvent(afterRetentionEvent, docModel, options, null, null, true, false);
     }
 
     @Override
@@ -2121,18 +2120,13 @@ public abstract class AbstractSession implements CoreSession, Serializable {
         checkPermission(doc, MANAGE_LEGAL_HOLD);
         DocumentModel docModel = readModel(doc);
         Map<String, Serializable> options = new HashMap<>();
-        options.put(CoreEventConstants.LEGAL_HOLD, Boolean.valueOf(hold));
-        String commentStart = Boolean.toString(hold);
-        if (comment == null) {
-            comment = commentStart;
-        } else {
-            comment = commentStart + " " + comment;
-        }
-        options.put("comment", comment);
-        notifyEvent(DocumentEventTypes.BEFORE_SET_LEGAL_HOLD, docModel, options, null, null, true, false);
+        options.put("comment", StringUtils.defaultString(comment));
+        String beforeLegalHoldEvent = hold ? DocumentEventTypes.BEFORE_SET_LEGAL_HOLD : DocumentEventTypes.BEFORE_REMOVE_LEGAL_HOLD;
+        notifyEvent(beforeLegalHoldEvent, docModel, options, null, null, true, false);
         doc.setLegalHold(hold);
         docModel = readModel(doc);
-        notifyEvent(DocumentEventTypes.AFTER_SET_LEGAL_HOLD, docModel, options, null, null, true, false);
+        String afterLegalHoldEvent = hold ? DocumentEventTypes.AFTER_SET_LEGAL_HOLD : DocumentEventTypes.AFTER_REMOVE_LEGAL_HOLD;
+        notifyEvent(afterLegalHoldEvent, docModel, options, null, null, true, false);
     }
 
     @Override

--- a/nuxeo-features/nuxeo-elasticsearch/nuxeo-elasticsearch-core/src/main/java/org/nuxeo/elasticsearch/commands/IndexingCommandsStacker.java
+++ b/nuxeo-features/nuxeo-elasticsearch/nuxeo-elasticsearch-core/src/main/java/org/nuxeo/elasticsearch/commands/IndexingCommandsStacker.java
@@ -20,7 +20,9 @@
 package org.nuxeo.elasticsearch.commands;
 
 import static org.nuxeo.ecm.core.api.event.DocumentEventTypes.ABOUT_TO_CHECKIN;
+import static org.nuxeo.ecm.core.api.event.DocumentEventTypes.AFTER_EXTEND_RETENTION;
 import static org.nuxeo.ecm.core.api.event.DocumentEventTypes.AFTER_MAKE_RECORD;
+import static org.nuxeo.ecm.core.api.event.DocumentEventTypes.AFTER_REMOVE_LEGAL_HOLD;
 import static org.nuxeo.ecm.core.api.event.DocumentEventTypes.AFTER_SET_LEGAL_HOLD;
 import static org.nuxeo.ecm.core.api.event.DocumentEventTypes.AFTER_SET_RETENTION;
 import static org.nuxeo.ecm.core.api.event.DocumentEventTypes.BEFORE_DOC_UPDATE;
@@ -144,7 +146,9 @@ public abstract class IndexingCommandsStacker {
         case DOCUMENT_RESTORED:
         case AFTER_MAKE_RECORD:
         case AFTER_SET_RETENTION:
+        case AFTER_EXTEND_RETENTION:
         case AFTER_SET_LEGAL_HOLD:
+        case AFTER_REMOVE_LEGAL_HOLD:
             if (doc.isProxy() && !doc.isImmutable()) {
                 stackCommand(doc.getCoreSession().getDocument(new IdRef(doc.getSourceId())), BEFORE_DOC_UPDATE, false);
             }

--- a/nuxeo-features/nuxeo-elasticsearch/nuxeo-elasticsearch-core/src/main/resources/OSGI-INF/listener-contrib.xml
+++ b/nuxeo-features/nuxeo-elasticsearch/nuxeo-elasticsearch-core/src/main/resources/OSGI-INF/listener-contrib.xml
@@ -27,7 +27,9 @@
       <event>documentUntrashed</event>
       <event>afterMakeRecord</event>
       <event>afterSetRetention</event>
+      <event>afterExtendRetention</event>
       <event>afterSetLegalHold</event>
+      <event>afterRemoveLegalHold</event>
     </listener>
 
   </extension>

--- a/nuxeo-features/nuxeo-platform-audit/nuxeo-platform-audit-core/src/main/resources/OSGI-INF/nxaudit-service.xml
+++ b/nuxeo-features/nuxeo-platform-audit/nuxeo-platform-audit-core/src/main/resources/OSGI-INF/nxaudit-service.xml
@@ -146,8 +146,10 @@
     <event name="removedFromCollection" />
     <event name="afterMakeRecord" />
     <event name="afterSetRetention" />
+    <event name="afterExtendRetention" />
     <event name="retentionExpired" />
     <event name="afterSetLegalHold" />
+    <event name="afterRemoveLegalHold" />
   </extension>
 
   <extension target="org.nuxeo.ecm.platform.audit.service.NXAuditEventsService"


### PR DESCRIPTION
PR created from https://qa2.nuxeo.org/jenkins/job/TestAndPush/job/ondemand-testandpush-saouana-10.10/107/


T&P on MongoDB [OK]: https://qa2.nuxeo.org/jenkins/job/TestAndPush/job/ondemand-testandpush-saouana-10.10/110/ 

New T&P (H2) [OK]: https://qa2.nuxeo.org/jenkins/job/TestAndPush/job/ondemand-testandpush-saouana-10.10-2/1/


New T&P after the review:

https://qa2.nuxeo.org/jenkins/job/TestAndPush/job/ondemand-testandpush-saouana-10.10-2/