### PR TITLE
NXP-29113: better logging on explorer

### DIFF
--- a/modules/platform/nuxeo-apidoc-server/nuxeo-apidoc-core/pom.xml
+++ b/modules/platform/nuxeo-apidoc-server/nuxeo-apidoc-core/pom.xml
@@ -15,10 +15,6 @@
 
   <dependencies>
     <dependency>
-      <groupId>com.cforcoding.jmd</groupId>
-      <artifactId>jmd</artifactId>
-    </dependency>
-    <dependency>
       <groupId>commons-io</groupId>
       <artifactId>commons-io</artifactId>
     </dependency>

--- a/modules/platform/nuxeo-apidoc-server/nuxeo-apidoc-core/src/main/java/org/nuxeo/apidoc/adapters/BaseNuxeoArtifactDocAdapter.java
+++ b/modules/platform/nuxeo-apidoc-server/nuxeo-apidoc-core/src/main/java/org/nuxeo/apidoc/adapters/BaseNuxeoArtifactDocAdapter.java
@@ -24,8 +24,8 @@ import java.util.Collections;
 import java.util.List;
 
 import org.apache.commons.lang3.StringUtils;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.nuxeo.apidoc.api.BaseNuxeoArtifact;
 import org.nuxeo.apidoc.api.NuxeoArtifact;
 import org.nuxeo.apidoc.snapshot.DistributionSnapshot;
