### PR TITLE
NXP-29476: include MD5 when uploading to S3 bucket with ObjectLock (10.10)

### DIFF
--- a/addons/nuxeo-core-binarymanager-cloud/nuxeo-core-binarymanager-s3/src/main/java/org/nuxeo/ecm/blob/s3/S3BlobStore.java
+++ b/addons/nuxeo-core-binarymanager-cloud/nuxeo-core-binarymanager-s3/src/main/java/org/nuxeo/ecm/blob/s3/S3BlobStore.java
@@ -62,6 +62,7 @@ import org.nuxeo.ecm.core.io.download.DownloadHelper;
 import org.nuxeo.runtime.api.Framework;
 
 import com.amazonaws.AmazonServiceException;
+import com.amazonaws.SdkBaseException;
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.model.BucketVersioningConfiguration;
 import com.amazonaws.services.s3.model.CopyObjectRequest;
@@ -266,6 +267,9 @@ public class S3BlobStore extends AbstractBlobStore {
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
             throw new NuxeoException(e);
+        } catch (SdkBaseException e) {
+            // catch SdkBaseException and not just AmazonServiceException
+            throw new NuxeoException("Failed to write blob: " + key, e);
         }
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -169,7 +169,7 @@
     <selenium.version>2.53.0</selenium.version>
     <pdfbox.version>1.8.16</pdfbox.version>
     <pdfbox.jbig2.version>2.99.0-NX1</pdfbox.jbig2.version>
-    <aws.version>1.11.738</aws.version>
+    <aws.version>1.11.878</aws.version>
     <gcp.version>1.76.0</gcp.version>
     <azure.version>3.1.0</azure.version>
     <jackson1.version>1.8.1</jackson1.version>


### PR DESCRIPTION
Backport of #4366 