### PR TITLE
NXP-28918: add a 'nx:arrayContains' function in the EL context

### DIFF
--- a/modules/core/nuxeo-core-el/src/main/java/org/nuxeo/ecm/platform/el/Functions.java
+++ b/modules/core/nuxeo-core-el/src/main/java/org/nuxeo/ecm/platform/el/Functions.java
@@ -1,0 +1,86 @@
+/*
+ * (C) Copyright 2020 Nuxeo (http://nuxeo.com/) and others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Contributors:
+ *     Thomas Roger <troger@nuxeo.com>
+ */
+
+package org.nuxeo.ecm.platform.el;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Stream;
+
+/**
+ * Helper functions injected in the {@link ExpressionContext} instance.
+ *
+ * @since 11.2
+ */
+public class Functions {
+
+    /**
+     * Returns {@code true} if the given {@code arr} contains the given {@code element}.
+     * <p>
+     * Always returns {@code false} if the given {@code arr} is {@code null}.
+     */
+    public static boolean arrayContains(Object[] arr, Object element) {
+        if (arr == null) {
+            return false;
+        }
+        return Arrays.asList(arr).contains(element);
+    }
+
+    /**
+     * Returns {@code true} if the given {@code arr} contains all the given {@code elements}.
+     * <p>
+     * Always returns {@code false} if the given {@code arr} is {@code null}.
+     */
+    public static boolean arrayContainsAll(Object[] arr, Object... elements) {
+        if (arr == null || elements == null) {
+            return false;
+        }
+        return Arrays.asList(arr).containsAll(Arrays.asList(elements));
+    }
+
+    /**
+     * Returns {@code true} if the given {@code arr} contains one of the given {@code elements}.
+     * <p>
+     * Always returns {@code false} if the given {@code arr} is {@code null}.
+     */
+    public static boolean arrayContainsAny(Object[] arr, Object... elements) {
+        if (arr == null || elements == null) {
+            return false;
+        }
+        List<Object> list = Arrays.asList(arr);
+        return Stream.of(elements).anyMatch(list::contains);
+    }
+
+    /**
+     * Returns {@code true} if the given {@code arr} contains none of the given {@code elements}.
+     * <p>
+     * Always returns {@code false} if the given {@code arr} is {@code null}.
+     */
+    public static boolean arrayContainsNone(Object[] arr, Object... elements) {
+        if (arr == null || elements == null) {
+            return false;
+        }
+        List<Object> list = Arrays.asList(arr);
+        return Stream.of(elements).noneMatch(list::contains);
+    }
+
+    private Functions() {
+        // helper class
+    }
+}

--- a/modules/core/nuxeo-core-el/src/test/java/org/nuxeo/platform/el/TestExpressionEvaluator.java
+++ b/modules/core/nuxeo-core-el/src/test/java/org/nuxeo/platform/el/TestExpressionEvaluator.java
@@ -22,6 +22,7 @@
 package org.nuxeo.platform.el;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
@@ -104,6 +105,93 @@ public class TestExpressionEvaluator {
         assertNotNull(value);
         value = evaluatorUnderTest.evaluateExpression(context, "${list.get(0).sampleValue}", String.class);
         assertNotNull(value);
+    }
+
+    /**
+     * NXP-28918
+     */
+    @Test
+    public void testArrayContainsFunction() {
+        Boolean res = evaluatorUnderTest.evaluateExpression(context, "${nx:arrayContains(array, 'foo')}",
+                Boolean.class);
+        assertFalse(res);
+
+        String[] arr = new String[] { "bar" };
+        evaluatorUnderTest.bindValue(context, "array", arr);
+        res = evaluatorUnderTest.evaluateExpression(context, "${nx:arrayContains(array, 'foo')}", Boolean.class);
+        assertFalse(res);
+
+        res = evaluatorUnderTest.evaluateExpression(context, "${nx:arrayContains(array, 'bar')}", Boolean.class);
+        assertTrue(res);
+    }
+
+    /**
+     * NXP-28918
+     */
+    @Test
+    public void testArrayContainsAllFunction() {
+        Boolean res = evaluatorUnderTest.evaluateExpression(context, "${nx:arrayContainsAll(array, 'foo')}",
+                Boolean.class);
+        assertFalse(res);
+
+        String[] arr = new String[] { "foo", "bar" };
+        evaluatorUnderTest.bindValue(context, "array", arr);
+        res = evaluatorUnderTest.evaluateExpression(context, "${nx:arrayContainsAll(array, 'foo', 'foobar')}",
+                Boolean.class);
+        assertFalse(res);
+
+        res = evaluatorUnderTest.evaluateExpression(context, "${nx:arrayContainsAll(array, 'bar', 'foo')}",
+                Boolean.class);
+        assertTrue(res);
+
+        res = evaluatorUnderTest.evaluateExpression(context, "${nx:arrayContainsAll(array, 'bar')}", Boolean.class);
+        assertTrue(res);
+    }
+
+    /**
+     * NXP-28918
+     */
+    @Test
+    public void testArrayContainsAnyFunction() {
+        Boolean res = evaluatorUnderTest.evaluateExpression(context, "${nx:arrayContainsAny(array, 'foo')}",
+                Boolean.class);
+        assertFalse(res);
+
+        String[] arr = new String[] { "foo", "bar" };
+        evaluatorUnderTest.bindValue(context, "array", arr);
+        res = evaluatorUnderTest.evaluateExpression(context, "${nx:arrayContainsAny(array, 'barfoo', 'foobar')}",
+                Boolean.class);
+        assertFalse(res);
+
+        res = evaluatorUnderTest.evaluateExpression(context, "${nx:arrayContainsAny(array, 'bar', 'foo')}",
+                Boolean.class);
+        assertTrue(res);
+
+        res = evaluatorUnderTest.evaluateExpression(context, "${nx:arrayContainsAny(array, 'bar')}", Boolean.class);
+        assertTrue(res);
+    }
+
+    /**
+     * NXP-28918
+     */
+    @Test
+    public void testArrayContainsNoneFunction() {
+        Boolean res = evaluatorUnderTest.evaluateExpression(context, "${nx:arrayContainsNone(array, 'foo')}",
+                Boolean.class);
+        assertFalse(res);
+
+        String[] arr = new String[] { "foo", "bar" };
+        evaluatorUnderTest.bindValue(context, "array", arr);
+        res = evaluatorUnderTest.evaluateExpression(context, "${nx:arrayContainsNone(array, 'foo', 'foobar')}",
+                Boolean.class);
+        assertFalse(res);
+
+        res = evaluatorUnderTest.evaluateExpression(context, "${nx:arrayContainsNone(array, 'barfoo', 'foobar')}",
+                Boolean.class);
+        assertTrue(res);
+
+        res = evaluatorUnderTest.evaluateExpression(context, "${nx:arrayContainsNone(array, 'foobar')}", Boolean.class);
+        assertTrue(res);
     }
 
 }

