### PR TITLE
NXP-29686: Run custom shell scripts at the end of ENTRYPOINT

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -209,5 +209,7 @@ docker run -it -p 8080:8080 -e NUXEO_CLID=<NUXEO_CLID> -e NUXEO_PACKAGES="nuxeo-
 
 ### Shell Scripts
 
-To run some shell scripts when running a container from a Nuxeo image, you can add
-`*.sh` files in the `/docker-entrypoint-initnuxeo.d` directory of the image. They will be executed at startup by the default `ENTRYPOINT`.
+To run some shell scripts when starting a container from a Nuxeo image, you can add
+`*.sh` files in the `/docker-entrypoint-initnuxeo.d` directory of the image.
+
+They will be alphabetically sorted and executed at the very end of the `ENTRYPOINT`, after handling the environment variables. Thus, if you run a container by passing the `NUXEO_CLID` environment variable, invoking `nuxeoctl` in such a shell script will work as being registered.

--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -56,15 +56,6 @@ if [[ ! -f $NUXEO_HOME/configured && ! -f $NUXEO_CONF ]]; then
   touch $NUXEO_HOME/configured
 fi
 
-# Handle shell scripts
-echo "ENTRYPOINT: Looking for shell scripts in /docker-entrypoint-initnuxeo.d"
-for f in /docker-entrypoint-initnuxeo.d/*; do
-  case "$f" in
-    *.sh)  echo "Running $f"; /bin/bash "$f" ;;
-    *)     echo "Ignoring $f" ;;
-  esac
-done
-
 # Handle instance.clid
 if [ -n "$NUXEO_CLID" ]; then
   echo "ENTRYPOINT: Write NUXEO_CLID environment variable to /var/lib/nuxeo/instance.clid"
@@ -78,5 +69,14 @@ if [ -n "$NUXEO_PACKAGES" ]; then
   echo "ENTRYPOINT: Install Nuxeo packages: $NUXEO_PACKAGES"
   nuxeoctl mp-install $NUXEO_PACKAGES --accept=true --relax no
 fi
+
+# Handle shell scripts
+echo "ENTRYPOINT: Looking for shell scripts in /docker-entrypoint-initnuxeo.d"
+for f in /docker-entrypoint-initnuxeo.d/*; do
+  case "$f" in
+    *.sh)  echo "Running $f"; /bin/bash "$f" ;;
+    *)     echo "Ignoring $f" ;;
+  esac
+done
 
 exec "$@"


### PR DESCRIPTION
This allows for instance to invoke `nuxeoctl mp-install` in a registered way if the NUXEO_CLID environment varible is passed when running the container.
