### PR TITLE
NXP-29673: Add default for boolean in BulkCommand avro (10.10)

### DIFF
--- a/nuxeo-core/nuxeo-core-bulk/src/main/java/org/nuxeo/ecm/core/bulk/message/BulkCommand.java
+++ b/nuxeo-core/nuxeo-core-bulk/src/main/java/org/nuxeo/ecm/core/bulk/message/BulkCommand.java
@@ -26,6 +26,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
 
+import org.apache.avro.reflect.AvroDefault;
 import org.apache.avro.reflect.AvroEncode;
 import org.apache.avro.reflect.Nullable;
 import org.apache.commons.lang3.builder.EqualsBuilder;
@@ -62,6 +63,7 @@ public class BulkCommand implements Serializable {
     protected String scroller;
 
     // @since 11.1
+    @AvroDefault("false")
     protected boolean genericScroller;
 
     @AvroEncode(using = MapAsJsonAsStringEncoding.class)


### PR DESCRIPTION
To be backward and forward compat any new field of an avro object must
have a default or Nullable, this applies also to boolean