### PR TITLE
improvement NXP 29686 shell scripts docker runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,8 @@ To take the shortest path for building the Docker image, run the following comma
 mvn install -Pdistrib,docker -pl docker -am -DskipTests -Dnuxeo.skip.enforcer=true -T6
 ```
 
+See the [docker](docker) directory for more information on how to build, run and configure the Nuxeo Docker Image.
+
 See our [Nuxeo Core Developer Guide](https://doc.nuxeo.com/n/9ib) for complete instructions and guidelines.
 
 ## Resources

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -100,7 +100,7 @@ COPY docker-entrypoint.sh /
 COPY install-packages.sh /
 COPY install-local-packages.sh /
 
-# Create directory in which to mount property files appended to nuxeo.conf at runtime.
+# Create directory in which to mount property files appended to nuxeo.conf at runtime
 RUN mkdir /etc/nuxeo/conf.d
 # Copy base property files.
 COPY conf.d /etc/nuxeo/conf.d/

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -105,6 +105,10 @@ RUN mkdir /etc/nuxeo/conf.d
 # Copy base property files.
 COPY conf.d /etc/nuxeo/conf.d/
 
+# Create directory in which to copy shell scripts to run at runtime
+RUN mkdir /docker-entrypoint-initnuxeo.d \
+  && chown 900:0 /docker-entrypoint-initnuxeo.d && chmod g+rwX /docker-entrypoint-initnuxeo.d
+
 # Copy Nuxeo distribution
 COPY --from=builder /distrib $NUXEO_HOME
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -111,6 +111,27 @@ The [dive](https://github.com/wagoodman/dive) tool is also very good for explori
 dive nuxeo/nuxeo:latest
 ```
 
+## Build an Image From the Nuxeo Image
+
+We provide some utility scripts to install Nuxeo packages when building an image from the Nuxeo image:
+
+- [install-local-packages.sh](./install-local-packages.sh): install a local Nuxeo package embedded in the image as a ZIP file.
+- [install-packages.sh](./install-packages.sh): install a remote Nuxeo package from [Nuxeo Connect](https://connect.nuxeo.com/).
+
+For instance, you can use these scripts in the following `Dockerfile`:
+
+```Dockerfile
+FROM <DOCKER_REGISTRY>/nuxeo:<TAG>
+
+ARG CLID
+ARG CONNECT_URL
+
+COPY --chown=900:0 path/to/local-package-*.zip $NUXEO_HOME/local-packages/local-package.zip
+
+RUN /install-local-packages.sh $NUXEO_HOME/local-packages
+RUN /install-packages.sh --clid ${CLID} --connect-url ${CONNECT_URL} nuxeo-web-ui nuxeo-drive
+```
+
 ## Configure the Image at Runtime
 
 Though we try to have immutable images configured at build time, in some cases it makes sense to configure a container at runtime. This typically applies to the address and credentials of each back-end store (database, Elasticsearch, S3, etc.) that are specific to a given deployment: development, staging, production, etc.

--- a/docker/README.md
+++ b/docker/README.md
@@ -185,3 +185,8 @@ For instance, to run a container with the `nuxeo-web-ui` and `nuxeo-drive` packa
 ```bash
 docker run -it -p 8080:8080 -e NUXEO_CLID=<NUXEO_CLID> -e NUXEO_PACKAGES="nuxeo-web-ui nuxeo-drive" nuxeo/nuxeo:latest
 ```
+
+### Shell Scripts
+
+To run some shell scripts when running a container from a Nuxeo image, you can add
+`*.sh` files in the `/docker-entrypoint-initnuxeo.d` directory of the image. They will be executed at startup by the default `ENTRYPOINT`.

--- a/docker/README.md
+++ b/docker/README.md
@@ -3,7 +3,7 @@
 Nuxeo provides a ready to use Docker image that is pushed to our Docker registry. To pull the image, run:
 
 ```bash
-docker pull DOCKER_REGISTRY/nuxeo:TAG
+docker pull <DOCKER_REGISTRY>/nuxeo:<TAG>
 ```
 
 ## Disclaimer
@@ -44,7 +44,7 @@ mvn -nsu install
 
 ### With Skaffold
 
-We use Skaffold to build the images as part of the [nuxeo](http://jenkins.platform.dev.nuxeo.com/job/nuxeo/job/nuxeo/) pipeline in our Jenkins CI/CD platform.
+We use Skaffold to build the image as part of the [nuxeo](http://jenkins.platform.dev.nuxeo.com/job/nuxeo/job/nuxeo/) pipeline in our Jenkins CI/CD platform.
 
 This requires to:
 
@@ -54,7 +54,7 @@ This requires to:
 
 It also requires the following environment variables:
 
-- `DOCKER_REGISTRY`: the Docker registry to push the images to.
+- `DOCKER_REGISTRY`: the Docker registry to push the image to.
 - `VERSION`: the image tag, for instance `latest`.
 
 To build the `nuxeo/nuxeo` image with Skaffold, you first need to fetch the Nuxeo server ZIP file and make it available for the Docker build with Maven:
@@ -94,7 +94,7 @@ docker run -it -p 8080:8080 nuxeo/nuxeo:latest
 To pull the `nuxeo/nuxeo` image from our Docker regsitry and run a container from it, run:
 
 ```bash
-docker run -it -p 8080:8080 DOCKER_REGISTRY/nuxeo/nuxeo:latest
+docker run -it -p 8080:8080 <DOCKER_REGISTRY>/nuxeo/nuxeo:latest
 ```
 
 ## Inspect the Image

--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
 set -e
 
+# expand filename patterns which match no files to a null string, rather than themselves
+shopt -s nullglob
+
 # Allow supporting arbitrary user IDs
 if ! whoami &> /dev/null; then
   if [ -w /etc/passwd ]; then
@@ -52,6 +55,15 @@ if [[ ! -f $NUXEO_HOME/configured && ! -f $NUXEO_CONF ]]; then
 
   touch $NUXEO_HOME/configured
 fi
+
+# Handle shell scripts
+echo "ENTRYPOINT: Looking for shell scripts in /docker-entrypoint-initnuxeo.d"
+for f in /docker-entrypoint-initnuxeo.d/*; do
+  case "$f" in
+    *.sh)  echo "Running $f"; /bin/bash "$f" ;;
+    *)     echo "Ignoring $f" ;;
+  esac
+done
 
 # Handle instance.clid
 if [ -n "$NUXEO_CLID" ]; then


### PR DESCRIPTION
Allow to run shell scripts when starting the Nuxeo Docker image (ENTRYPOINT).

Also, document utility scripts to install packages in a Docker image built from the Nuxeo image.
