### PR TITLE
NXP-27559: remove uppercase in chronical-threads pom dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4981,7 +4981,7 @@
       <dependency>
         <!-- unused dependency, declared to exclude affinity -->
         <groupId>net.openhft</groupId>
-        <artifactId>chronicle-Threads</artifactId>
+        <artifactId>chronicle-threads</artifactId>
         <version>${chronicle.threads.version}</version>
         <exclusions>
           <exclusion>


### PR DESCRIPTION
Don't ask me why but this is making eclipse build fail with this odd error on core-event (and others, but this one is the only one caught by eclipse logs:

```
java.lang.NullPointerException
        at org.eclipse.jdt.internal.compiler.ast.ReferenceExpression.generateCode(ReferenceExpression.java:353)
        at org.eclipse.jdt.internal.compiler.ast.Statement.generateArguments(Statement.java:420)
        at org.eclipse.jdt.internal.compiler.ast.MessageSend.generateCode(MessageSend.java:506)
        at org.eclipse.jdt.internal.compiler.ast.MessageSend.generateCode(MessageSend.java:499)
        at org.eclipse.jdt.internal.compiler.ast.ReturnStatement.generateCode(ReturnStatement.java:205)
        at org.eclipse.jdt.internal.compiler.ast.AbstractMethodDeclaration.generateCode(AbstractMethodDeclaration.java:344)
        at org.eclipse.jdt.internal.compiler.ast.AbstractMethodDeclaration.generateCode(AbstractMethodDeclaration.java:281)
        at org.eclipse.jdt.internal.compiler.ast.TypeDeclaration.generateCode(TypeDeclaration.java:579)
        at org.eclipse.jdt.internal.compiler.ast.TypeDeclaration.generateCode(TypeDeclaration.java:649)
        at org.eclipse.jdt.internal.compiler.ast.CompilationUnitDeclaration.generateCode(CompilationUnitDeclaration.java:412)
        at org.eclipse.jdt.internal.compiler.Compiler.process(Compiler.java:912)
        at org.eclipse.jdt.internal.compiler.ProcessTaskManager.run(ProcessTaskManager.java:145)
        at java.base/java.lang.Thread.run(Thread.java:834)
```

Error messages on the project: The project was not built since its build path is incomplete. Cannot find the class file for java.lang.String. Fix the build path then try building this project.

When removing the uppercase letter, after re-running "mvn eclipse:eclipse", it's magically fixed.