### PR TITLE
NXP-28976: Fix Nexus connection reset on Gatling tests in Jenkins X

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -125,7 +125,7 @@
     <gatling-plugin.version>3.0.4</gatling-plugin.version>
     <scala.version>2.12.3</scala.version>
     <scala-logging.version>3.9.0</scala-logging.version>
-    <scala-maven-plugin.version>3.3.2</scala-maven-plugin.version>
+    <scala-maven-plugin.version>4.3.1</scala-maven-plugin.version>
     <jgiven.version>0.18.2</jgiven.version>
 
     <nuxeo.skip.enforcer>false</nuxeo.skip.enforcer>


### PR DESCRIPTION
For some unknown reason, with the 3.3.2 version of scala-maven-plugin, running `mvn verify` in nuxeo-server-gatling-tests fails with the following error, when the Maven repository is empty (no scala-compiler JAR downloaded yet):

```
Failed to execute goal net.alchim31.maven:scala-maven-plugin:3.3.2:compile (scala-compile) on project nuxeo-server-gatling-tests: wrap: org.apache.maven.artifact.resolver.ArtifactResolutionException: Could not transfer artifact org.scala-lang:scala-compiler:jar:2.12.3 from/to nexus (http://nexus/repository/maven-group/): GET request of: org/scala-lang/scala-compiler/2.12.3/scala-compiler-2.12.3.jar from nexus failed
  org.scala-lang:scala-compiler:jar:2.12.3

from the specified remote repositories:
  nexus (http://nexus/repository/maven-group/, releases=true, snapshots=true): Connection reset
```