### PR TITLE
NXP-29151: use HTTP code 400 instead of 500 for Automation request parsing errors (9.10)

### DIFF
--- a/nuxeo-features/nuxeo-automation/nuxeo-automation-io/pom.xml
+++ b/nuxeo-features/nuxeo-automation/nuxeo-automation-io/pom.xml
@@ -68,6 +68,10 @@
       <artifactId>commons-lang</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.apache.httpcomponents</groupId>
+      <artifactId>httpcore</artifactId>
+    </dependency>
+    <dependency>
       <groupId>javax.mail</groupId>
       <artifactId>mail</artifactId>
     </dependency>
@@ -132,11 +136,6 @@
     <dependency>
       <groupId>org.nuxeo.ecm.platform</groupId>
       <artifactId>nuxeo-platform-audit-core</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.httpcomponents</groupId>
-      <artifactId>httpcore</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/nuxeo-features/nuxeo-automation/nuxeo-automation-io/src/main/java/org/nuxeo/ecm/automation/jaxrs/io/documents/BusinessAdapterReader.java
+++ b/nuxeo-features/nuxeo-automation/nuxeo-automation-io/src/main/java/org/nuxeo/ecm/automation/jaxrs/io/documents/BusinessAdapterReader.java
@@ -18,6 +18,8 @@
  */
 package org.nuxeo.ecm.automation.jaxrs.io.documents;
 
+import static org.apache.http.HttpStatus.SC_BAD_REQUEST;
+
 import java.io.IOException;
 import java.io.InputStream;
 import java.lang.annotation.Annotation;
@@ -37,6 +39,7 @@ import org.apache.commons.io.IOUtils;
 import org.codehaus.jackson.JsonFactory;
 import org.codehaus.jackson.JsonNode;
 import org.codehaus.jackson.JsonParser;
+import org.codehaus.jackson.JsonProcessingException;
 import org.nuxeo.ecm.automation.core.operations.business.adapter.BusinessAdapter;
 import org.nuxeo.ecm.automation.io.services.codec.ObjectCodecService;
 import org.nuxeo.ecm.core.api.CoreSession;
@@ -99,11 +102,12 @@ public class BusinessAdapterReader implements MessageBodyReader<BusinessAdapter>
 
     public BusinessAdapter readRequest0(String content, MultivaluedMap<String, String> headers) throws IOException {
         ObjectCodecService codecService = Framework.getService(ObjectCodecService.class);
-
-        JsonParser jp = factory.createJsonParser(content);
-        JsonNode inputNode = jp.readValueAsTree();
-
-        return (BusinessAdapter) codecService.readNode(inputNode, getCoreSession());
+        try (JsonParser jp = factory.createJsonParser(content)) {
+            JsonNode inputNode = jp.readValueAsTree();
+            return (BusinessAdapter) codecService.readNode(inputNode, getCoreSession());
+        } catch (JsonProcessingException e) {
+            throw new WebApplicationException(e, SC_BAD_REQUEST);
+        }
 
     }
 

--- a/nuxeo-features/nuxeo-automation/nuxeo-automation-io/src/main/java/org/nuxeo/ecm/automation/jaxrs/io/operations/UrlEncodedFormRequestReader.java
+++ b/nuxeo-features/nuxeo-automation/nuxeo-automation-io/src/main/java/org/nuxeo/ecm/automation/jaxrs/io/operations/UrlEncodedFormRequestReader.java
@@ -18,6 +18,8 @@
  */
 package org.nuxeo.ecm.automation.jaxrs.io.operations;
 
+import static org.apache.http.HttpStatus.SC_BAD_REQUEST;
+
 import java.io.IOException;
 import java.io.InputStream;
 import java.lang.annotation.Annotation;
@@ -30,13 +32,13 @@ import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.MultivaluedMap;
-import javax.ws.rs.core.Response;
 import javax.ws.rs.ext.MessageBodyReader;
 import javax.ws.rs.ext.Provider;
 
 import org.apache.commons.io.IOUtils;
 import org.codehaus.jackson.JsonFactory;
 import org.codehaus.jackson.JsonParser;
+import org.codehaus.jackson.JsonProcessingException;
 import org.nuxeo.ecm.core.api.CoreSession;
 import org.nuxeo.ecm.webengine.jaxrs.context.RequestContext;
 import org.nuxeo.ecm.webengine.jaxrs.session.SessionFactory;
@@ -89,11 +91,10 @@ public class UrlEncodedFormRequestReader implements MessageBodyReader<ExecutionR
         if (jsonString == null) {
             return null;
         }
-        JsonParser jp = factory.createJsonParser(jsonString);
-        try {
+        try (JsonParser jp = factory.createJsonParser(jsonString)) {
             return JsonRequestReader.readRequest(jp, httpHeaders, getCoreSession());
-        } catch (IOException e) {
-            throw new WebApplicationException(Response.Status.INTERNAL_SERVER_ERROR.getStatusCode());
+        } catch (JsonProcessingException e) {
+            throw new WebApplicationException(e, SC_BAD_REQUEST);
         }
     }
 


### PR DESCRIPTION
Unit tests aren't backported due to the complexity of the task. (9.10 uses nuxeo-automation-client, whereas 11.x uses a much smaller custom framework that's easier to modify to test invalid inputs.)