--- a/modules/platform/nuxeo-platform-imaging/nuxeo-platform-imaging-core/src/test/java/org/nuxeo/ecm/platform/picture/core/test/TestPictureConversions.java
+++ b/modules/platform/nuxeo-platform-imaging/nuxeo-platform-imaging-core/src/test/java/org/nuxeo/ecm/platform/picture/core/test/TestPictureConversions.java
@@ -194,6 +194,32 @@ public class TestPictureConversions {
         assertNull(multiviewPicture.getView("anotherSmallConversion"));
     }
 
+    /**
+     * NXP-28918
+     */
+    @Test
+    @Deploy("org.nuxeo.ecm.platform.picture.core:OSGI-INF/imaging-picture-conversions-filters.xml")
+    public void shouldFilterPictureConversionWithArrayProperty() throws IOException {
+        DocumentModel picture = session.createDocumentModel("/", "picture", "Picture");
+        Blob blob = Blobs.createBlob(FileUtils.getResourceFileFromContext("images/test.jpg"));
+        blob.setFilename("MyTest.jpg");
+        blob.setMimeType("image/jpeg");
+        picture.setPropertyValue("file:content", (Serializable) blob);
+        picture = session.createDocument(picture);
+
+        MultiviewPicture multiviewPicture = picture.getAdapter(MultiviewPicture.class);
+        assertEquals(5, multiviewPicture.getViews().length);
+        assertNull(multiviewPicture.getView("subjectFilteredConversion"));
+
+        picture.setPropertyValue("file:content", (Serializable) blob);
+        picture.setPropertyValue("dc:subjects", new String[] { "art/paint" });
+        picture = session.saveDocument(picture);
+
+        multiviewPicture = picture.getAdapter(MultiviewPicture.class);
+        assertEquals(6, multiviewPicture.getViews().length);
+        assertNotNull(multiviewPicture.getView("subjectFilteredConversion"));
+    }
+
     @Test
     public void pictureConversionsAlwaysHaveExtensions() throws IOException {
         DocumentModel picture = session.createDocumentModel("/", "picture", "Picture");

--- a/modules/platform/nuxeo-platform-imaging/nuxeo-platform-imaging-core/src/test/resources/OSGI-INF/imaging-picture-conversions-filters.xml
+++ b/modules/platform/nuxeo-platform-imaging/nuxeo-platform-imaging-core/src/test/resources/OSGI-INF/imaging-picture-conversions-filters.xml
@@ -17,6 +17,12 @@
       </filters>
     </pictureConversion>
 
+    <pictureConversion id="subjectFilteredConversion" maxSize="200">
+      <filters>
+        <filter-id>subjectFilter</filter-id>
+      </filters>
+    </pictureConversion>
+
   </extension>
 
   <extension target="org.nuxeo.ecm.platform.actions.ActionService"
@@ -31,6 +37,12 @@
     <filter id="unauthorized">
       <rule grant="false">
         <condition>#{currentDocument.dc.rights == "Unauthorized"}</condition>
+      </rule>
+    </filter>
+
+    <filter id="subjectFilter">
+      <rule grant="true">
+        <condition>#{nx:arrayContains(currentDocument.dc.subjects, "art/paint")}</condition>
       </rule>
     </filter>
 


### PR DESCRIPTION
This function is used to test if an array contains a given element.