### PR TITLE
NXP-29067: add the command line name to the created tmp directory

### DIFF
--- a/modules/core/nuxeo-core-convert-plugins/src/main/java/org/nuxeo/ecm/platform/convert/plugins/CommandLineConverter.java
+++ b/modules/core/nuxeo-core-convert-plugins/src/main/java/org/nuxeo/ecm/platform/convert/plugins/CommandLineConverter.java
@@ -31,6 +31,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import org.nuxeo.common.utils.FileUtils;
 import org.nuxeo.ecm.core.api.Blob;
 import org.nuxeo.ecm.core.api.Blobs;
 import org.nuxeo.ecm.core.api.blobholder.BlobHolder;
@@ -91,8 +92,9 @@ public class CommandLineConverter extends CommandLineBasedConverter {
         String tmpDir = getTmpDirectory(parameters);
         Path tmpDirPath = tmpDir != null ? Paths.get(tmpDir) : null;
         try {
-            Path outDirPath = tmpDirPath != null ? Files.createTempDirectory(tmpDirPath, null)
-                    : Framework.createTempDirectory(null);
+            String prefix = String.format("clc-%s-", FileUtils.getSafeFilename(getCommandName(blobHolder, parameters)));
+            Path outDirPath = tmpDirPath != null ? Files.createTempDirectory(tmpDirPath, prefix)
+                    : Framework.createTempDirectory(prefix);
 
             Map<String, String> cmdStringParams = new HashMap<>();
             cmdStringParams.put(OUT_DIR_PATH_KEY, outDirPath.toString());

--- a/modules/platform/nuxeo-platform-convert/src/test/java/org/nuxeo/ecm/platform/convert/tests/TestCommandLineConverter.java
+++ b/modules/platform/nuxeo-platform-convert/src/test/java/org/nuxeo/ecm/platform/convert/tests/TestCommandLineConverter.java
@@ -21,7 +21,9 @@ package org.nuxeo.ecm.platform.convert.tests;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
+import java.io.File;
 import java.io.Serializable;
 import java.util.HashMap;
 import java.util.List;
@@ -56,6 +58,12 @@ public class TestCommandLineConverter extends BaseConverterTest {
 
         Blob mainBlob = result.getBlob();
         assertEquals("hello.png", mainBlob.getFilename());
+
+        // NXP-29067: make sure the parent path is prefixed with the command line name
+        File file = mainBlob.getFile();
+        assertNotNull(file);
+        String parentPath = file.getParent();
+        assertTrue(parentPath, parentPath.contains("clc-pdftoimage-"));
     }
 
 }


### PR DESCRIPTION
This would be useful when debugging to know which command line
has created the tmp directory