### PR TITLE
NXP-28532: mention failing doc id and property when reindexing ES

### DIFF
--- a/modules/platform/nuxeo-elasticsearch/nuxeo-elasticsearch-core/src/main/java/org/nuxeo/elasticsearch/io/JsonESDocumentWriter.java
+++ b/modules/platform/nuxeo-elasticsearch/nuxeo-elasticsearch-core/src/main/java/org/nuxeo/elasticsearch/io/JsonESDocumentWriter.java
@@ -38,6 +38,7 @@ import org.nuxeo.ecm.automation.core.util.JSONPropertyWriter;
 import org.nuxeo.ecm.core.api.CoreSession;
 import org.nuxeo.ecm.core.api.DocumentModel;
 import org.nuxeo.ecm.core.api.DocumentRef;
+import org.nuxeo.ecm.core.api.NuxeoException;
 import org.nuxeo.ecm.core.api.model.Property;
 import org.nuxeo.ecm.core.api.security.ACE;
 import org.nuxeo.ecm.core.api.security.ACL;
@@ -212,7 +213,12 @@ public class JsonESDocumentWriter {
         }
 
         for (Property p : properties) {
-            writer.writeProperty(jg, p);
+            try {
+                writer.writeProperty(jg, p);
+            } catch (ClassCastException e) {
+                throw new NuxeoException(
+                        String.format("writing JSON property failed on document: %s for property: %s", doc, p), e);
+            }
         }
     }
 


### PR DESCRIPTION
Helps with debugging when ES reindexing fails