### PR TITLE
NXP-27713: explicitly write nuxeo helm chart overriden nuxeo.conf values

### DIFF
--- a/ci/helm/preview/values.yaml
+++ b/ci/helm/preview/values.yaml
@@ -21,9 +21,6 @@ cleanup:
 nuxeo:
   fullnameOverride: nuxeo-preview
   nuxeo:
-    customParams: |-
-      elasticsearch.restClient.socketTimeoutMs=300000
-      elasticsearch.restClient.connectionTimeoutMs=300000
     podLabels:
       branch: "$BRANCH_NAME"
       team: platform


### PR DESCRIPTION
The overriden nuxeo.conf are lost, so they need to be written explicitly:
In our case: 
elasticsearch.indexNumberOfReplicas=0