### PR TITLE
NXP-29151: use HTTP code 400 instead of 500 for Automation request parsing errors (10.10)

### DIFF
--- a/nuxeo-features/nuxeo-automation/nuxeo-automation-io/pom.xml
+++ b/nuxeo-features/nuxeo-automation/nuxeo-automation-io/pom.xml
@@ -72,6 +72,10 @@
       <artifactId>commons-lang3</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.apache.httpcomponents</groupId>
+      <artifactId>httpcore</artifactId>
+    </dependency>
+    <dependency>
       <groupId>javax.mail</groupId>
       <artifactId>mail</artifactId>
     </dependency>
@@ -136,11 +140,6 @@
     <dependency>
       <groupId>org.nuxeo.ecm.platform</groupId>
       <artifactId>nuxeo-platform-audit-core</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.httpcomponents</groupId>
-      <artifactId>httpcore</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/nuxeo-features/nuxeo-automation/nuxeo-automation-io/src/main/java/org/nuxeo/ecm/automation/jaxrs/io/documents/BusinessAdapterReader.java
+++ b/nuxeo-features/nuxeo-automation/nuxeo-automation-io/src/main/java/org/nuxeo/ecm/automation/jaxrs/io/documents/BusinessAdapterReader.java
@@ -18,6 +18,8 @@
  */
 package org.nuxeo.ecm.automation.jaxrs.io.documents;
 
+import static org.apache.http.HttpStatus.SC_BAD_REQUEST;
+
 import java.io.IOException;
 import java.io.InputStream;
 import java.lang.annotation.Annotation;
@@ -42,6 +44,7 @@ import org.nuxeo.runtime.api.Framework;
 
 import com.fasterxml.jackson.core.JsonFactory;
 import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 
 /**
@@ -100,11 +103,11 @@ public class BusinessAdapterReader implements MessageBodyReader<BusinessAdapter>
 
     public BusinessAdapter readRequest0(String content, MultivaluedMap<String, String> headers) throws IOException {
         ObjectCodecService codecService = Framework.getService(ObjectCodecService.class);
-
         try (JsonParser jp = factory.createParser(content)) {
             JsonNode inputNode = jp.readValueAsTree();
-
             return (BusinessAdapter) codecService.readNode(inputNode, getCoreSession());
+        } catch (JsonProcessingException e) {
+            throw new WebApplicationException(e, SC_BAD_REQUEST);
         }
 
     }

--- a/nuxeo-features/nuxeo-automation/nuxeo-automation-io/src/main/java/org/nuxeo/ecm/automation/jaxrs/io/operations/JsonRequestReader.java
+++ b/nuxeo-features/nuxeo-automation/nuxeo-automation-io/src/main/java/org/nuxeo/ecm/automation/jaxrs/io/operations/JsonRequestReader.java
@@ -18,6 +18,8 @@
  */
 package org.nuxeo.ecm.automation.jaxrs.io.operations;
 
+import static org.apache.http.HttpStatus.SC_BAD_REQUEST;
+
 import java.io.IOException;
 import java.io.InputStream;
 import java.lang.annotation.Annotation;
@@ -30,7 +32,6 @@ import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.MultivaluedMap;
-import javax.ws.rs.core.Response;
 import javax.ws.rs.ext.MessageBodyReader;
 import javax.ws.rs.ext.Provider;
 
@@ -43,6 +44,7 @@ import org.nuxeo.runtime.api.Framework;
 
 import com.fasterxml.jackson.core.JsonFactory;
 import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.JsonToken;
 import com.fasterxml.jackson.databind.JsonNode;
 
@@ -119,7 +121,7 @@ public class JsonRequestReader implements MessageBodyReader<ExecutionRequest> {
         // LE)
         String content = IOUtils.toString(in, "UTF-8");
         if (content.isEmpty()) {
-            throw new WebApplicationException(Response.Status.BAD_REQUEST);
+            throw new WebApplicationException(SC_BAD_REQUEST);
         }
         return readRequest(content, headers, session);
     }
@@ -137,10 +139,11 @@ public class JsonRequestReader implements MessageBodyReader<ExecutionRequest> {
 
     public ExecutionRequest readRequest0(String content, MultivaluedMap<String, String> headers, CoreSession session)
             throws IOException {
-
-        JsonParser jp = factory.createJsonParser(content);
-
-        return readRequest(jp, headers, session);
+        try (JsonParser jp = factory.createParser(content)) {
+            return readRequest(jp, headers, session);
+        } catch (JsonProcessingException e) {
+            throw new WebApplicationException(e, SC_BAD_REQUEST);
+        }
     }
 
     /**

--- a/nuxeo-features/nuxeo-automation/nuxeo-automation-io/src/main/java/org/nuxeo/ecm/automation/jaxrs/io/operations/UrlEncodedFormRequestReader.java
+++ b/nuxeo-features/nuxeo-automation/nuxeo-automation-io/src/main/java/org/nuxeo/ecm/automation/jaxrs/io/operations/UrlEncodedFormRequestReader.java
@@ -18,6 +18,8 @@
  */
 package org.nuxeo.ecm.automation.jaxrs.io.operations;
 
+import static org.apache.http.HttpStatus.SC_BAD_REQUEST;
+
 import java.io.IOException;
 import java.io.InputStream;
 import java.lang.annotation.Annotation;
@@ -30,7 +32,6 @@ import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.MultivaluedMap;
-import javax.ws.rs.core.Response;
 import javax.ws.rs.ext.MessageBodyReader;
 import javax.ws.rs.ext.Provider;
 
@@ -41,6 +42,7 @@ import org.nuxeo.ecm.webengine.jaxrs.session.SessionFactory;
 
 import com.fasterxml.jackson.core.JsonFactory;
 import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonProcessingException;
 
 /**
  * Reads {@link ExecutionRequest} from a urlencoded POST (Needed for OAuth calls)
@@ -90,11 +92,10 @@ public class UrlEncodedFormRequestReader implements MessageBodyReader<ExecutionR
         if (jsonString == null) {
             return null;
         }
-        JsonParser jp = factory.createJsonParser(jsonString);
-        try {
+        try (JsonParser jp = factory.createParser(jsonString)) {
             return JsonRequestReader.readRequest(jp, httpHeaders, getCoreSession());
-        } catch (IOException e) {
-            throw new WebApplicationException(Response.Status.INTERNAL_SERVER_ERROR.getStatusCode());
+        } catch (JsonProcessingException e) {
+            throw new WebApplicationException(e, SC_BAD_REQUEST);
         }
     }
 


### PR DESCRIPTION
Unit tests aren't backported due to the complexity of the task. (10.10 uses nuxeo-automation-client, whereas 11.x uses a much smaller custom framework that's easier to modify to test invalid inputs.)