### PR TITLE
NXP-29587: Scroller produces records downstream depending on a thres…

### DIFF
--- a/modules/core/nuxeo-core-bulk/src/main/java/org/nuxeo/ecm/core/bulk/BulkAdminServiceImpl.java
+++ b/modules/core/nuxeo-core-bulk/src/main/java/org/nuxeo/ecm/core/bulk/BulkAdminServiceImpl.java
@@ -47,6 +47,13 @@ public class BulkAdminServiceImpl implements BulkAdminService {
 
     public static final String BULK_SCROLL_PRODUCE_IMMEDIATE_PROPERTY = "nuxeo.core.bulk.scroller.produceImmediate";
 
+    // @since 11.4
+    public static final String BULK_SCROLL_PRODUCE_IMMEDIATE_THRESHOLD_PROPERTY = "nuxeo.core.bulk.scroller.produceImmediateThreshold";
+
+    // by default switch to produce immediate when there are more than 1m ids
+    // @since 11.4
+    public static final int DEFAULT_PRODUCE_IMMEDIATE_THRESHOLD_PROPERTY = 1_000_000;
+
     public static final int DEFAULT_SCROLL_SIZE = 100;
 
     public static final int DEFAULT_SCROLL_KEEP_ALIVE = 60;

--- a/modules/core/nuxeo-core-bulk/src/main/java/org/nuxeo/ecm/core/bulk/BulkServiceProcessor.java
+++ b/modules/core/nuxeo-core-bulk/src/main/java/org/nuxeo/ecm/core/bulk/BulkServiceProcessor.java
@@ -20,8 +20,10 @@ package org.nuxeo.ecm.core.bulk;
 
 import static org.nuxeo.ecm.core.bulk.BulkAdminServiceImpl.BULK_SCROLL_KEEP_ALIVE_PROPERTY;
 import static org.nuxeo.ecm.core.bulk.BulkAdminServiceImpl.BULK_SCROLL_PRODUCE_IMMEDIATE_PROPERTY;
+import static org.nuxeo.ecm.core.bulk.BulkAdminServiceImpl.BULK_SCROLL_PRODUCE_IMMEDIATE_THRESHOLD_PROPERTY;
 import static org.nuxeo.ecm.core.bulk.BulkAdminServiceImpl.BULK_SCROLL_SIZE_PROPERTY;
 import static org.nuxeo.ecm.core.bulk.BulkAdminServiceImpl.BULK_SCROLL_TRANSACTION_TIMEOUT_PROPERTY;
+import static org.nuxeo.ecm.core.bulk.BulkAdminServiceImpl.DEFAULT_PRODUCE_IMMEDIATE_THRESHOLD_PROPERTY;
 import static org.nuxeo.ecm.core.bulk.BulkAdminServiceImpl.DEFAULT_SCROLL_KEEP_ALIVE;
 import static org.nuxeo.ecm.core.bulk.BulkAdminServiceImpl.DEFAULT_SCROLL_SIZE;
 import static org.nuxeo.ecm.core.bulk.BulkAdminServiceImpl.DEFAULT_SCROLL_TRANSACTION_TIMEOUT;
@@ -70,10 +72,13 @@ public class BulkServiceProcessor implements StreamProcessorTopology {
                 DEFAULT_SCROLL_TRANSACTION_TIMEOUT);
 
         boolean scrollProduceImmediate = confService.isBooleanTrue(BULK_SCROLL_PRODUCE_IMMEDIATE_PROPERTY);
+        int scrollProduceImmediateThreshold = confService.getInteger(BULK_SCROLL_PRODUCE_IMMEDIATE_THRESHOLD_PROPERTY)
+                                                         .orElse(DEFAULT_PRODUCE_IMMEDIATE_THRESHOLD_PROPERTY);
         return Topology.builder()
                        .addComputation( //
                                () -> new BulkScrollerComputation(SCROLLER_NAME, actions.size() + 1, scrollBatchSize,
-                                       scrollKeepAlive, transactionTimeout, scrollProduceImmediate), //
+                                       scrollKeepAlive, transactionTimeout, scrollProduceImmediate,
+                                       scrollProduceImmediateThreshold), //
                                mapping)
                        .addComputation(() -> new BulkStatusComputation(STATUS_NAME),
                                Arrays.asList(INPUT_1 + ":" + STATUS_STREAM, //

--- a/server/nuxeo-nxr-server/src/main/resources/templates/perf/nxserver/config/bulk-perf-config.xml
+++ b/server/nuxeo-nxr-server/src/main/resources/templates/perf/nxserver/config/bulk-perf-config.xml
@@ -6,7 +6,6 @@
     <property name="nuxeo.core.bulk.scroller.concurrency">2</property>
     <property name="nuxeo.core.bulk.scroller.scroll.size">250</property>
     <property name="nuxeo.core.bulk.scroller.scroll.keepAliveSeconds">60</property>
-    <property name="nuxeo.core.bulk.scroller.produceImmediate">true</property>
     <property name="nuxeo.core.bulk.status.concurrency">1</property>
     <property name="nuxeo.core.bulk.done.concurrency">1</property>
   </extension>


### PR DESCRIPTION
…hold

If the bulk scroller materialize more than 1m ids, records are sent
downstream to prevent a possible OOM.