### PR TITLE
9.10-HF/fix-NXP-29100-delete-orphan-document-routes

### DIFF
--- a/addons/nuxeo-platform-document-routing/nuxeo-routing-core/src/main/java/org/nuxeo/ecm/platform/routing/core/listener/DocumentRouteOrphanedListener.java
+++ b/addons/nuxeo-platform-document-routing/nuxeo-routing-core/src/main/java/org/nuxeo/ecm/platform/routing/core/listener/DocumentRouteOrphanedListener.java
@@ -1,0 +1,76 @@
+/*
+ * (C) Copyright 2020 Nuxeo (http://nuxeo.com/) and others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Contributors:
+ *     Nour AL KOTOB
+ */
+package org.nuxeo.ecm.platform.routing.core.listener;
+
+import static org.nuxeo.ecm.platform.routing.api.DocumentRoutingConstants.ATTACHED_DOCUMENTS_PROPERTY_NAME;
+import static org.nuxeo.ecm.platform.routing.api.DocumentRoutingConstants.DOCUMENT_ROUTE_DOCUMENT_TYPE;
+import static org.nuxeo.ecm.platform.routing.api.DocumentRoutingConstants.ROUTING_TASK_DOC_TYPE;
+
+import java.io.Serializable;
+import java.util.List;
+
+import org.nuxeo.ecm.core.api.CoreSession;
+import org.nuxeo.ecm.core.api.DocumentModel;
+import org.nuxeo.ecm.core.event.Event;
+import org.nuxeo.ecm.core.event.EventBundle;
+import org.nuxeo.ecm.core.event.PostCommitEventListener;
+import org.nuxeo.ecm.core.event.impl.DocumentEventContext;
+
+/**
+ * Listener that deletes orphan DocumentRoutes.
+ *
+ * @since 11.2
+ */
+public class DocumentRouteOrphanedListener implements PostCommitEventListener {
+
+    protected static final String QUERY_GET_RELATED_DOCUMENT_ROUTES = "SELECT * FROM " + DOCUMENT_ROUTE_DOCUMENT_TYPE
+            + " WHERE " + ATTACHED_DOCUMENTS_PROPERTY_NAME + " = '%s'";
+
+    @Override
+    public void handleEvent(EventBundle events) {
+        for (Event event : events) {
+            DocumentEventContext context = (DocumentEventContext) event.getContext();
+            DocumentModel docModel = context.getSourceDocument();
+            if (!DOCUMENT_ROUTE_DOCUMENT_TYPE.equals(docModel.getType())
+                    && !ROUTING_TASK_DOC_TYPE.equals(docModel.getType())) {
+                deleteOrphanDocumentRoutes(context.getCoreSession(), docModel.getId());
+            }
+        }
+    }
+
+    /**
+     * Removes the given id from DocumentRoutes attached documents list and deletes the DocumentRoutes if they are not
+     * attached to a document anymore.
+     */
+    protected void deleteOrphanDocumentRoutes(CoreSession session, String id) {
+        String query = String.format(QUERY_GET_RELATED_DOCUMENT_ROUTES, id);
+        for (DocumentModel doc : session.query(query)) {
+            @SuppressWarnings("unchecked")
+            List<String> attachedDocuments = (List<String>) doc.getPropertyValue(ATTACHED_DOCUMENTS_PROPERTY_NAME);
+            attachedDocuments.remove(id);
+            if (attachedDocuments.isEmpty()) {
+                session.removeDocument(doc.getRef());
+            } else {
+                doc.setPropertyValue(ATTACHED_DOCUMENTS_PROPERTY_NAME, (Serializable) attachedDocuments);
+                session.saveDocument(doc);
+            }
+        }
+    }
+
+}

--- a/addons/nuxeo-platform-document-routing/nuxeo-routing-core/src/main/resources/OSGI-INF/document-routing-listeners-contrib.xml
+++ b/addons/nuxeo-platform-document-routing/nuxeo-routing-core/src/main/resources/OSGI-INF/document-routing-listeners-contrib.xml
@@ -18,13 +18,13 @@
       priority="200">
       <event>documentCreated</event>
     </listener>
-    
+
     <listener name="securityListener" async="false" postCommit="false"
       class="org.nuxeo.ecm.platform.routing.core.listener.DocumentRoutingSecurityListener"
       priority="120">
       <event>beforeRouteReady</event>
     </listener>
-    
+
     <listener name="routingSecurityUpdaterForActors" async="false" postCommit="false"
       class="org.nuxeo.ecm.platform.routing.core.listener.RoutingTaskSecurityUpdaterListener"
       priority="250">
@@ -32,7 +32,7 @@
       <event>workflowTaskReassigned</event>
       <event>workflowTaskDelegated</event>
     </listener>
-    
+
     <listener name="triggerEsclationRules" async="true"
       class="org.nuxeo.ecm.platform.routing.core.listener.DocumentRoutingEscalationListener">
       <event>executeEscalationRules</event>
