### PR TITLE
NXP-28939: add the ability to validate an EL

### DIFF
--- a/addons/nuxeo-retention/nuxeo-retention-core/src/main/java/org/nuxeo/retention/service/RetentionManagerImpl.java
+++ b/addons/nuxeo-retention/nuxeo-retention-core/src/main/java/org/nuxeo/retention/service/RetentionManagerImpl.java
@@ -291,14 +291,16 @@ public class RetentionManagerImpl extends DefaultComponent implements RetentionM
         if (events.contains(startingPointEvent)) {
             ELActionContext actionContext = initActionContext(record.getDocument(), session);
             String expression = rule.getStartingPointExpression();
-            boolean startNow = evaluateConditionExpression(actionContext, expression);
-            if (startNow) {
-                session.setRetainUntil(record.getDocument().getRef(), rule.getRetainUntilDateFromNow(), null);
-                log.debug("Evaluating event-based rules: expression {} matched on event {}", expression,
-                        startingPointEvent);
-            } else {
-                log.debug("Evaluating event-based rules: expression {} did not match on event {}", expression,
-                        startingPointEvent);
+            if (actionContext.isValid(expression)) {
+                boolean startNow = evaluateConditionExpression(actionContext, expression);
+                if (startNow) {
+                    session.setRetainUntil(record.getDocument().getRef(), rule.getRetainUntilDateFromNow(), null);
+                    log.debug("Evaluating event-based rules: expression {} matched on event {}", expression,
+                            startingPointEvent);
+                } else {
+                    log.debug("Evaluating event-based rules: expression {} did not match on event {}", expression,
+                            startingPointEvent);
+                }
             }
         }
     }

--- a/addons/nuxeo-retention/nuxeo-retention-core/src/test/java/org/nuxeo/retention/test/RetentionTestCase.java
+++ b/addons/nuxeo-retention/nuxeo-retention-core/src/test/java/org/nuxeo/retention/test/RetentionTestCase.java
@@ -33,6 +33,7 @@ import org.nuxeo.ecm.automation.test.AutomationFeature;
 import org.nuxeo.ecm.core.api.CoreSession;
 import org.nuxeo.ecm.core.api.DocumentModel;
 import org.nuxeo.ecm.core.bulk.BulkService;
+import org.nuxeo.ecm.core.bulk.CoreBulkFeature;
 import org.nuxeo.ecm.core.security.RetentionExpiredFinderListener;
 import org.nuxeo.ecm.core.test.CoreFeature;
 import org.nuxeo.ecm.core.test.DefaultRepositoryInit;
@@ -59,6 +60,7 @@ import org.nuxeo.runtime.test.runner.TransactionalFeature;
 @Deploy("org.nuxeo.retention.core:OSGI-INF/retention-service-framework.xml")
 @Deploy("org.nuxeo.retention.core:OSGI-INF/retention-listeners.xml")
 @Deploy("org.nuxeo.retention.core:OSGI-INF/retention-operations.xml")
