### PR TITLE
NXP-29118: fix Redis SSL support

### DIFF
--- a/modules/runtime/nuxeo-runtime-redis/src/main/java/org/nuxeo/ecm/core/redis/RedisServerDescriptor.java
+++ b/modules/runtime/nuxeo-runtime-redis/src/main/java/org/nuxeo/ecm/core/redis/RedisServerDescriptor.java
@@ -111,7 +111,7 @@ public class RedisServerDescriptor extends RedisPoolDescriptor {
         conf.setMaxTotal(maxTotal);
         conf.setMaxIdle(maxIdle);
         RedisExecutor base = new RedisPoolExecutor(new JedisPool(conf, host, port, timeout,
-                StringUtils.defaultIfBlank(password, null), database));
+                StringUtils.defaultIfBlank(password, null), database, useSSL, sslSocketFactory, null, null));
         return new RedisFailoverExecutor(failoverTimeout, base);
     }
 


### PR DESCRIPTION
SSL support for Redis (non HA) does not seem to be complete. The [ping attempt](https://github.com/nuxeo/nuxeo/blob/v11.1.24/modules/runtime/nuxeo-runtime-redis/src/main/java/org/nuxeo/ecm/core/redis/RedisServerDescriptor.java#L100) uses SSL as expected, but the [pool creation](https://github.com/nuxeo/nuxeo/blob/v11.1.24/modules/runtime/nuxeo-runtime-redis/src/main/java/org/nuxeo/ecm/core/redis/RedisServerDescriptor.java#L113) ignores SSL.

This issues prevents the use of Azure Redis Cache for example (unless SSL is disabled server-side, of course).

A backport to 10.10 would be appreciated, I can open another PR on that branch if needed.