@@ -42,7 +42,7 @@
       class="org.nuxeo.ecm.platform.routing.core.listener.DocumentRoutingWorkflowDoneListener">
       <event>afterRouteFinish</event>
     </listener>
-    
+
     <listener name="deleteRoutingTaskListener" async="true"
       class="org.nuxeo.ecm.platform.routing.core.listener.RoutingTaskDeletedListener">
       <event>aboutToRemove</event>
@@ -50,6 +50,11 @@
     
     <listener name="removeTasksForDeletedDocumentRoute" async="true" postCommit="true"
       class="org.nuxeo.ecm.platform.routing.core.listener.DocumentRouteDeletedListener">
+      <event>documentRemoved</event>
+    </listener>
+    
+    <listener name="removeDocumentRoutesForDeletedDocument" async="true" postCommit="true"
+      class="org.nuxeo.ecm.platform.routing.core.listener.DocumentRouteOrphanedListener">
       <event>documentRemoved</event>
     </listener>
 

--- a/addons/nuxeo-platform-document-routing/nuxeo-routing-core/src/test/java/org/nuxeo/ecm/platform/routing/test/TestDocumentRoutingService.java
+++ b/addons/nuxeo-platform-document-routing/nuxeo-routing-core/src/test/java/org/nuxeo/ecm/platform/routing/test/TestDocumentRoutingService.java
@@ -23,13 +23,16 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
+import static org.nuxeo.ecm.platform.routing.api.DocumentRoutingConstants.ATTACHED_DOCUMENTS_PROPERTY_NAME;
 import static org.nuxeo.ecm.platform.routing.api.DocumentRoutingConstants.DOCUMENT_ROUTE_DOCUMENT_TYPE;
 import static org.nuxeo.ecm.platform.task.TaskConstants.TASK_PROCESS_ID_PROPERTY_NAME;
 import static org.nuxeo.ecm.platform.task.TaskConstants.TASK_TYPE_NAME;
 
 import java.io.File;
 import java.net.URL;
+import java.io.Serializable;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
@@ -386,6 +389,28 @@ public class TestDocumentRoutingService extends DocumentRoutingTestCase {
         session.removeDocument(route.getRef());
         waitForAsyncExec();
         assertFalse(session.exists(task.getRef()));
+    }
+
+    @Test
+    public void testOrphanDocumentRoutesDeletion() {
+        DocumentModel file1 = session.createDocumentModel("/", "File1", "File");
+        file1 = session.createDocument(file1);
+        DocumentModel file2 = session.createDocumentModel("/", "File2", "File");
+        file2 = session.createDocument(file2);
+        List<String> docIds = Arrays.asList(file1.getId(), file2.getId());
+        DocumentModel route = session.createDocumentModel("/default-domain/workspaces", "dummyRoute1",
+                DOCUMENT_ROUTE_DOCUMENT_TYPE);
+        route.setPropertyValue(ATTACHED_DOCUMENTS_PROPERTY_NAME, (Serializable) docIds);
+        route = session.createDocument(route);
+
+        session.removeDocument(file1.getRef());
+        waitForAsyncExec();
+        // Still attached to file2
+        assertTrue(session.exists(route.getRef()));
+        session.removeDocument(file2.getRef());
+        waitForAsyncExec();
+        // Not attached anymore
+        assertFalse(session.exists(route.getRef()));
     }
 
     protected void setPermissionToUser(DocumentModel doc, String username, String... perms) {

--- a/addons/nuxeo-platform-document-routing/nuxeo-routing-rest-api/src/test/resources/test-disable-task-deletion-listener.xml
+++ b/addons/nuxeo-platform-document-routing/nuxeo-routing-rest-api/src/test/resources/test-disable-task-deletion-listener.xml
@@ -5,6 +5,7 @@
 
   <extension target="org.nuxeo.ecm.core.event.EventServiceComponent" point="listener">
     <listener name="removeProcessForDeletedDocument" enabled="false" />
+    <listener name="removeDocumentRoutesForDeletedDocument" enabled="false" />
   </extension>
 
 </component>

--- a/nuxeo-distribution/nuxeo-server-hotreload-tests/src/test/resources/ITDevHotReloadTest/testHotReloadWorkflow/OSGI-INF/contribution.xml
+++ b/nuxeo-distribution/nuxeo-server-hotreload-tests/src/test/resources/ITDevHotReloadTest/testHotReloadWorkflow/OSGI-INF/contribution.xml
@@ -30,5 +30,9 @@
       </rule>
     </filter>
   </extension>
+  
+  <extension target="org.nuxeo.ecm.core.event.EventServiceComponent" point="listener">
+    <listener name="removeDocumentRoutesForDeletedDocument" enabled="false" />
+  </extension>
 
 </component>


### PR DESCRIPTION
PR created from https://qa2.nuxeo.org/jenkins/job/TestAndPush/job/ondemand-testandpush-nalkotob-9.10/35/