### PR TITLE
NXP-29734: Test new external service versions

### DIFF
--- a/ci/Jenkinsfiles/build.groovy
+++ b/ci/Jenkinsfiles/build.groovy
@@ -216,6 +216,7 @@ def buildUnitTestStage(env) {
                 jx step helm install ${HELM_CHART_REPOSITORY_NAME}/${HELM_CHART_NUXEO} \
                   --name=${TEST_HELM_CHART_RELEASE} \
                   --namespace=${testNamespace} \
+                  --version=1.0.13-PR-24-2 \
                   ${testValues}
               """
               // wait for external services to be ready


### PR DESCRIPTION
This PR is not supposed to be merged, it exists to trigger the build and test the new chart version.

See: https://github.com/nuxeo/nuxeo-helm-chart/pull/24