### PR TITLE
NXP-28869: Add a new API to refresh AWS tokens in the batch handler

### DIFF
--- a/modules/core/nuxeo-core-binarymanager-cloud/nuxeo-core-binarymanager-s3/src/main/java/org/nuxeo/ecm/core/storage/sql/S3DirectBatchHandler.java
+++ b/modules/core/nuxeo-core-binarymanager-cloud/nuxeo-core-binarymanager-s3/src/main/java/org/nuxeo/ecm/core/storage/sql/S3DirectBatchHandler.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright 2011-2018 Nuxeo (http://nuxeo.com/) and others.
+ * (C) Copyright 2011-2020 Nuxeo (http://nuxeo.com/) and others.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -267,9 +267,11 @@ public class S3DirectBatchHandler extends AbstractBatchHandler {
 
         ObjectMetadata newMetadata;
         if (metadata.getContentLength() > lowerThresholdToUseMultipartCopy()) {
-            newMetadata = S3Utils.copyFileMultipart(amazonS3, metadata, bucket, fileKey, bucket, newFileKey, targetSSEAlgorithm, true);
+            newMetadata = S3Utils.copyFileMultipart(amazonS3, metadata, bucket, fileKey, bucket, newFileKey,
+                    targetSSEAlgorithm, true);
         } else {
-            newMetadata = S3Utils.copyFile(amazonS3, metadata, bucket, fileKey, bucket, newFileKey, targetSSEAlgorithm, true);
+            newMetadata = S3Utils.copyFile(amazonS3, metadata, bucket, fileKey, bucket, newFileKey, targetSSEAlgorithm,
+                    true);
             boolean isMultipartUpload = REGEX_MULTIPART_ETAG.matcher(etag).find();
             if (isMultipartUpload) {
                 etag = newMetadata.getETag();

--- a/modules/core/nuxeo-core-binarymanager-cloud/nuxeo-core-binarymanager-s3/src/main/java/org/nuxeo/ecm/core/storage/sql/S3DirectBatchHandler.java
+++ b/modules/core/nuxeo-core-binarymanager-cloud/nuxeo-core-binarymanager-s3/src/main/java/org/nuxeo/ecm/core/storage/sql/S3DirectBatchHandler.java
@@ -16,6 +16,7 @@
  * Contributors:
  *     Luís Duarte
  *     Florent Guillaume
+ *     Mickaël Schoentgen
  */
 package org.nuxeo.ecm.core.storage.sql;
 
@@ -36,7 +37,9 @@ import static org.nuxeo.ecm.core.storage.sql.S3BinaryManager.PATHSTYLEACCESS_PRO
 import static org.nuxeo.ecm.core.storage.sql.S3Utils.NON_MULTIPART_COPY_MAX_SIZE;
 
 import java.io.Serializable;
+import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 import java.util.regex.Pattern;
 
 import org.apache.commons.logging.Log;
@@ -217,14 +220,7 @@ public class S3DirectBatchHandler extends AbstractBatchHandler {
         // create the batch
         Batch batch = new Batch(batchId, parameters, getName(), getTransientStore());
 
-        AssumeRoleRequest request = new AssumeRoleRequest().withRoleArn(roleArn)
-                                                           .withPolicy(policy)
-                                                           .withRoleSessionName(batchId);
-        if (expiration > 0) {
-            request.setDurationSeconds(expiration);
-        }
-
-        Credentials credentials = assumeRole(request);
+        Credentials credentials = getAwsCredentials(batchId);
 
         Map<String, Object> properties = batch.getProperties();
         properties.put(INFO_AWS_SECRET_KEY_ID, credentials.getAccessKeyId());
@@ -299,6 +295,31 @@ public class S3DirectBatchHandler extends AbstractBatchHandler {
 
     protected long lowerThresholdToUseMultipartCopy() {
         return NON_MULTIPART_COPY_MAX_SIZE;
+    }
+
+    /** @since 11.1 */
+    protected Credentials getAwsCredentials(String batchId) {
+        AssumeRoleRequest request = new AssumeRoleRequest().withRoleArn(roleArn)
+                                                           .withPolicy(policy)
+                                                           .withRoleSessionName(batchId);
+        if (expiration > 0) {
+            request.setDurationSeconds(expiration);
+        }
+        return assumeRole(request);
+    }
+
+    /** @since 11.1 */
+    @Override
+    public Map<String, Object> refreshToken(String batchId) {
+        Objects.requireNonNull(batchId, "required batch ID");
+
+        Credentials credentials = getAwsCredentials(batchId);
+        Map<String, Object> result = new HashMap<String, Object>();
+        result.put(INFO_AWS_SECRET_KEY_ID, credentials.getAccessKeyId());
+        result.put(INFO_AWS_SECRET_ACCESS_KEY, credentials.getSecretAccessKey());
+        result.put(INFO_AWS_SESSION_TOKEN, credentials.getSessionToken());
+        result.put(INFO_EXPIRATION, credentials.getExpiration().toInstant().toEpochMilli());
+        return result;
     }
 
 }

--- a/modules/core/nuxeo-core-binarymanager-cloud/nuxeo-core-binarymanager-s3/src/test/java/org/nuxeo/ecm/core/storage/sql/TestS3DirectBatchHandler.java
+++ b/modules/core/nuxeo-core-binarymanager-cloud/nuxeo-core-binarymanager-s3/src/test/java/org/nuxeo/ecm/core/storage/sql/TestS3DirectBatchHandler.java
@@ -15,10 +15,12 @@
  *
  * Contributors:
  *     pierre
+ *     Mickaël Schoentgen
  */
 package org.nuxeo.ecm.core.storage.sql;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
@@ -160,6 +162,48 @@ public class TestS3DirectBatchHandler {
     @Deploy("org.nuxeo.ecm.core.storage.binarymanager.s3.tests:OSGI-INF/test-s3directupload-contrib.xml")
     public void test20MB() throws SdkBaseException, InterruptedException {
         test("s3", 20 * 1024 * 1024);
+    }
+
+    @Test
+    @Deploy("org.nuxeo.ecm.core.storage.binarymanager.s3.tests:OSGI-INF/test-s3directupload-contrib.xml")
+    public void testTokenRenewal() throws SdkBaseException, InterruptedException {
+        // Test that refreshing tokens actually returns back valid and different tokens.
+        S3DirectBatchHandler handler = (S3DirectBatchHandler) batchManager.getHandler("s3");
+        Batch newBatch = handler.newBatch(null);
+        Batch batch = handler.getBatch(newBatch.getKey());
+
+        // Save current details
+        Map<String, Object> properties = batch.getProperties();
+        String secretKeyId = (String) properties.get(S3DirectBatchHandler.INFO_AWS_SECRET_KEY_ID);
+        String secretAccessKey = (String) properties.get(S3DirectBatchHandler.INFO_AWS_SECRET_ACCESS_KEY);
+        String sessionToken = (String) properties.get(S3DirectBatchHandler.INFO_AWS_SESSION_TOKEN);
+        Long expiration = (Long) properties.get(S3DirectBatchHandler.INFO_EXPIRATION);
+
+        // Renew tokens
+        properties = handler.refreshToken(newBatch.getKey());
+        String newSecretKeyId = (String) properties.get(S3DirectBatchHandler.INFO_AWS_SECRET_KEY_ID);
+        String newSecretAccessKey = (String) properties.get(S3DirectBatchHandler.INFO_AWS_SECRET_ACCESS_KEY);
+        String newSessionToken = (String) properties.get(S3DirectBatchHandler.INFO_AWS_SESSION_TOKEN);
+        Long newExpiration = (Long) properties.get(S3DirectBatchHandler.INFO_EXPIRATION);
+
+        // Checks
+        assertNotEquals(secretKeyId, newSecretKeyId);
+        assertNotEquals(secretAccessKey, newSecretAccessKey);
+        assertNotEquals(sessionToken, newSessionToken);
+        assertTrue(expiration <= newExpiration);
+    }
+
+    @Test
+    @Deploy("org.nuxeo.ecm.core.storage.binarymanager.s3.tests:OSGI-INF/test-s3directupload-contrib.xml")
+    public void testTokenRenewalNullBatchId() throws InterruptedException {
+        // Test that refreshing tokens does not work for an invalid batch ID.
+        S3DirectBatchHandler handler = (S3DirectBatchHandler) batchManager.getHandler("s3");
+        try {
+            handler.refreshToken(null);
+            fail("should not allow null batch ID");
+        } catch (NullPointerException e) {
+            assertTrue(e.getMessage().contains("required batch ID"));
+        }
     }
 
     public void test(String handlerName, int size) throws SdkBaseException, InterruptedException {

--- a/modules/core/nuxeo-core-binarymanager-cloud/nuxeo-core-binarymanager-s3/src/test/java/org/nuxeo/ecm/core/storage/sql/TestS3DirectBatchHandler.java
+++ b/modules/core/nuxeo-core-binarymanager-cloud/nuxeo-core-binarymanager-s3/src/test/java/org/nuxeo/ecm/core/storage/sql/TestS3DirectBatchHandler.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright 2018 Nuxeo (http://nuxeo.com/) and others.
+ * (C) Copyright 2018-2020 Nuxeo (http://nuxeo.com/) and others.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/platform/nuxeo-automation/nuxeo-automation-server/src/main/java/org/nuxeo/ecm/automation/server/jaxrs/batch/BatchHandler.java
+++ b/modules/platform/nuxeo-automation/nuxeo-automation-server/src/main/java/org/nuxeo/ecm/automation/server/jaxrs/batch/BatchHandler.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright 2018 Nuxeo SA (http://nuxeo.com/) and others.
+ * (C) Copyright 2018-2020 Nuxeo SA (http://nuxeo.com/) and others.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/platform/nuxeo-automation/nuxeo-automation-server/src/main/java/org/nuxeo/ecm/automation/server/jaxrs/batch/BatchHandler.java
+++ b/modules/platform/nuxeo-automation/nuxeo-automation-server/src/main/java/org/nuxeo/ecm/automation/server/jaxrs/batch/BatchHandler.java
@@ -16,6 +16,7 @@
  * Contributors:
  *     Luís Duarte
  *     Florent Guillaume
+ *     Mickaël Schoentgen
  */
 package org.nuxeo.ecm.automation.server.jaxrs.batch;
 
@@ -61,6 +62,17 @@ public interface BatchHandler {
      * @return the batch with the given id, or {@code null} if not found
      */
     Batch getBatch(String batchId);
+
+    /**
+     * Attempts to renew the credentials associated to this batch handler.
+     * This is only typically used in third-party batch handlers.
+     *
+     * @param batchId the batch id
+     * @return the new credentials
+     *
+     * @since 11.1
+     */
+    Map<String, Object> refreshToken(String batchId);
 
     /**
      * Callback for the batch handler to execute post-upload actions. This is only typically used in third-party batch

--- a/modules/platform/nuxeo-automation/nuxeo-automation-server/src/main/java/org/nuxeo/ecm/automation/server/jaxrs/batch/handler/impl/DefaultBatchHandler.java
+++ b/modules/platform/nuxeo-automation/nuxeo-automation-server/src/main/java/org/nuxeo/ecm/automation/server/jaxrs/batch/handler/impl/DefaultBatchHandler.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright 2018 Nuxeo SA (http://nuxeo.com/) and others.
+ * (C) Copyright 2018-2020 Nuxeo SA (http://nuxeo.com/) and others.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/platform/nuxeo-automation/nuxeo-automation-server/src/main/java/org/nuxeo/ecm/automation/server/jaxrs/batch/handler/impl/DefaultBatchHandler.java
+++ b/modules/platform/nuxeo-automation/nuxeo-automation-server/src/main/java/org/nuxeo/ecm/automation/server/jaxrs/batch/handler/impl/DefaultBatchHandler.java
@@ -16,6 +16,7 @@
  * Contributors:
  *     Luís Duarte
  *     Florent Guillaume
+ *     Mickaël Schoentgen
  */
 package org.nuxeo.ecm.automation.server.jaxrs.batch.handler.impl;
 
@@ -53,6 +54,11 @@ public class DefaultBatchHandler extends AbstractBatchHandler {
         return fileEntry.getFileSize() == fileInfo.getLength()
                 && Objects.equals(fileEntry.getMimeType(), fileInfo.getMimeType())
                 && Objects.equals(fileEntry.getBlob().getDigest(), fileInfo.getMd5());
+    }
+
+    @Override
+    public Map<String, Object> refreshToken(String batchId) {
+        throw new UnsupportedOperationException("Refresh token is not supported for the default batch handler.");
     }
 
 }

--- a/modules/platform/rest-api/nuxeo-rest-api-server/src/main/java/org/nuxeo/ecm/restapi/server/jaxrs/BatchUploadObject.java
+++ b/modules/platform/rest-api/nuxeo-rest-api-server/src/main/java/org/nuxeo/ecm/restapi/server/jaxrs/BatchUploadObject.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright 2015-2018 Nuxeo (http://nuxeo.com/) and others.
+ * (C) Copyright 2015-2020 Nuxeo (http://nuxeo.com/) and others.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/platform/rest-api/nuxeo-rest-api-test/src/test/java/org/nuxeo/ecm/restapi/test/BatchUploadFixture.java
+++ b/modules/platform/rest-api/nuxeo-rest-api-test/src/test/java/org/nuxeo/ecm/restapi/test/BatchUploadFixture.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright 2015-2019 Nuxeo (http://nuxeo.com/) and others.
+ * (C) Copyright 2015-2020 Nuxeo (http://nuxeo.com/) and others.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/platform/rest-api/nuxeo-rest-api-test/src/test/java/org/nuxeo/ecm/restapi/test/BatchUploadFixture.java
+++ b/modules/platform/rest-api/nuxeo-rest-api-test/src/test/java/org/nuxeo/ecm/restapi/test/BatchUploadFixture.java
@@ -17,11 +17,13 @@
  *     dmetzler
  *     ataillefer
  *     Gabriel Barata
+ *     Mickaël Schoentgen
  */
 package org.nuxeo.ecm.restapi.test;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static javax.servlet.http.HttpServletResponse.SC_FORBIDDEN;
+import static javax.servlet.http.HttpServletResponse.SC_NOT_IMPLEMENTED;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
@@ -1037,6 +1039,17 @@ public class BatchUploadFixture extends BaseTest {
             assertEquals(0, fileEntriesArrayNode.size());
 
             assertEquals(batchId, jsonNode.get("batchId").asText());
+        }
+    }
+
+    /** @since 11.1 */
+    @Test
+    public void testErrorOnRefreshedTokenError() throws Exception {
+        // The default batch handler does not support token renewal.
+        String batchId = initializeNewBatch();
+
+        try (CloseableClientResponse response = getResponse(RequestType.POST, "upload/" + batchId + "/refreshToken")) {
+            assertEquals(SC_NOT_IMPLEMENTED, response.getStatus());
         }
     }
 


### PR DESCRIPTION
The new API can be used from `/upload/{batchId}/refreshToken`. It will return new tokens when the batch handler can handle the request, else it will throw an error.

Note: opening the PR soon to ease discussion.