### PR TITLE
NXP-29252: Fix EasyShare Expired mail template

### DIFF
--- a/modules/platform/nuxeo-easyshare-core/src/main/resources/templates/easyShareExpiredSubject.ftl
+++ b/modules/platform/nuxeo-easyshare-core/src/main/resources/templates/easyShareExpiredSubject.ftl
@@ -1,1 +1,1 @@
-EasyShare folder ${docFolder.name} has expired
+EasyShare folder ${docShare.name} has expired


### PR DESCRIPTION
There was no unit test sending mail notification, I did not add one.
But I did test on Nuxeo 11 Snapshot :> all good, I do have my correct title (like "Nuxeo]EasyShare folder My EasyShare Test has expired")