### PR TITLE
NXP-28885: Retention Search feature is not working

### DIFF
--- a/addons/nuxeo-retention/nuxeo-retention-core/src/main/resources/OSGI-INF/retention-core-types.xml
+++ b/addons/nuxeo-retention/nuxeo-retention-core/src/main/resources/OSGI-INF/retention-core-types.xml
@@ -10,7 +10,7 @@
       prefix="retention_def" />
     <schema name="record" src="schemas/record.xsd" prefix="record" />
     <schema name="retention_search" src="schemas/retention_search.xsd"
-      prefix="ret_search" />
+      prefix="retention_search" />
   </extension>
 
   <extension target="org.nuxeo.ecm.core.schema.TypeService" point="doctype">

--- a/addons/nuxeo-retention/nuxeo-retention-core/src/main/resources/OSGI-INF/retention-pageproviders.xml
+++ b/addons/nuxeo-retention/nuxeo-retention-core/src/main/resources/OSGI-INF/retention-pageproviders.xml
@@ -37,10 +37,10 @@
           AND ecm:mixinType != 'HiddenInNavigation'
         </fixedPart>
         <predicate parameter="ecm:fulltext" operator="FULLTEXT">
-          <field schema="rendition_search" name="ecm_fulltext" />
+          <field schema="retention_search" name="ecm_fulltext" />
         </predicate>
         <predicate parameter="dc:creator" operator="IN">
-          <field schema="rendition_search" name="dc_creator" />
+          <field schema="retention_search" name="dc_creator" />
         </predicate>
       </whereClause>
       <aggregates>

--- a/addons/nuxeo-retention/nuxeo-retention-web-ui/src/main/resources/web/nuxeo.war/ui/nuxeo-retention/nuxeo-retention.html
+++ b/addons/nuxeo-retention/nuxeo-retention-web-ui/src/main/resources/web/nuxeo.war/ui/nuxeo-retention/nuxeo-retention.html
@@ -50,7 +50,7 @@ limitations under the License.
                            provider="retention_search"
                            schemas="dublincore,common,retention_def"
                            search-name="retention"
-                           show-filters opened stop-error-propagation></nuxeo-search-page>
+                           show-filters opened stop-error-propagation auto></nuxeo-search-page>
       </template>
     </nuxeo-filter>
   </template>

--- a/addons/nuxeo-retention/nuxeo-retention-web-ui/src/main/resources/web/nuxeo.war/ui/search/retention/nuxeo-retention-search-form.html
+++ b/addons/nuxeo-retention/nuxeo-retention-web-ui/src/main/resources/web/nuxeo.war/ui/search/retention/nuxeo-retention-search-form.html
@@ -64,7 +64,8 @@ limitations under the License.
         <label>[[i18n('retention.search.rules')]]</label>
         <nuxeo-dropdown-aggregation
           data="[[aggregations.rules_agg]]"
-          value="{{params.ecm_retain_agg}}">
+          value="{{params.rules_agg}}"
+          multiple>
         </nuxeo-dropdown-aggregation>
       </div>
     </div>


### PR DESCRIPTION
PR opened manually, at the same time the T&P is launched (https://qa2.nuxeo.org/jenkins/job/TestAndPush/job/ondemand-testandpush-saouana-10.10/111/) -> **T&P OK**

As discussed with @jaubenque,  PO needs to release a first version of retention addon asap. 

Its why: 
Currently there is no Tests coverture on retention search feature at the backend part (test of the Page Provider). As see with @jaubenque he will create for us a new ticket to make improvements on retention and we will add the needed tests.

For the web-ui a new ticket will be created to improve the way to make the search auto vs manually (the search button)  until that we make choice to handle it with the search button.