### PR TITLE
NXP-28867: fix sanitization of style attribute

### DIFF
--- a/modules/platform/nuxeo-platform-htmlsanitizer/src/main/resources/antisamy-nuxeo-policy.xml
+++ b/modules/platform/nuxeo-platform-htmlsanitizer/src/main/resources/antisamy-nuxeo-policy.xml
@@ -500,7 +500,6 @@
     <!-- Not valid in base, head, html, meta, param, script, style, and title
       elements. -->
     <attribute name="id" />
-    <attribute name="style" />
     <attribute name="title" />
     <attribute name="class" />
     <!-- Not valid in base, br, frame, frameset, hr, iframe, param, and script

--- a/modules/platform/nuxeo-platform-htmlsanitizer/src/test/java/org/nuxeo/ecm/platform/htmlsanitizer/TestHtmlSanitizerServiceImpl.java
+++ b/modules/platform/nuxeo-platform-htmlsanitizer/src/test/java/org/nuxeo/ecm/platform/htmlsanitizer/TestHtmlSanitizerServiceImpl.java
@@ -220,4 +220,13 @@ public class TestHtmlSanitizerServiceImpl {
 
         session.save();
     }
+
+    @Test
+    public void sanitizeStyle() {
+        String html = "<span style=\"color:red;invalid:removed\"></span>";
+        String expected = "<span style=\"color:red\"></span>";
+        HtmlSanitizerService service = Framework.getService(HtmlSanitizerService.class);
+        String res = service.sanitizeString(html, null);
+        assertEquals(expected, res);
+    }
 }


### PR DESCRIPTION
For some reason when building the policy from the legacy antisamy conf we ended up with a spurious AttributePolicy with an empty list of accepted values and/or regexps for the style attribute. By default a StylingPolicy is already in place for the style attribute.