### PR TITLE
Fix LDAP timeouts

### DIFF
--- a/server/nuxeo-nxr-server/src/main/resources/templates/common/config/default-ldap-users-directory-bundle.xml.nxftl
+++ b/server/nuxeo-nxr-server/src/main/resources/templates/common/config/default-ldap-users-directory-bundle.xml.nxftl
@@ -93,7 +93,7 @@
       <querySizeLimit>${nuxeo.ldap.query.sizeLimit}</querySizeLimit>
 
       <!-- Time to wait for a search to finish. 0 to wait indefinitely -->
-      <queryTimeLimit>0</queryTimeLimit>
+      <queryTimeLimit>${nuxeo.ldap.query.timeLimit}</queryTimeLimit>
 
       <creationBaseDn>ou=people,dc=example,dc=com</creationBaseDn>
       <creationClass>top</creationClass>


### PR DESCRIPTION
Seen traces such as:

```
2020-09-25T22:50:10,551 ERROR [http-nio-0.0.0.0-8080-exec-3] [nuxeo-error-log] org.nuxeo.ecm.directory.DirectoryException: getEntry failed: LDAP response read timed out, timeout used:-1ms.
	at org.nuxeo.ecm.directory.ldap.LDAPSession.getEntryFromSource(LDAPSession.java:434)
```

```
Caused by: javax.naming.NamingException: LDAP response read timed out, timeout used:-1ms.; remaining name 'dc=engees,dc=fr'
```

While my nuxeo.conf sets a 1s timeout.

Apparently, that timeout isn't used everywhere. I assume this is a bug ?