### PR TITLE
NXP-27019: Enable to trace only specific requests

### DIFF
--- a/modules/runtime/nuxeo-runtime-metrics/src/main/java/org/nuxeo/runtime/metrics/reporter/JaegerReporter.java
+++ b/modules/runtime/nuxeo-runtime-metrics/src/main/java/org/nuxeo/runtime/metrics/reporter/JaegerReporter.java
@@ -90,7 +90,7 @@ public class JaegerReporter extends AbstractMetricsReporter {
         float samplerProbability = Float.parseFloat(options.getOrDefault(SAMPLER_PROB, DEFAULT_SAMPLER_PROB));
         if (samplerProbability >= 0.999) {
             builder.setSampler(Samplers.alwaysSample());
-        } else if (samplerProbability <= 0.001) {
+        } else if (samplerProbability < 0) {
             builder.setSampler(Samplers.neverSample());
         } else {
             builder.setSampler(Samplers.probabilitySampler(samplerProbability));


### PR DESCRIPTION
This can be done using tracing.sampler.probability=0 and proper
HTTP Tracer headers, like:
traceparent: 00-00000000000000000000000000000000-0000000000000000-01