### PR TITLE
NXP-28903: allow data uri for images

### DIFF
--- a/modules/platform/nuxeo-platform-htmlsanitizer/src/main/java/org/nuxeo/ecm/platform/htmlsanitizer/HtmlSanitizerServiceImpl.java
+++ b/modules/platform/nuxeo-platform-htmlsanitizer/src/main/java/org/nuxeo/ecm/platform/htmlsanitizer/HtmlSanitizerServiceImpl.java
@@ -137,6 +137,7 @@ public class HtmlSanitizerServiceImpl extends DefaultComponent implements HtmlSa
 
     protected void initializeBuilder(HtmlPolicyBuilder builder) {
         builder.allowStandardUrlProtocols();
+        builder.allowUrlProtocols("data"); // still enforces regex matchers from policy
         builder.allowStyling();
         builder.disallowElements("script");
     }

--- a/modules/platform/nuxeo-platform-htmlsanitizer/src/main/resources/antisamy-nuxeo-policy.xml
+++ b/modules/platform/nuxeo-platform-htmlsanitizer/src/main/resources/antisamy-nuxeo-policy.xml
@@ -48,6 +48,8 @@
       value="([\p{L}\p{N}\\\.\#@\$%\+&amp;;\-_~,\?=/!]+|\#(\w)+)" />
     <regexp name="offsiteURL"
       value="(\s)*((ht|f)tp(s?)://|mailto:)[\p{L}\p{N}]+[\p{L}\p{N}\p{Zs}\.\#@\$%\+&amp;;:\-_~,\?=/!\(\)]*(\s)*" />
+    <regexp name="imgDataURL"
+      value="data:image/[\w\-\+]+;base64,.*" />
 
     <regexp name="boolean" value="(true|false)" />
     <regexp name="singlePrintable" value="[a-zA-Z0-9]{1}" /> <!-- \w allows the '_' character -->
@@ -819,6 +821,7 @@
         <regexp-list>
           <regexp name="onsiteURL" />
           <regexp name="offsiteURL" />
+          <regexp name="imgDataURL" />
         </regexp-list>
       </attribute>
       <attribute name="name" />

--- a/modules/platform/nuxeo-platform-htmlsanitizer/src/test/java/org/nuxeo/ecm/platform/htmlsanitizer/TestHtmlSanitizerServiceImpl.java
+++ b/modules/platform/nuxeo-platform-htmlsanitizer/src/test/java/org/nuxeo/ecm/platform/htmlsanitizer/TestHtmlSanitizerServiceImpl.java
@@ -229,4 +229,19 @@ public class TestHtmlSanitizerServiceImpl {
         String res = service.sanitizeString(html, null);
         assertEquals(expected, res);
     }
+
+    @Test
+    public void sanitizeImageDataUri() {
+        HtmlSanitizerService service = Framework.getService(HtmlSanitizerService.class);
+
+        String html = "<img src=\"data:image/jpeg;base64,Zm9v\" />";
+        String expected = html;
+        String res = service.sanitizeString(html, null);
+        assertEquals(expected, res);
+
+        html = "<img src=\"data:text/plain;foo\">";
+        expected = "<img />";
+        res = service.sanitizeString(html, null);
+        assertEquals(expected, res);
+    }
 }


### PR DESCRIPTION
Data uris are not part of default allowed protocols. This makes them allowed and assumes the policy defines regexes for attribute values (which is the case for us with the legacy antisamy policy in place).