### PR TITLE
NXP-29107: make explorer ftest using new window more robust

### DIFF
--- a/ftests/nuxeo-platform-explorer-ftests/src/test/java/org/nuxeo/functionaltests/explorer/AbstractExplorerTest.java
+++ b/ftests/nuxeo-platform-explorer-ftests/src/test/java/org/nuxeo/functionaltests/explorer/AbstractExplorerTest.java
@@ -41,6 +41,11 @@ import org.nuxeo.functionaltests.explorer.pages.artifacts.ExtensionPointArtifact
 import org.nuxeo.functionaltests.explorer.pages.artifacts.OperationArtifactPage;
 import org.nuxeo.functionaltests.explorer.pages.artifacts.ServiceArtifactPage;
 import org.openqa.selenium.By;
+import org.openqa.selenium.StaleElementReferenceException;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.support.ui.Wait;
+
+import com.google.common.base.Function;
 
 /**
  * @since 11.1
@@ -196,9 +201,25 @@ public abstract class AbstractExplorerTest extends AbstractTest {
     }
 
     protected void switchToNewWindow() {
-        for (String winHandle : driver.getWindowHandles()) {
-            driver.switchTo().window(winHandle);
+        Wait<WebDriver> wait = Locator.getFluentWait();
+        wait.until((new Function<WebDriver, Boolean>() {
+            @Override
+            public Boolean apply(WebDriver driver) {
+                try {
+                    // wait for one more window to be opened
+                    return driver.getWindowHandles().size() > 1;
+                } catch (StaleElementReferenceException e) {
+                    return null;
+                }
+            }
+        }));
+        // select last handle
+        String handle = null;
+        for (String h : driver.getWindowHandles()) {
+            handle = h;
         }
+        // switch to it
+        driver.switchTo().window(handle);
     }
 
     protected void switchBackToPreviousWindow() {

--- a/ftests/nuxeo-platform-explorer-ftests/src/test/java/org/nuxeo/functionaltests/explorer/ITExplorerTest.java
+++ b/ftests/nuxeo-platform-explorer-ftests/src/test/java/org/nuxeo/functionaltests/explorer/ITExplorerTest.java
@@ -23,7 +23,6 @@ import java.io.IOException;
 
 import org.junit.After;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.nuxeo.apidoc.api.BundleGroup;
 import org.nuxeo.apidoc.api.BundleInfo;
@@ -203,7 +202,6 @@ public class ITExplorerTest extends AbstractExplorerTest {
         apage.checkAlternative();
     }
 
-    @Ignore("Failing randomly: see NXP-29107")
     @Test
     public void testBundleGroups() {
         ExplorerHomePage home = goHome();
@@ -233,7 +231,6 @@ public class ITExplorerTest extends AbstractExplorerTest {
         switchBackToPreviousWindow();
     }
 
-    @Ignore("Failing randomly: see NXP-29107")
     @Test
     public void testOverrideContributionFromExtensionPoint() throws IOException {
         goToArtifact(ExtensionPointInfo.TYPE_NAME, "org.nuxeo.ecm.core.event.EventServiceComponent--listener");


### PR DESCRIPTION
Try to avoid random failure for new tests.

T&P at https://qa.nuxeo.org/jenkins/job/TestAndPush/job/ondemand-testandpush-atchertchian-master/217/ passed but did not create a PR because of merging conflict (linked to other changes merged in the meantime).

Launched again (without unit tests) at https://qa.nuxeo.org/jenkins/job/TestAndPush/job/ondemand-testandpush-atchertchian-master/218/ just in case it still catches a random failure.