### PR TITLE
fix-NXP-29697-fix-NPE-if-realm_access-not-present-in-Keycloak-token

### DIFF
--- a/nuxeo-services/login/nuxeo-platform-login-keycloak/src/main/java/org/nuxeo/ecm/platform/ui/web/keycloak/KeycloakAuthenticationPlugin.java
+++ b/nuxeo-services/login/nuxeo-platform-login-keycloak/src/main/java/org/nuxeo/ecm/platform/ui/web/keycloak/KeycloakAuthenticationPlugin.java
@@ -173,10 +173,12 @@ public class KeycloakAuthenticationPlugin implements NuxeoAuthenticationPlugin,
      */
     private Set<String> getRoles(AccessToken token, String keycloakNuxeoApp) {
         Set<String> allRoles = new HashSet<>();
-        Set<String> roles = token.getRealmAccess().getRoles();
-        if (roles != null) {
-            allRoles.addAll(roles);
+
+        AccessToken.Access realmAccess = token.getRealmAccess();
+        if (realmAccess != null && realmAccess.getRoles() != null) {
+            allRoles.addAll(realmAccess.getRoles());
         }
+
         AccessToken.Access nuxeoResource = token.getResourceAccess(keycloakNuxeoApp);
         if (nuxeoResource != null) {
             Set<String> nuxeoRoles = nuxeoResource.getRoles();

--- a/nuxeo-services/login/nuxeo-platform-login-keycloak/src/test/java/org/nuxeo/ecm/platform/ui/web/keycloak/TestKeycloakAuthenticationPlugin.java
+++ b/nuxeo-services/login/nuxeo-platform-login-keycloak/src/test/java/org/nuxeo/ecm/platform/ui/web/keycloak/TestKeycloakAuthenticationPlugin.java
@@ -191,4 +191,31 @@ public class TestKeycloakAuthenticationPlugin {
         return keycloakAuthenticationPlugin;
     }
 
+    @Test
+    public void testKeycloakBearerAuthenticationSucceedingWithNullRealmAcess() throws Exception {
+        KeycloakAuthenticationPlugin keycloakAuthenticationPlugin = new KeycloakAuthenticationPlugin();
+        initPlugin(keycloakAuthenticationPlugin);
+
+        AccessToken accessToken = new AccessToken();
+        accessToken.setEmail("username@example.com");
+        AccessToken.Access realmAccess = new AccessToken.Access();
+        realmAccess.addRole("user");
+        accessToken.setRealmAccess(null);
+        Mockito.when(requestMock.getAttribute(KEYCLOAK_ACCESS_TOKEN)).thenReturn(accessToken);
+        Mockito.when(authenticatorMock.authenticate()).thenReturn(AuthOutcome.AUTHENTICATED);
+
+        Mockito.when(providerMock.provide(any(HttpServletRequest.class), any(HttpServletResponse.class))).thenReturn(
+                authenticatorMock);
+        KeycloakDeployment deployment = new KeycloakDeployment();
+        deployment.setResourceName("test");
+        Mockito.when(providerMock.getResolvedDeployment()).thenReturn(deployment);
+
+        keycloakAuthenticationPlugin.setKeycloakAuthenticatorProvider(providerMock);
+
+        UserIdentificationInfo identity = keycloakAuthenticationPlugin.handleRetrieveIdentity(requestFacade,
+                responseMock);
+
+        assertNotNull(identity);
+        assertEquals("username@example.com", identity.getUserName());
+    }
 }


### PR DESCRIPTION
PR created from https://qa2.nuxeo.org/jenkins/job/TestAndPush/job/ondemand-testandpush-cboidot-10.10/2/