### PR TITLE
NXP-29673: Add default for boolean in BulkCommand avro

### DIFF
--- a/modules/core/nuxeo-core-bulk/src/main/java/org/nuxeo/ecm/core/bulk/message/BulkCommand.java
+++ b/modules/core/nuxeo-core-bulk/src/main/java/org/nuxeo/ecm/core/bulk/message/BulkCommand.java
@@ -26,6 +26,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
 
+import org.apache.avro.reflect.AvroDefault;
 import org.apache.avro.reflect.AvroEncode;
 import org.apache.avro.reflect.Nullable;
 import org.apache.commons.lang3.BooleanUtils;
@@ -62,9 +63,11 @@ public class BulkCommand implements Serializable {
     protected String scroller;
 
     // @since 11.1
+    @AvroDefault("false")
     protected boolean genericScroller;
 
     // @since 11.3
+    @AvroDefault("false")
     protected boolean externalScroller;
 
     @AvroEncode(using = MapAsJsonAsStringEncoding.class)


### PR DESCRIPTION
To be backward and forward compat any new field of an avro object must
have a default or Nullable, this applies also to boolean