### PR TITLE
Fix nxp 29066 Init of the ACL document root occurs many times

### DIFF
--- a/nuxeo-features/nuxeo-platform-audit/nuxeo-platform-audit-core/src/test/java/org/nuxeo/ecm/platform/audit/TestSimpleTemplateBasedRootAudit.java
+++ b/nuxeo-features/nuxeo-platform-audit/nuxeo-platform-audit-core/src/test/java/org/nuxeo/ecm/platform/audit/TestSimpleTemplateBasedRootAudit.java
@@ -1,0 +1,103 @@
+/*
+ * (C) Copyright 2020 Nuxeo (http://nuxeo.com/) and others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Contributors:
+ *     Salem Aouana
+ */
+
+package org.nuxeo.ecm.platform.audit;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import java.io.Serializable;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import javax.inject.Inject;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.nuxeo.ecm.core.api.CoreSession;
+import org.nuxeo.ecm.core.api.DocumentModel;
+import org.nuxeo.ecm.core.api.PathRef;
+import org.nuxeo.ecm.core.api.security.ACE;
+import org.nuxeo.ecm.core.api.security.ACL;
+import org.nuxeo.ecm.core.api.security.ACP;
+import org.nuxeo.ecm.platform.audit.api.LogEntry;
+import org.nuxeo.ecm.platform.query.api.PageProvider;
+import org.nuxeo.ecm.platform.query.api.PageProviderService;
+import org.nuxeo.runtime.test.runner.Deploy;
+import org.nuxeo.runtime.test.runner.Features;
+import org.nuxeo.runtime.test.runner.FeaturesRunner;
+
+/**
+ * The root init acl which happens at
+ * {@link org.nuxeo.ecm.platform.content.template.factories.SimpleTemplateBasedRootFactory}. Should occur only once, at
+ * the beginning when we add the first children of the root document.
+ * <p>
+ * Deploying a new contribution for a given test method, will call the {@code SimpleTemplateBasedRootFactory} for a
+ * second time, but as the root documents already contains children, we should not init the acl of the root document.
+ * 
+ * @since 11.1
+ */
+@RunWith(FeaturesRunner.class)
+@Features(AuditFeature.class)
+public class TestSimpleTemplateBasedRootAudit {
+
+    @Inject
+    protected CoreSession session;
+
+    @Inject
+    protected PageProviderService pps;
+
+    @Test
+    @Deploy("org.nuxeo.ecm.platform.audit.tests:test-add-content-template-contrib.xml")
+    public void shouldInitRootAclOnlyOnce() {
+        DocumentModel root = session.getDocument(new PathRef("/"));
+        @SuppressWarnings("unchecked")
+        PageProvider<LogEntry> pp = (PageProvider<LogEntry>) pps.getPageProvider("DOCUMENT_HISTORY_PROVIDER", null, 3l,
+                0l, new HashMap<String, Serializable>(), root);
+        assertEquals(1, pp.getResultsCount());
+        LogEntry entry = pp.getCurrentEntry();
+        assertEquals("documentSecurityUpdated", entry.getEventId());
+        assertEquals("Root", entry.getDocType());
+        assertEquals("/", entry.getDocPath());
+
+        // Check the permission of the root document
+        ACP acp = root.getACP();
+        assertNotNull(acp);
+        ACL acl = acp.getOrCreateACL();
+        assertNotNull(acl);
+        assertEquals(2, acl.getACEs().length);
+        List<String> users = Arrays.stream(acl.getACEs()).map(ACE::getUsername).collect(Collectors.toList());
+        assertTrue(users.contains("Administrator"));
+        assertTrue(users.contains("members"));
+
+        // Check the permission of the added document template
+        DocumentModel documentModel = session.getDocument(new PathRef("/MyFolderTemplateName"));
+        acp = documentModel.getACP();
+        assertNotNull(acp);
+        acl = acp.getOrCreateACL();
+        assertNotNull(acl);
+        assertEquals(1, acl.getACEs().length);
+        users = Arrays.stream(acl.getACEs()).map(ACE::getUsername).collect(Collectors.toList());
+        assertEquals("John", acl.getACEs()[0].getUsername());
+    }
+
+}

--- a/nuxeo-features/nuxeo-platform-audit/nuxeo-platform-audit-core/src/test/resources/test-add-content-template-contrib.xml
+++ b/nuxeo-features/nuxeo-platform-audit/nuxeo-platform-audit-core/src/test/resources/test-add-content-template-contrib.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0"?>
+<component name="org.nuxeo.retention.contentTemplate">
+
+  <require>
+    org.nuxeo.ecm.platform.content.template.service.ContentTemplateService.defaultContrib
+  </require>
+
+  <extension
+    target="org.nuxeo.ecm.platform.content.template.service.ContentTemplateService"
+    point="factoryBinding">
+
+    <factoryBinding name="MyFactory" factoryName="SimpleTemplateRootFactory"
+                    targetType="Root" append="true">
+      <template>
+        <templateItem typeName="Folder" id="MyFolderTemplateName" title="MyFolderTemplate">
+          <acl>
+            <ace principal="John" permission="Everything"
+                 granted="true" />
+          </acl>
+        </templateItem>
+      </template>
+    </factoryBinding>
+
+  </extension>
+
+</component>


### PR DESCRIPTION
T&P: https://qa2.nuxeo.org/jenkins/job/TestAndPush/job/ondemand-testandpush-saouana-10.10/129/

T&P MongoDB: https://qa2.nuxeo.org/jenkins/job/TestAndPush/job/ondemand-testandpush-saouana-10.10-2/6/

**Context**

Initially this PR was open to fix  [NXP-29048](https://jira.nuxeo.com/browse/NXP-29048) which is a race condition issue that happens only in the test context. But to fix the problem that was initially introduced by the fix [here](https://github.com/nuxeo/nuxeo/commit/8f84864a3bcdf4190b72409d0ff194929b471f85) This new fix allows us to see the problem of the race condition that happens when we add `@Deploy` on the test (see [NXP-29048](https://jira.nuxeo.com/browse/NXP-29048)).

But with the new fix the root acl init will occurs each time, which is not the expected behaviour, we should init the acl only once, as it was before the fix. But we should be able to add new entry in the template.

to recap:
To fix the issue introduced by  [NXP-28958](https://jira.nuxeo.com/browse/NXP-28958) on init the acl many times. I created a new   [NXP-29066](https://jira.nuxeo.com/browse/NXP-29066). 

this fix should also fix the failure test on MongoDB, because now once we `@Deploy` run it will not reinit the Acl for a second time and it will avoid the race condition that occurs. 