@@ -39,7 +39,7 @@ import org.nuxeo.ecm.core.api.PropertyException;
 
 public abstract class BaseNuxeoArtifactDocAdapter extends BaseNuxeoArtifact {
 
-    protected static final Log log = LogFactory.getLog(BaseNuxeoArtifactDocAdapter.class);
+    private static final Logger log = LogManager.getLogger(BaseNuxeoArtifactDocAdapter.class);
 
     protected final DocumentModel doc;
 

--- a/modules/platform/nuxeo-apidoc-server/nuxeo-apidoc-core/src/main/java/org/nuxeo/apidoc/adapters/BundleGroupDocAdapter.java
+++ b/modules/platform/nuxeo-apidoc-server/nuxeo-apidoc-core/src/main/java/org/nuxeo/apidoc/adapters/BundleGroupDocAdapter.java
@@ -24,6 +24,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.nuxeo.apidoc.api.BundleGroup;
 import org.nuxeo.apidoc.api.BundleInfo;
 import org.nuxeo.apidoc.api.NuxeoArtifact;
@@ -37,6 +39,8 @@ import org.nuxeo.ecm.core.api.DocumentModelList;
 import org.nuxeo.ecm.core.api.PathRef;
 
 public class BundleGroupDocAdapter extends BaseNuxeoArtifactDocAdapter implements BundleGroup {
+
+    private static final Logger log = LogManager.getLogger(BundleGroupDocAdapter.class);
 
     public static BundleGroupDocAdapter create(BundleGroup bundleGroup, CoreSession session, String containerPath) {
 

--- a/modules/platform/nuxeo-apidoc-server/nuxeo-apidoc-core/src/main/java/org/nuxeo/apidoc/adapters/ComponentInfoDocAdapter.java
+++ b/modules/platform/nuxeo-apidoc-server/nuxeo-apidoc-core/src/main/java/org/nuxeo/apidoc/adapters/ComponentInfoDocAdapter.java
@@ -24,6 +24,8 @@ import java.net.URL;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.nuxeo.apidoc.api.BundleInfo;
 import org.nuxeo.apidoc.api.ComponentInfo;
 import org.nuxeo.apidoc.api.ExtensionInfo;
@@ -41,6 +43,8 @@ import org.nuxeo.ecm.core.api.DocumentModelList;
 import org.nuxeo.ecm.core.api.PathRef;
 
 public class ComponentInfoDocAdapter extends BaseNuxeoArtifactDocAdapter implements ComponentInfo {
+
+    private static final Logger log = LogManager.getLogger(ComponentInfoDocAdapter.class);
 
     public ComponentInfoDocAdapter(DocumentModel doc) {
         super(doc);

--- a/modules/platform/nuxeo-apidoc-server/nuxeo-apidoc-core/src/main/java/org/nuxeo/apidoc/adapters/ExtensionInfoDocAdapter.java
+++ b/modules/platform/nuxeo-apidoc-server/nuxeo-apidoc-core/src/main/java/org/nuxeo/apidoc/adapters/ExtensionInfoDocAdapter.java
@@ -22,6 +22,8 @@ import java.io.Serializable;
 import java.util.Collections;
 import java.util.List;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.dom4j.DocumentException;
 import org.nuxeo.apidoc.api.BundleInfo;
 import org.nuxeo.apidoc.api.ComponentInfo;
@@ -40,6 +42,8 @@ import org.nuxeo.ecm.core.api.PathRef;
 import org.nuxeo.runtime.model.ComponentName;
 
 public class ExtensionInfoDocAdapter extends BaseNuxeoArtifactDocAdapter implements ExtensionInfo {
+
+    private static final Logger log = LogManager.getLogger(ExtensionInfoDocAdapter.class);
 
     public static ExtensionInfoDocAdapter create(ExtensionInfo xi, int index, CoreSession session,
             String containerPath) {

--- a/modules/platform/nuxeo-apidoc-server/nuxeo-apidoc-core/src/main/java/org/nuxeo/apidoc/adapters/ExtensionPointInfoDocAdapter.java
+++ b/modules/platform/nuxeo-apidoc-server/nuxeo-apidoc-core/src/main/java/org/nuxeo/apidoc/adapters/ExtensionPointInfoDocAdapter.java
@@ -21,6 +21,8 @@ package org.nuxeo.apidoc.adapters;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.nuxeo.apidoc.api.BundleInfo;
 import org.nuxeo.apidoc.api.ComponentInfo;
 import org.nuxeo.apidoc.api.ExtensionInfo;
@@ -38,6 +40,8 @@ import org.nuxeo.ecm.core.api.PathRef;
 import org.nuxeo.ecm.core.api.PropertyException;
 
 public class ExtensionPointInfoDocAdapter extends BaseNuxeoArtifactDocAdapter implements ExtensionPointInfo {
+
+    private static final Logger log = LogManager.getLogger(ExtensionPointInfoDocAdapter.class);
 
     public static ExtensionPointInfoDocAdapter create(ExtensionPointInfo xpi, CoreSession session,
             String containerPath) {

--- a/modules/platform/nuxeo-apidoc-server/nuxeo-apidoc-core/src/main/java/org/nuxeo/apidoc/adapters/ServiceInfoDocAdapter.java
+++ b/modules/platform/nuxeo-apidoc-server/nuxeo-apidoc-core/src/main/java/org/nuxeo/apidoc/adapters/ServiceInfoDocAdapter.java
@@ -18,6 +18,8 @@
  */
 package org.nuxeo.apidoc.adapters;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.nuxeo.apidoc.api.BundleInfo;
 import org.nuxeo.apidoc.api.ComponentInfo;
 import org.nuxeo.apidoc.api.NuxeoArtifact;
@@ -29,6 +31,8 @@ import org.nuxeo.ecm.core.api.DocumentModel;
 import org.nuxeo.ecm.core.api.PathRef;
 
 public class ServiceInfoDocAdapter extends BaseNuxeoArtifactDocAdapter implements ServiceInfo {
+
+    private static final Logger log = LogManager.getLogger(ServiceInfoDocAdapter.class);
 
     public ServiceInfoDocAdapter(DocumentModel doc) {
         super(doc);

--- a/modules/platform/nuxeo-apidoc-server/nuxeo-apidoc-core/src/main/java/org/nuxeo/apidoc/introspection/BundleIdReader.java
+++ b/modules/platform/nuxeo-apidoc-server/nuxeo-apidoc-core/src/main/java/org/nuxeo/apidoc/introspection/BundleIdReader.java
@@ -29,12 +29,12 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 public class BundleIdReader {
 
-    private static final Log log = LogFactory.getLog(BundleIdReader.class);
+    private static final Logger log = LogManager.getLogger(BundleIdReader.class);
 
     protected final Map<String, Long> ids = new HashMap<>();
 

--- a/modules/platform/nuxeo-apidoc-server/nuxeo-apidoc-core/src/main/java/org/nuxeo/apidoc/introspection/ComponentInfoImpl.java
+++ b/modules/platform/nuxeo-apidoc-server/nuxeo-apidoc-core/src/main/java/org/nuxeo/apidoc/introspection/ComponentInfoImpl.java
@@ -33,8 +33,8 @@ import java.util.zip.ZipFile;
 
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.nuxeo.apidoc.api.BaseNuxeoArtifact;
 import org.nuxeo.apidoc.api.BundleInfo;
 import org.nuxeo.apidoc.api.ComponentInfo;
@@ -48,6 +48,8 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 public class ComponentInfoImpl extends BaseNuxeoArtifact implements ComponentInfo {
+
+    private static final Logger log = LogManager.getLogger(ComponentInfoImpl.class);
 
     protected final BundleInfo bundle;
 
@@ -73,8 +75,6 @@ public class ComponentInfoImpl extends BaseNuxeoArtifact implements ComponentInf
     protected String componentClass;
 
     protected String documentation;
-
-    protected static final Log log = LogFactory.getLog(ComponentInfoImpl.class);
 
     public ComponentInfoImpl(BundleInfo bundleInfo, String name) {
         bundle = bundleInfo;

--- a/modules/platform/nuxeo-apidoc-server/nuxeo-apidoc-core/src/main/java/org/nuxeo/apidoc/introspection/ExtensionInfoImpl.java
+++ b/modules/platform/nuxeo-apidoc-server/nuxeo-apidoc-core/src/main/java/org/nuxeo/apidoc/introspection/ExtensionInfoImpl.java
@@ -22,8 +22,8 @@ package org.nuxeo.apidoc.introspection;
 import java.util.Collections;
 import java.util.List;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.dom4j.DocumentException;
 import org.nuxeo.apidoc.api.BaseNuxeoArtifact;
 import org.nuxeo.apidoc.api.ComponentInfo;
@@ -40,7 +40,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 
 public class ExtensionInfoImpl extends BaseNuxeoArtifact implements ExtensionInfo {
 
-    protected static final Log log = LogFactory.getLog(ExtensionInfoImpl.class);
+    private static final Logger log = LogManager.getLogger(ExtensionInfoImpl.class);
 
     protected final String id;
 

--- a/modules/platform/nuxeo-apidoc-server/nuxeo-apidoc-core/src/main/java/org/nuxeo/apidoc/introspection/ServerInfo.java
+++ b/modules/platform/nuxeo-apidoc-server/nuxeo-apidoc-core/src/main/java/org/nuxeo/apidoc/introspection/ServerInfo.java
@@ -51,8 +51,8 @@ import javax.xml.xpath.XPathException;
 import javax.xml.xpath.XPathFactory;
 
 import org.apache.commons.io.IOUtils;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.nuxeo.apidoc.api.BundleInfo;
 import org.nuxeo.apidoc.documentation.DocumentationHelper;
 import org.nuxeo.common.Environment;
@@ -117,7 +117,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
  */
 public class ServerInfo {
 
-    private static final Log log = LogFactory.getLog(ServerInfo.class);
+    private static final Logger log = LogManager.getLogger(ServerInfo.class);
 
     public static final String META_INF_MANIFEST_MF = "META-INF/MANIFEST.MF";
 

--- a/modules/platform/nuxeo-apidoc-server/nuxeo-apidoc-core/src/main/java/org/nuxeo/apidoc/repository/RepositoryDistributionSnapshot.java
+++ b/modules/platform/nuxeo-apidoc-server/nuxeo-apidoc-core/src/main/java/org/nuxeo/apidoc/repository/RepositoryDistributionSnapshot.java
@@ -30,6 +30,8 @@ import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.nuxeo.apidoc.adapters.BaseNuxeoArtifactDocAdapter;
 import org.nuxeo.apidoc.api.BundleGroup;
 import org.nuxeo.apidoc.api.BundleInfo;
@@ -58,6 +60,8 @@ import org.nuxeo.runtime.api.Framework;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 public class RepositoryDistributionSnapshot extends BaseNuxeoArtifactDocAdapter implements DistributionSnapshot {
+
+    private static final Logger log = LogManager.getLogger(RepositoryDistributionSnapshot.class);
 
     protected JavaDocHelper jdocHelper = null;
 

--- a/modules/platform/nuxeo-apidoc-server/nuxeo-apidoc-core/src/main/java/org/nuxeo/apidoc/repository/SnapshotPersister.java
+++ b/modules/platform/nuxeo-apidoc-server/nuxeo-apidoc-core/src/main/java/org/nuxeo/apidoc/repository/SnapshotPersister.java
@@ -25,8 +25,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.nuxeo.apidoc.adapters.BundleGroupDocAdapter;
 import org.nuxeo.apidoc.adapters.BundleInfoDocAdapter;
 import org.nuxeo.apidoc.adapters.ComponentInfoDocAdapter;
@@ -54,6 +54,8 @@ import org.nuxeo.ecm.core.api.PathRef;
 
 public class SnapshotPersister {
 
+    private static final Logger log = LogManager.getLogger(SnapshotPersister.class);
+
     public static final String Root_PATH = "/";
 
     public static final String Root_NAME = "nuxeo-distributions";
@@ -65,8 +67,6 @@ public class SnapshotPersister {
     public static final String Read_Grp = "Everyone";
 
     public static final String Write_Grp = "members";
-
-    protected static final Log log = LogFactory.getLog(SnapshotPersister.class);
 
     public DocumentModel getSubRoot(CoreSession session, DocumentModel root, String name) {
 

--- a/modules/platform/nuxeo-apidoc-server/nuxeo-apidoc-core/src/main/java/org/nuxeo/apidoc/snapshot/SnapshotManagerComponent.java
+++ b/modules/platform/nuxeo-apidoc-server/nuxeo-apidoc-core/src/main/java/org/nuxeo/apidoc/snapshot/SnapshotManagerComponent.java
@@ -37,8 +37,8 @@ import java.util.Map;
 
 import javax.servlet.http.HttpServletRequest;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.nuxeo.apidoc.api.BundleGroup;
 import org.nuxeo.apidoc.api.BundleInfo;
 import org.nuxeo.apidoc.api.ComponentInfo;
@@ -73,7 +73,7 @@ import org.nuxeo.runtime.model.DefaultComponent;
 
 public class SnapshotManagerComponent extends DefaultComponent implements SnapshotManager {
 
-    private static final Log log = LogFactory.getLog(SnapshotManagerComponent.class);
+    private static final Logger log = LogManager.getLogger(SnapshotManagerComponent.class);
 
     /**
      * ArtifactSearcher service, moved from removed documentation service.

--- a/modules/platform/nuxeo-apidoc-server/nuxeo-apidoc-webengine/pom.xml
+++ b/modules/platform/nuxeo-apidoc-server/nuxeo-apidoc-webengine/pom.xml
@@ -35,13 +35,9 @@
       <groupId>javax.transaction</groupId>
       <artifactId>javax.transaction-api</artifactId>
     </dependency>
-     <dependency>
+    <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-lang3</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.wikimodel</groupId>
-      <artifactId>wem</artifactId>
     </dependency>
 
     <dependency>

--- a/modules/platform/nuxeo-apidoc-server/nuxeo-apidoc-webengine/src/main/java/org/nuxeo/apidoc/browse/Distribution.java
+++ b/modules/platform/nuxeo-apidoc-server/nuxeo-apidoc-webengine/src/main/java/org/nuxeo/apidoc/browse/Distribution.java
@@ -53,8 +53,8 @@ import javax.ws.rs.Produces;
 import javax.ws.rs.core.Response;
 
 import org.apache.commons.lang3.StringUtils;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.nuxeo.apidoc.export.ArchiveFile;
 import org.nuxeo.apidoc.listener.AttributesExtractorStater;
 import org.nuxeo.apidoc.plugin.Plugin;
@@ -89,9 +89,9 @@ import org.nuxeo.runtime.transaction.TransactionHelper;
 @WebObject(type = "distribution")
 public class Distribution extends ModuleRoot {
 
-    public static final String DIST_ID = "distId";
+    private static final Logger log = LogManager.getLogger(Distribution.class);
 
-    protected static final Log log = LogFactory.getLog(Distribution.class);
+    public static final String DIST_ID = "distId";
 
     protected static final Pattern VERSION_REGEX = Pattern.compile("^(\\d+)(?:\\.(\\d+))?(?:\\.(\\d+))?(?:-.*)?$",
             Pattern.CASE_INSENSITIVE);

--- a/modules/platform/nuxeo-apidoc-server/nuxeo-apidoc-webengine/src/main/java/org/nuxeo/apidoc/tree/TreeHelper.java
+++ b/modules/platform/nuxeo-apidoc-server/nuxeo-apidoc-webengine/src/main/java/org/nuxeo/apidoc/tree/TreeHelper.java
@@ -20,8 +20,8 @@ package org.nuxeo.apidoc.tree;
 
 import javax.servlet.http.HttpSession;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.nuxeo.apidoc.adapters.BaseNuxeoArtifactDocAdapter;
 import org.nuxeo.apidoc.snapshot.DistributionSnapshot;
 import org.nuxeo.apidoc.snapshot.SnapshotManager;
@@ -32,7 +32,7 @@ import org.nuxeo.runtime.api.Framework;
 
 public class TreeHelper {
 
-    protected static final Log log = LogFactory.getLog(TreeHelper.class);
+    private static final Logger log = LogManager.getLogger(TreeHelper.class);
 
     public static NuxeoArtifactTree getOrBuildAnonymousTree(WebContext ctx) {
         NuxeoArtifactTree tree = (NuxeoArtifactTree) ctx.getRequest()

--- a/pom.xml
+++ b/pom.xml
@@ -5405,8 +5405,13 @@
           <configuration>
             <ignoredUnusedDeclaredDependencies>
               <artifact>org.apache.logging.log4j:log4j-api</artifact>
-              <artifact>junit:junit</artifact>
+              <artifact>org.apache.logging.log4j:log4j-core</artifact>
+              <artifact>org.apache.logging.log4j:log4j-jcl</artifact>
+              <artifact>org.apache.logging.log4j:log4j-slf4j-impl</artifact>
+              <artifact>org.apache.logging.log4j:log4j-1.2-api</artifact>
               <artifact>commons-logging:commons-logging</artifact>
+              <artifact>junit:junit</artifact>
+              <artifact>org.assertj:assertj-core</artifact>
             </ignoredUnusedDeclaredDependencies>
           </configuration>
         </plugin>


### PR DESCRIPTION
Took that opportunity to update maven-dependency-plugin configurations to remove noise when running "mvn dependency:analyze" (on log and test libraries).

T&P running at https://qa.nuxeo.org/jenkins/job/TestAndPush/job/ondemand-testandpush-atchertchian-master-3/9/