### PR TITLE
NXP-29633: Make sure all CQ tailer are closed

### DIFF
--- a/modules/runtime/nuxeo-stream/src/main/java/org/nuxeo/lib/stream/log/chronicle/ChronicleLogAppender.java
+++ b/modules/runtime/nuxeo-stream/src/main/java/org/nuxeo/lib/stream/log/chronicle/ChronicleLogAppender.java
@@ -26,7 +26,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.nio.file.StandardOpenOption;
 import java.time.Duration;
 import java.time.Instant;
@@ -51,6 +50,7 @@ import org.nuxeo.lib.stream.log.internals.LogOffsetImpl;
 import net.openhft.chronicle.bytes.util.DecoratedBufferOverflowException;
 import net.openhft.chronicle.queue.ChronicleQueue;
 import net.openhft.chronicle.queue.ExcerptAppender;
+import net.openhft.chronicle.queue.ExcerptTailer;
 import net.openhft.chronicle.queue.impl.single.SingleChronicleQueue;
 import net.openhft.chronicle.queue.impl.single.SingleChronicleQueueBuilder;
 
@@ -301,7 +301,9 @@ public class ChronicleLogAppender<M extends Externalizable> implements Closeable
     }
 
     public long endOffset(int partition) {
-        return partitions.get(partition).createTailer().toEnd().index();
+        try (ExcerptTailer tailer = partitions.get(partition).createTailer().toEnd()) {
+            return tailer.index();
+        }
     }
 
     public long firstOffset(int partition) {

--- a/modules/runtime/nuxeo-stream/src/main/java/org/nuxeo/lib/stream/log/chronicle/ChronicleRetentionListener.java
+++ b/modules/runtime/nuxeo-stream/src/main/java/org/nuxeo/lib/stream/log/chronicle/ChronicleRetentionListener.java
@@ -78,7 +78,7 @@ public class ChronicleRetentionListener implements StoreFileListener {
         purgedStamp = System.currentTimeMillis();
         cycles.subList(0, cyclesToRemove).forEach(this::dropCycle);
         // this is needed to update first cycle, it calls directoryListing.refresh()
-        queue.createTailer();
+        queue.createTailer().close();
     }
 
     protected void dropCycle(Integer cycle) {

--- a/server/nuxeo-nxr-server/src/main/resources/templates/docker-json/lib/log4j2.xml
+++ b/server/nuxeo-nxr-server/src/main/resources/templates/docker-json/lib/log4j2.xml
@@ -191,6 +191,8 @@
     <Logger name="org.apache.shindig.common.xml.XmlUtil" level="warn" />
     <Logger name="org.apache.myfaces.shared_tomahawk" level="warn" />
     <Logger name="net.openhft.chronicle.queue.impl.single.SCQIndexing" level="error" /> <!-- Hide perf warnings -->
+    <Logger name="net.openhft.chronicle.bytes.MappedFile" level="error" /> <!-- Hide perf warnings -->
+    <Logger name="net.openhft.chronicle.queue.impl.single.ReferenceCountedCache" level="error" /> <!-- Hide cache cleaning warnings -->
 
     <Logger name="org.elasticsearch.bootstrap" level="error" />
 

--- a/server/nuxeo-nxr-server/src/main/resources/templates/docker/lib/log4j2.xml
+++ b/server/nuxeo-nxr-server/src/main/resources/templates/docker/lib/log4j2.xml
@@ -192,6 +192,8 @@
     <Logger name="org.apache.shindig.common.xml.XmlUtil" level="warn" />
     <Logger name="org.apache.myfaces.shared_tomahawk" level="warn" />
     <Logger name="net.openhft.chronicle.queue.impl.single.SCQIndexing" level="error" /> <!-- Hide perf warnings -->
+    <Logger name="net.openhft.chronicle.bytes.MappedFile" level="error" /> <!-- Hide perf warnings -->
+    <Logger name="net.openhft.chronicle.queue.impl.single.ReferenceCountedCache" level="error" /> <!-- Hide cache cleaning warnings -->
 
     <Logger name="org.elasticsearch.bootstrap" level="error" />
 

--- a/server/nuxeo-server-tomcat/src/main/resources/tomcat/lib/log4j2.xml
+++ b/server/nuxeo-server-tomcat/src/main/resources/tomcat/lib/log4j2.xml
@@ -237,6 +237,8 @@
     <Logger name="org.apache.shindig.common.xml.XmlUtil" level="warn" />
     <Logger name="org.apache.myfaces.shared_tomahawk" level="warn" />
     <Logger name="net.openhft.chronicle.queue.impl.single.SCQIndexing" level="error" /> <!-- Hide perf warnings -->
+    <Logger name="net.openhft.chronicle.bytes.MappedFile" level="error" /> <!-- Hide perf warnings -->
+    <Logger name="net.openhft.chronicle.queue.impl.single.ReferenceCountedCache" level="error" /> <!-- Hide cache cleaning warnings -->
 
     <Logger name="org.elasticsearch.bootstrap" level="error" />
 


### PR DESCRIPTION
This reduces drastically the number of ReferenceCountedCache warning,
still, it happens during the activity, this is not relevant and ignored
by the log4j2 configuration.