### PR TITLE
NXP-29709: use strict same site cookies by default

### DIFF
--- a/server/nuxeo-nxr-server/src/main/resources/templates/common-base/conf/Catalina/localhost/nuxeo.xml.nxftl
+++ b/server/nuxeo-nxr-server/src/main/resources/templates/common-base/conf/Catalina/localhost/nuxeo.xml.nxftl
@@ -11,6 +11,8 @@
   governing permissions and limitations under the License. -->
 <Context antiResourceLocking="false" privileged="true" docBase="../nxserver/nuxeo.war">
 
+  <CookieProcessor sameSiteCookies="${nuxeo.server.cookies.sameSite}" />
+  
   <!-- Disable HTTP Session persistence between restart since webengine session objects
     are not serializable -->
   <Manager pathname="" />

--- a/server/nuxeo-nxr-server/src/main/resources/templates/common-base/nuxeo.defaults
+++ b/server/nuxeo-nxr-server/src/main/resources/templates/common-base/nuxeo.defaults
@@ -12,6 +12,7 @@ nuxeo.server.ajp.port=8009
 nuxeo.server.ajp.secretRequired=true
 nuxeo.server.ajp.secret=changeme
 nuxeo.server.https.port=0
+nuxeo.server.cookies.sameSite=strict
 nuxeo.server.tomcat_admin.host=localhost
 nuxeo.server.tomcat_admin.port=8005
 nuxeo.server.tomcat_error.show_report=false

--- a/server/nuxeo-nxr-server/src/main/resources/templates/common/META-INF/templates/web.xml.nxftl
+++ b/server/nuxeo-nxr-server/src/main/resources/templates/common/META-INF/templates/web.xml.nxftl
@@ -52,6 +52,11 @@
     <session-timeout>${session.timeout}</session-timeout>
 <#if "${session.config.tracking.mode.cookie}" == "true">
     <tracking-mode>COOKIE</tracking-mode>
+    <#if "${nuxeo.server.cookies.sameSite}" == "none">
+    <cookie-config>
+      <secure>true</secure>
+    </cookie-config>
+    </#if>
 </#if>
   </session-config>
 


### PR DESCRIPTION
Basically this introduces a new conf property to set SameSite to strict by default.
When set to `none` we force secure cookies which are required. Unfortunately this means cross origin cookie based auth will only work when serving over SSL so we don't have any easy alternative for local dev..

FYI @bstefanescu 