### PR TITLE
10.10-HF/fix-NXP-29393-blank-assertion-oauth2

### DIFF
--- a/nuxeo-features/nuxeo-platform-oauth/src/test/java/org/nuxeo/ecm/platform/oauth/tests/OAuth2ChallengeFixture.java
+++ b/nuxeo-features/nuxeo-platform-oauth/src/test/java/org/nuxeo/ecm/platform/oauth/tests/OAuth2ChallengeFixture.java
@@ -631,6 +631,16 @@ public class OAuth2ChallengeFixture {
 
         Map<String, String> params = new HashMap<>();
         params.put(GRANT_TYPE_PARAM, JWT_BEARER_GRANT_TYPE);
+
+        // Test empty assertion
+        try (CloseableClientResponse cr = responseFromTokenWith(params)) {
+            assertEquals(400, cr.getStatus());
+            String json = cr.getEntity(String.class);
+            Map<String, Serializable> error = new ObjectMapper().readValue(json, Map.class);
+            assertEquals(INVALID_REQUEST, error.get(ERROR_PARAM));
+            assertEquals("Empty assertion", error.get(ERROR_DESCRIPTION_PARAM));
+        }
+
         params.put(ASSERTION_PARAM, jwtToken);
 
         // Test empty client id


### PR DESCRIPTION
PR created from https://qa2.nuxeo.org/jenkins/job/TestAndPush/job/ondemand-testandpush-kleturc-10.10/100/