### PR TITLE
9.10-HF/fix-NXP-28935-lifecycle-untrash-sub-children

### DIFF
--- a/nuxeo-core/nuxeo-core-api/src/main/java/org/nuxeo/ecm/core/api/LifeCycleConstants.java
+++ b/nuxeo-core/nuxeo-core-api/src/main/java/org/nuxeo/ecm/core/api/LifeCycleConstants.java
@@ -44,7 +44,10 @@ public interface LifeCycleConstants {
 
     /**
      * Event for a document undeleted by the user. Triggers an async listener that undeletes its children too.
+     *
+     * @deprecated since 11.1, technical event used by former trash mechanism
      */
+    @Deprecated
     static final String DOCUMENT_UNDELETED = "documentUndeleted";
 
     /**

--- a/nuxeo-core/nuxeo-core/src/main/java/org/nuxeo/ecm/core/lifecycle/event/BulkLifeCycleChangeListener.java
+++ b/nuxeo-core/nuxeo-core/src/main/java/org/nuxeo/ecm/core/lifecycle/event/BulkLifeCycleChangeListener.java
@@ -18,6 +18,8 @@
  */
 package org.nuxeo.ecm.core.lifecycle.event;
 
+import static org.apache.commons.lang3.StringUtils.isBlank;
+
 import java.util.List;
 
 import org.apache.commons.logging.Log;
@@ -28,11 +30,13 @@ import org.nuxeo.ecm.core.api.DocumentModel;
 import org.nuxeo.ecm.core.api.DocumentModelList;
 import org.nuxeo.ecm.core.api.LifeCycleConstants;
 import org.nuxeo.ecm.core.api.event.CoreEventConstants;
+import org.nuxeo.ecm.core.api.event.DocumentEventCategories;
 import org.nuxeo.ecm.core.api.event.DocumentEventTypes;
 import org.nuxeo.ecm.core.api.impl.DocumentModelListImpl;
 import org.nuxeo.ecm.core.event.Event;
 import org.nuxeo.ecm.core.event.EventBundle;
 import org.nuxeo.ecm.core.event.EventContext;
+import org.nuxeo.ecm.core.event.EventService;
 import org.nuxeo.ecm.core.event.PostCommitEventListener;
 import org.nuxeo.ecm.core.event.impl.DocumentEventContext;
 import org.nuxeo.runtime.api.Framework;
@@ -202,6 +206,14 @@ public class BulkLifeCycleChangeListener implements PostCommitEventListener {
                 }
             } else if (doc.getAllowedStateTransitions().contains(transition) && !doc.isProxy()) {
                 doc.followTransition(transition);
+                // handle children if we're handling the technical documentUndeleted event
+                if (LifeCycleConstants.UNDELETE_TRANSITION.equals(transition) && isBlank(targetState)
+                        && doc.isFolder()) {
+                    DocumentEventContext ctx = new DocumentEventContext(session, session.getPrincipal(), doc);
+                    ctx.setCategory(DocumentEventCategories.EVENT_DOCUMENT_CATEGORY);
+                    Framework.getService(EventService.class)
+                             .fireEvent(ctx.newEvent(LifeCycleConstants.DOCUMENT_UNDELETED));
+                }
             } else {
                 if (targetState.equals(doc.getCurrentLifeCycleState())) {
                     log.debug("Document" + doc.getRef() + " is already in the target LifeCycle state");


### PR DESCRIPTION
PR created from https://qa2.nuxeo.org/jenkins/job/TestAndPush/job/ondemand-testandpush-kleturc-9.10/101/