### PR TITLE
NXP-29252: fix EasyShare Expired mail template (#4146)

### DIFF
--- a/addons/nuxeo-easyshare/nuxeo-easyshare-core/src/main/resources/templates/easyShareExpiredSubject.ftl
+++ b/addons/nuxeo-easyshare/nuxeo-easyshare-core/src/main/resources/templates/easyShareExpiredSubject.ftl
@@ -1,1 +1,1 @@
-EasyShare folder ${docFolder.name} has expired
+EasyShare folder ${docShare.name} has expired


### PR DESCRIPTION
I did test the mail subject was correct by deploying the built jar in a 10.10 and creating an expired EasyShareFolder. 