+@Deploy("org.nuxeo.retention.core:OSGI-INF/retention-actions.xml")
 public abstract class RetentionTestCase {
 
     @Inject

--- a/addons/nuxeo-retention/nuxeo-retention-core/src/test/java/org/nuxeo/retention/test/TestRetentionManager.java
+++ b/addons/nuxeo-retention/nuxeo-retention-core/src/test/java/org/nuxeo/retention/test/TestRetentionManager.java
@@ -34,8 +34,11 @@ import org.nuxeo.ecm.automation.AutomationService;
 import org.nuxeo.ecm.core.api.DocumentModel;
 import org.nuxeo.ecm.core.api.NuxeoException;
 import org.nuxeo.ecm.core.api.event.DocumentEventTypes;
+import org.nuxeo.ecm.core.event.Event;
+import org.nuxeo.ecm.core.event.EventProducer;
 import org.nuxeo.retention.adapters.Record;
 import org.nuxeo.retention.adapters.RetentionRule;
+import org.nuxeo.retention.event.RetentionEventContext;
 
 /**
  * @since 11.1
@@ -44,6 +47,9 @@ public class TestRetentionManager extends RetentionTestCase {
 
     @Inject
     protected AutomationService automationService;
+
+    @Inject
+    protected EventProducer eventProducer;
 
     @Test
     public void testRuleOnlyFile() {
@@ -112,7 +118,7 @@ public class TestRetentionManager extends RetentionTestCase {
     }
 
     @Test
-    public void testManualDocumentMovedToFolderRule() throws InterruptedException {
+    public void testManualDocumentMovedToFolderExpressionRule() throws InterruptedException {
 
         RetentionRule testRule = createManualEventBasedRuleMillis(DocumentEventTypes.DOCUMENT_MOVED,
                 "document.getPathAsString().startsWith('/testFolder')", 1000);
@@ -149,6 +155,45 @@ public class TestRetentionManager extends RetentionTestCase {
         record = file.getAdapter(Record.class);
 
         // it has no retention anymore
+        assertFalse(session.isUnderRetentionOrLegalHold(file.getRef()));
+        assertTrue(record.isRetentionExpired());
+    }
+
+    @Test
+    public void testManualDocumentMovedToFolderValueRule() throws InterruptedException {
+        String myRetentionEventInput = "myEventInput";
+        RetentionRule testRule = createManualEventBasedRuleMillis(DocumentEventTypes.DOCUMENT_MOVED,
+                myRetentionEventInput, 1000);
+
+        file = service.attachRule(file, testRule, session);
+        assertTrue(file.isRecord());
+        assertTrue(session.isUnderRetentionOrLegalHold(file.getRef()));
+
+        awaitRetentionExpiration(500);
+
+        file = session.getDocument(file.getRef());
+        Record record = file.getAdapter(Record.class);
+        assertTrue(session.isUnderRetentionOrLegalHold(file.getRef()));
+        assertTrue(record.isRetentionIndeterminate());
+
+        RetentionEventContext evctx = new RetentionEventContext(session.getPrincipal());
+        evctx.setInput(myRetentionEventInput);
+        Event event = evctx.newEvent(DocumentEventTypes.DOCUMENT_MOVED);
+        eventProducer.fireEvent(event);
+
+        awaitRetentionExpiration(500);
+
+        file = session.getDocument(file.getRef());
+        record = file.getAdapter(Record.class);
+        assertTrue(session.isUnderRetentionOrLegalHold(file.getRef()));
+        assertTrue(file.isRecord());
+        assertFalse(record.isRetentionIndeterminate());
+
+        awaitRetentionExpiration(500);
+
+        // it has no retention anymore
+        file = session.getDocument(file.getRef());
+        record = file.getAdapter(Record.class);
         assertFalse(session.isUnderRetentionOrLegalHold(file.getRef()));
         assertTrue(record.isRetentionExpired());
     }

--- a/nuxeo-jsf/nuxeo-platform-actions-jsf/src/test/java/org/nuxeo/ecm/platform/actions/TestELJSFActionContext.java
+++ b/nuxeo-jsf/nuxeo-platform-actions-jsf/src/test/java/org/nuxeo/ecm/platform/actions/TestELJSFActionContext.java
@@ -1,0 +1,78 @@
+/*
+ * (C) Copyright 2020 Nuxeo (http://nuxeo.com/) and others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Contributors:
+ *     Salem Aouana
+ */
+
+package org.nuxeo.ecm.platform.actions;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import javax.faces.context.FacesContext;
+import javax.inject.Inject;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.nuxeo.ecm.core.api.DocumentModel;
+import org.nuxeo.ecm.platform.actions.jsf.JSFActionContext;
+import org.nuxeo.ecm.platform.ui.web.jsf.MockFacesContext;
+import org.nuxeo.runtime.test.runner.Deploy;
+import org.nuxeo.runtime.test.runner.Features;
+import org.nuxeo.runtime.test.runner.FeaturesRunner;
+import org.nuxeo.runtime.test.runner.RuntimeFeature;
+
+/**
+ * @since 11.1
+ */
+@RunWith(FeaturesRunner.class)
+@Features(RuntimeFeature.class)
+@Deploy("org.nuxeo.ecm.core.schema")
+public class TestELJSFActionContext {
+
+    @Inject
+    protected ActionService actionService;
+
+    @Test
+    public void shouldValidateAndEvaluateExpression() {
+        DocumentModel document = new MockDocumentModel("File", new String[0]);
+
+        ActionContext actionContext = getActionContext(document);
+
+        String expression = "document.getType().equals('Folder')";
+        assertTrue(actionContext.isValid(expression));
+        assertFalse(actionContext.checkCondition(expression));
+
+        expression = "document.getType().equals('File')";
+        assertTrue(actionContext.isValid(expression));
+        assertTrue(actionContext.checkCondition(expression));
+
+        assertTrue(actionContext.isValid("'Nuxeo'.equals('Nuxeo')"));
+        assertTrue(actionContext.isValid("1==1"));
+
+        assertFalse(actionContext.isValid("1255475"));
+    }
+
+    protected ActionContext getActionContext(DocumentModel document) {
+        MockFacesContext facesContext = new MockFacesContext();
+        facesContext.setCurrent();
+        assertNotNull(FacesContext.getCurrentInstance());
+        ActionContext context = new JSFActionContext(facesContext);
+        context.setCurrentDocument(document);
+        return context;
+    }
+}

--- a/nuxeo-services/nuxeo-platform-actions-core/src/main/java/org/nuxeo/ecm/platform/actions/ActionContext.java
+++ b/nuxeo-services/nuxeo-platform-actions-core/src/main/java/org/nuxeo/ecm/platform/actions/ActionContext.java
@@ -112,4 +112,14 @@ public interface ActionContext extends Serializable {
      */
     boolean disableGlobalCaching();
 
+    /**
+     * Validates the given expression before evaluated it, which avoid any errors or exception during the evaluation.
+     * <p>
+     * This is designed to be called before {@link #checkCondition(String)}.
+     * 
+     * @param expression the expression to evaluate
+     * @return true if the given expression can be evaluated without exceptions
+     */
+    boolean isValid(String expression);
+
 }

--- a/nuxeo-services/nuxeo-platform-actions-core/src/test/java/org/nuxeo/ecm/platform/actions/TestELActionContext.java
+++ b/nuxeo-services/nuxeo-platform-actions-core/src/test/java/org/nuxeo/ecm/platform/actions/TestELActionContext.java
@@ -1,0 +1,75 @@
+/*
+ * (C) Copyright 2020 Nuxeo (http://nuxeo.com/) and others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *  
+ * Contributors:
+ *     Salem Aouana
+ */
+
+package org.nuxeo.ecm.platform.actions;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import javax.inject.Inject;
+
+import org.jboss.el.ExpressionFactoryImpl;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.nuxeo.ecm.core.api.CoreSession;
+import org.nuxeo.ecm.core.api.DocumentModel;
+import org.nuxeo.ecm.core.test.CoreFeature;
+import org.nuxeo.ecm.platform.el.ExpressionContext;
+import org.nuxeo.runtime.test.runner.Features;
+import org.nuxeo.runtime.test.runner.FeaturesRunner;
+
+/**
+ * @since 11.1
+ */
+@RunWith(FeaturesRunner.class)
+@Features(CoreFeature.class)
+public class TestELActionContext {
+
+    @Inject
+    protected CoreSession session;
+
+    @Test
+    public void shouldValidateAndEvaluateExpression() {
+        DocumentModel document = session.createDocumentModel("/", "anyFile", "File");
+        document = session.createDocument(document);
+
+        ActionContext actionContext = getActionContext(document);
+
+        String expression = "document.getPathAsString().startsWith('/testFile')";
+        assertTrue(actionContext.isValid(expression));
+        assertFalse(actionContext.checkCondition(expression));
+
+        expression = "document.getPathAsString().startsWith('/anyFile')";
+        assertTrue(actionContext.isValid(expression));
+        assertTrue(actionContext.checkCondition(expression));
+
+        assertTrue(actionContext.isValid("'Nuxeo'.equals('Nuxeo')"));
+        assertTrue(actionContext.isValid("1==1"));
+
+        assertFalse(actionContext.isValid("1255475"));
+    }
+
+    protected ActionContext getActionContext(DocumentModel document) {
+        ELActionContext context = new ELActionContext(new ExpressionContext(), new ExpressionFactoryImpl());
+        context.setCurrentPrincipal(session.getPrincipal());
+        context.setCurrentDocument(document);
+        return context;
+    }
+
+}


### PR DESCRIPTION
This PR is in Draft mode to let the involved persons (Florent, Neslon and Nuno) to see how things can be done, to avoid the exception that we have on the retention in the case of EL and event based rule.

I create a specific ticket for adding the validity check: https://jira.nuxeo.com/browse/NXP-28994

T&P In Progress: https://qa2.nuxeo.org/jenkins/job/TestAndPush/job/ondemand-testandpush-saouana-10.10-2/4/


As discussed with @nmpcunha we will keep this PR and this improvement. But we will do it on `11.1` only. No need it for `10.10` as we did the split of the properties in https://github.com/nuxeo/nuxeo/pull/3963