### PR TITLE
10.10-HF/fix-NXP-29099-clean-orphan-Tasks-when-deleting-DocumentRoutes

### DIFF
--- a/addons/nuxeo-platform-document-routing/nuxeo-routing-core/src/main/java/org/nuxeo/ecm/platform/routing/core/listener/DocumentRouteDeletedListener.java
+++ b/addons/nuxeo-platform-document-routing/nuxeo-routing-core/src/main/java/org/nuxeo/ecm/platform/routing/core/listener/DocumentRouteDeletedListener.java
@@ -1,0 +1,68 @@
+/*
+ * (C) Copyright 2020 Nuxeo (http://nuxeo.com/) and others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Contributors:
+ *     Nour AL KOTOB
+ */
+package org.nuxeo.ecm.platform.routing.core.listener;
+
+import static org.nuxeo.ecm.core.query.sql.NXQL.ECM_UUID;
+import static org.nuxeo.ecm.platform.routing.api.DocumentRoutingConstants.DOCUMENT_ROUTE_DOCUMENT_TYPE;
+import static org.nuxeo.ecm.platform.task.TaskConstants.TASK_PROCESS_ID_PROPERTY_NAME;
+
+import org.nuxeo.ecm.core.api.CoreSession;
+import org.nuxeo.ecm.core.api.DocumentModel;
+import org.nuxeo.ecm.core.api.IdRef;
+import org.nuxeo.ecm.core.event.Event;
+import org.nuxeo.ecm.core.event.EventBundle;
+import org.nuxeo.ecm.core.event.PostCommitEventListener;
+import org.nuxeo.ecm.core.event.impl.DocumentEventContext;
+
+/**
+ * Listener that deletes orphan Tasks.
+ *
+ * @since 11.1
+ */
+public class DocumentRouteDeletedListener implements PostCommitEventListener {
+
+    protected static final String QUERY_GET_TASKS_RELATED_TO_DOCUMENT_ROUTE = "SELECT * FROM Document WHERE "
+            + TASK_PROCESS_ID_PROPERTY_NAME + " = '%s'";
+
+    @Override
+    public void handleEvent(EventBundle events) {
+        for (Event event : events) {
+            DocumentEventContext context = (DocumentEventContext) event.getContext();
+            DocumentModel docModel = context.getSourceDocument();
+            if (DOCUMENT_ROUTE_DOCUMENT_TYPE.equals(docModel.getType())) {
+                deleteOrphanTasks(context.getCoreSession(), docModel.getId());
+            }
+        }
+    }
+
+    /**
+     * Deletes all tasks whose process id matches the given DocumentRoute id.
+     *
+     * @since 11.1
+     */
+    protected void deleteOrphanTasks(CoreSession session, String id) {
+        String query = String.format(QUERY_GET_TASKS_RELATED_TO_DOCUMENT_ROUTE, id);
+        session.queryProjection(query, 0, 0)
+               .stream()
+               .map(m -> m.get(ECM_UUID))
+               .map(taskId -> new IdRef((String) taskId))
+               .forEach(session::removeDocument);
+    }
+
+}

--- a/addons/nuxeo-platform-document-routing/nuxeo-routing-core/src/main/resources/OSGI-INF/document-routing-listeners-contrib.xml
+++ b/addons/nuxeo-platform-document-routing/nuxeo-routing-core/src/main/resources/OSGI-INF/document-routing-listeners-contrib.xml
@@ -47,6 +47,11 @@
       class="org.nuxeo.ecm.platform.routing.core.listener.RoutingTaskDeletedListener">
       <event>aboutToRemove</event>
     </listener>
+    
+    <listener name="removeTasksForDeletedDocumentRoute" async="true" postCommit="true"
+      class="org.nuxeo.ecm.platform.routing.core.listener.DocumentRouteDeletedListener">
+      <event>documentRemoved</event>
+    </listener>
 
   </extension>
 

--- a/addons/nuxeo-platform-document-routing/nuxeo-routing-core/src/test/java/org/nuxeo/ecm/platform/routing/test/TestDocumentRoutingService.java
+++ b/addons/nuxeo-platform-document-routing/nuxeo-routing-core/src/test/java/org/nuxeo/ecm/platform/routing/test/TestDocumentRoutingService.java
@@ -23,11 +23,16 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
+import static org.nuxeo.ecm.platform.routing.api.DocumentRoutingConstants.DOCUMENT_ROUTE_DOCUMENT_TYPE;
+import static org.nuxeo.ecm.platform.task.TaskConstants.TASK_PROCESS_ID_PROPERTY_NAME;
+import static org.nuxeo.ecm.platform.task.TaskConstants.TASK_TYPE_NAME;
 
 import java.io.File;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+
+import javax.inject.Inject;
 
 import org.junit.After;
 import org.junit.Test;
@@ -53,9 +58,13 @@ import org.nuxeo.ecm.platform.routing.api.DocumentRoutingConstants;
 import org.nuxeo.ecm.platform.routing.api.exception.DocumentRouteAlredayLockedException;
 import org.nuxeo.ecm.platform.routing.api.exception.DocumentRouteNotLockedException;
 import org.nuxeo.runtime.api.Framework;
+import org.nuxeo.runtime.test.runner.TransactionalFeature;
 import org.nuxeo.runtime.transaction.TransactionHelper;
 
 public class TestDocumentRoutingService extends DocumentRoutingTestCase {
+
+    @Inject
+    protected TransactionalFeature txFeature;
 
     protected File tmp;
 
@@ -365,6 +374,19 @@ public class TestDocumentRoutingService extends DocumentRoutingTestCase {
             // branch not executed is now in canceled state
             assertEquals("canceled", children.get(2).getCurrentLifeCycleState());
         }
+    }
+
+    @Test
+    public void testOrphanTasksDeletion() {
+        DocumentModel route = session.createDocumentModel("/default-domain/workspaces", "dummyRoute",
+                DOCUMENT_ROUTE_DOCUMENT_TYPE);
+        route = session.createDocument(route);
+        DocumentModel task = session.createDocumentModel("/default-domain/workspaces", "dummyTask", TASK_TYPE_NAME);
+        task.setPropertyValue(TASK_PROCESS_ID_PROPERTY_NAME, route.getId());
+        task = session.createDocument(task);
+        session.removeDocument(route.getRef());
+        txFeature.nextTransaction();
+        assertFalse(session.exists(task.getRef()));
     }
 
     protected void setPermissionToUser(DocumentModel doc, String username, String... perms) {


### PR DESCRIPTION
PR created from https://qa2.nuxeo.org/jenkins/job/TestAndPush/job/ondemand-testandpush-nalkotob-10.10/154/