### PR TITLE
Fix nxp 28709 log silent failure in automation bulk.run action

### DIFF
--- a/modules/platform/nuxeo-automation/nuxeo-automation-server/src/main/java/org/nuxeo/ecm/automation/server/jaxrs/adapters/AsyncOperationAdapter.java
+++ b/modules/platform/nuxeo-automation/nuxeo-automation-server/src/main/java/org/nuxeo/ecm/automation/server/jaxrs/adapters/AsyncOperationAdapter.java
@@ -60,6 +60,7 @@ import org.nuxeo.ecm.core.api.NuxeoException;
 import org.nuxeo.ecm.core.api.NuxeoPrincipal;
 import org.nuxeo.ecm.core.transientstore.api.TransientStore;
 import org.nuxeo.ecm.core.transientstore.api.TransientStoreService;
+import org.nuxeo.ecm.platform.web.common.exceptionhandling.ExceptionHelper;
 import org.nuxeo.ecm.platform.web.common.vh.VirtualHostHelper;
 import org.nuxeo.ecm.webengine.model.WebAdapter;
 import org.nuxeo.ecm.webengine.model.exceptions.WebResourceNotFoundException;
@@ -164,7 +165,7 @@ public class AsyncOperationAdapter extends DefaultAdapter {
 
             @Override
             public OperationException onError(OperationException error) {
-                setError(executionId, error.getMessage());
+                setError(executionId, error);
                 return error;
             }
 
@@ -182,7 +183,7 @@ public class AsyncOperationAdapter extends DefaultAdapter {
                     opCtx.setCoreSession(s);
                     service.run(opCtx, opId, xreq.getParams());
                 } catch (OperationException e) {
-                    setError(executionId, e.getMessage());
+                    setError(executionId, e);
                 } finally {
                     LoginComponent.popPrincipal();
                 }
@@ -200,11 +201,11 @@ public class AsyncOperationAdapter extends DefaultAdapter {
     @GET
     @Path("{executionId}/status")
     public Object status(@PathParam("executionId") String executionId) throws IOException, MessagingException {
+        String error = getError(executionId);
+        if (error != null) {
+            throw new NuxeoException(error, HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
+        }
         if (isCompleted(executionId)) {
-            String error = getError(executionId);
-            if (error != null) {
-                throw new NuxeoException(error, HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
-            }
             String resURL = String.format("%s/%s", getPath(), executionId);
             return redirect(resURL);
         } else {
@@ -289,6 +290,14 @@ public class AsyncOperationAdapter extends DefaultAdapter {
         }
     }
 
+    protected void setError(String executionId, Throwable t) {
+        setError(executionId, ExceptionHelper.unwrapException(t).getMessage());
+    }
+
+    /**
+     * @deprecated since 11.1, because unused
+     */
+    @Deprecated(since = "11.1")
     protected void setError(String executionId, String error) {
         getTransientStore().putParameter(executionId, TRANSIENT_STORE_ERROR, error);
         setCompleted(executionId);

--- a/modules/platform/nuxeo-automation/nuxeo-automation-test/src/test/java/org/nuxeo/ecm/automation/server/test/AsyncOperationAdapterTest.java
+++ b/modules/platform/nuxeo-automation/nuxeo-automation-test/src/test/java/org/nuxeo/ecm/automation/server/test/AsyncOperationAdapterTest.java
@@ -183,7 +183,7 @@ public class AsyncOperationAdapterTest {
                             .set("error", true)
                             .set("rollback", true)
                             .executeReturningExceptionEntity(SC_INTERNAL_SERVER_ERROR);
-        assertEquals("Failed to invoke operation Test.Exit", error);
+        assertEquals("termination error", error);
     }
 
     @Test
@@ -220,6 +220,19 @@ public class AsyncOperationAdapterTest {
                                  .executeReturningDocument();
 
         assertEquals("foo", getTitle(folder));
+    }
+
+    @Test
+    public void testFailingBulkAction() throws Exception {
+        String result = async.newRequest(BulkRunAction.ID) //
+                             .set("action", AutomationBulkAction.ACTION_NAME)
+                             .set("query", "SELECT * FROM Folder")
+                             .set("bucketSize", "10")
+                             .set("batchSize", "5")
+                             .set("parameters", "{}")
+                             .executeReturningExceptionEntity(SC_INTERNAL_SERVER_ERROR);
+        assertTrue(
+                result.startsWith("Unknown operation id null in command: org.nuxeo.ecm.core.bulk.message.BulkCommand"));
     }
 
     /**


### PR DESCRIPTION
setError is called twice.
The second call overrides the first one so it is conditioned.

There is some logic to reconstitute the whole error message. I would rather have changed setError to take the throwable and do this work than just giving it a string.

Then no matter how many times we call setError with the same executionId and throwable, we would always get the same resulting message