### PR TITLE
NXP-29854: remove unused dependency commons-dbcp

### DIFF
--- a/modules/core/nuxeo-core-management-jtajca/pom.xml
+++ b/modules/core/nuxeo-core-management-jtajca/pom.xml
@@ -20,10 +20,6 @@
       <artifactId>commons-beanutils</artifactId>
     </dependency>
     <dependency>
-      <groupId>commons-dbcp</groupId>
-      <artifactId>commons-dbcp</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.apache.tomcat</groupId>
       <artifactId>tomcat-dbcp</artifactId>
     </dependency>

--- a/modules/platform/login/nuxeo-platform-login-deputy/pom.xml
+++ b/modules/platform/login/nuxeo-platform-login-deputy/pom.xml
@@ -62,11 +62,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>commons-dbcp</groupId>
-      <artifactId>commons-dbcp</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>commons-beanutils</groupId>
       <artifactId>commons-beanutils</artifactId>
       <scope>test</scope>

--- a/pom.xml
+++ b/pom.xml
@@ -2252,11 +2252,6 @@
         <version>1.20</version>
       </dependency>
       <dependency>
-        <groupId>commons-dbcp</groupId>
-        <artifactId>commons-dbcp</artifactId>
-        <version>1.4</version>
-      </dependency>
-      <dependency>
         <groupId>commons-jexl</groupId>
         <artifactId>commons-jexl</artifactId>
         <version>1.1</version>

--- a/scripts/licenses-descriptions.txt
+++ b/scripts/licenses-descriptions.txt
@@ -76,7 +76,6 @@ com.vaadin.external.flute:flute|[Flute](http://code.google.com/p/google-web-tool
 commons-beanutils:commons-beanutils|[Apache Commons BeanUtils](http://commons.apache.org/beanutils/)
 commons-codec:commons-codec|[Apache Commons Codec](http://commons.apache.org/codec/)
 commons-collections:commons-collections|[Apache Commons Collections](http://commons.apache.org/collections/)
-commons-dbcp:commons-dbcp|[Apache Commons DBCP](http://commons.apache.org/dbcp/)
 commons-digester:commons-digester|[Apache Commons Digester](http://commons.apache.org/digester/)
 commons-fileupload:commons-fileupload|[Apache Commons FileUpload](http://commons.apache.org/fileupload/)
 commons-httpclient:commons-httpclient|[Apache Commons HttpClient](http://hc.apache.org/httpclient-3.x/)


### PR DESCRIPTION
Remove DBCP 1. We still use DBCP 2.