### PR TITLE
NXP-27786: fix test after operation id change

### DIFF
--- a/modules/platform/nuxeo-apidoc-server/nuxeo-apidoc-repo/src/test/resources/apidoc_snapshot/operations.txt
+++ b/modules/platform/nuxeo-apidoc-server/nuxeo-apidoc-repo/src/test/resources/apidoc_snapshot/operations.txt
@@ -65,7 +65,7 @@ NXOperation: op:Directory.ReadEntries *** /op:Directory.ReadEntries
 NXOperation: op:Directory.SuggestEntries *** /op:Directory.SuggestEntries
 NXOperation: op:Directory.UpdateEntries *** /op:Directory.UpdateEntries
 NXOperation: op:Document.AddACE *** /op:Document.AddACE
-NXOperation: op:Document.AddEntrytoMultivaluedProperty *** /op:Document.AddEntrytoMultivaluedProperty
+NXOperation: op:Document.AddEntryToMultivaluedProperty *** /op:Document.AddEntryToMultivaluedProperty
 NXOperation: op:Document.AddFacet *** /op:Document.AddFacet
 NXOperation: op:Document.AddItemToListProperty *** /op:Document.AddItemToListProperty
 NXOperation: op:Document.AddPermission *** /op:Document.AddPermission

--- a/modules/platform/nuxeo-apidoc-server/nuxeo-apidoc-repo/src/test/resources/apidoc_snapshot/operations.txt
+++ b/modules/platform/nuxeo-apidoc-server/nuxeo-apidoc-repo/src/test/resources/apidoc_snapshot/operations.txt
@@ -65,6 +65,7 @@ NXOperation: op:Directory.ReadEntries *** /op:Directory.ReadEntries
 NXOperation: op:Directory.SuggestEntries *** /op:Directory.SuggestEntries
 NXOperation: op:Directory.UpdateEntries *** /op:Directory.UpdateEntries
 NXOperation: op:Document.AddACE *** /op:Document.AddACE
+NXOperation: op:Document.AddEntrytoMultivaluedProperty *** /op:Document.AddEntrytoMultivaluedProperty
 NXOperation: op:Document.AddFacet *** /op:Document.AddFacet
 NXOperation: op:Document.AddItemToListProperty *** /op:Document.AddItemToListProperty
 NXOperation: op:Document.AddPermission *** /op:Document.AddPermission
@@ -122,7 +123,6 @@ NXOperation: op:Document.UnblockPermissionInheritance *** /op:Document.UnblockPe
 NXOperation: op:Document.Unlock *** /op:Document.Unlock
 NXOperation: op:Document.Untrash *** /op:Document.Untrash
 NXOperation: op:Document.Update *** /op:Document.Update
-NXOperation: op:DocumentMultivaluedProperty.addItem *** /op:DocumentMultivaluedProperty.addItem
 NXOperation: op:Event.Fire *** /op:Event.Fire
 NXOperation: op:Favorite.Fetch *** /op:Favorite.Fetch
 NXOperation: op:Favorite.GetDocuments *** /op:Favorite.GetDocuments

--- a/modules/platform/nuxeo-automation/nuxeo-automation-core/src/main/java/org/nuxeo/ecm/automation/core/operations/document/AddEntryToMultiValuedProperty.java
+++ b/modules/platform/nuxeo-automation/nuxeo-automation-core/src/main/java/org/nuxeo/ecm/automation/core/operations/document/AddEntryToMultiValuedProperty.java
@@ -44,7 +44,7 @@ import org.nuxeo.ecm.core.schema.types.Type;
 @Operation(id = AddEntryToMultiValuedProperty.ID, category = Constants.CAT_DOCUMENT, label = "Add entry into multi-valued metadata", description = "Add value into the field expressed by the xpath parameter. This field must be a multivalued metadata.<p> 'checkExists' parameter enables to add value only if doesn't already exists in the field: <ul><li> if checked, the value will not be added if it exists already in the list</li><li>if not checked the value will be always added</li</ul>.<p> Remark: <b>only works for a field that stores a list of scalars (string, boolean, date, int, long) and not list of complex types.</b></p><p>Save parameter automatically saves the document in the database. It has to be turned off when this operation is used in the context of the empty document created, about to create, before document modification, document modified events.</p>", aliases = { "AddEntryToMultivaluedProperty", "DocumentMultivaluedProperty.addItem" })
 public class AddEntryToMultiValuedProperty extends AbstractOperationMultiValuedProperty {
 
-    public static final String ID = "Document.AddEntrytoMultivaluedProperty";
+    public static final String ID = "Document.AddEntryToMultivaluedProperty";
 
     @Context
     protected CoreSession session;


### PR DESCRIPTION
To fix tests after merge of #4105.

Note i would have expected new id to be "Document.AddEntryToMultivaluedProperty" instead of lower case to "to".