### PR TITLE
NXP-29729: Align java code after org.json:json upgrade

### DIFF
--- a/modules/platform/nuxeo-scim-server/src/main/java/org/nuxeo/scim/server/jaxrs/marshalling/NXJsonUnmarshaller.java
+++ b/modules/platform/nuxeo-scim-server/src/main/java/org/nuxeo/scim/server/jaxrs/marshalling/NXJsonUnmarshaller.java
@@ -68,11 +68,10 @@ public class NXJsonUnmarshaller extends JsonUnmarshaller {
             return null;
         }
 
-        @SuppressWarnings("unchecked")
-        Iterator<Object> keys = jsonObject.keys();
+        Iterator<String> keys = jsonObject.keys();
         Map<String, Object> lowerCaseMap = new HashMap<>(jsonObject.length());
         while (keys.hasNext()) {
-            String key = keys.next().toString();
+            String key = keys.next();
             String lowerCaseKey = toLowerCase(key);
             lowerCaseMap.put(lowerCaseKey, jsonObject.get(key));
         }


### PR DESCRIPTION
Maven/javac succeed to build this class but it wasn't the case for IDEs (Eclipse or IDEA) which reported a compilation error.