### PR TITLE
NXP-29585: Add Bulk command queryLimit

### DIFF
--- a/modules/core/nuxeo-core-bulk/src/main/java/org/nuxeo/ecm/core/bulk/BulkActionDescriptor.java
+++ b/modules/core/nuxeo-core-bulk/src/main/java/org/nuxeo/ecm/core/bulk/BulkActionDescriptor.java
@@ -66,6 +66,10 @@ public class BulkActionDescriptor implements Descriptor {
     @XNode("@defaultScroller")
     public String defaultScroller;
 
+    // @since 11.4 the maximum number of items that the scroller can return
+    @XNode("@defaultQueryLimit")
+    public Long defaultQueryLimit;
+
     @Override
     public String getId() {
         return name;
@@ -77,6 +81,11 @@ public class BulkActionDescriptor implements Descriptor {
 
     public Integer getBatchSize() {
         return batchSize;
+    }
+
+    // @since 11.4
+    public Long getDefaultQueryLimit() {
+        return defaultQueryLimit;
     }
 
     /**

--- a/modules/core/nuxeo-core-bulk/src/main/java/org/nuxeo/ecm/core/bulk/BulkAdminService.java
+++ b/modules/core/nuxeo-core-bulk/src/main/java/org/nuxeo/ecm/core/bulk/BulkAdminService.java
@@ -40,6 +40,13 @@ public interface BulkAdminService {
     int getBatchSize(String action);
 
     /**
+     * Returns the default query limit for the bulk action.
+     *
+     * @since 11.4
+     */
+    Long getQueryLimit(String action);
+
+    /**
      * @since 11.1
      */
     String getDefaultScroller(String action);

--- a/modules/core/nuxeo-core-bulk/src/main/java/org/nuxeo/ecm/core/bulk/BulkAdminServiceImpl.java
+++ b/modules/core/nuxeo-core-bulk/src/main/java/org/nuxeo/ecm/core/bulk/BulkAdminServiceImpl.java
@@ -100,6 +100,11 @@ public class BulkAdminServiceImpl implements BulkAdminService {
     }
 
     @Override
+    public Long getQueryLimit(String action) {
+        return descriptors.get(action).getDefaultQueryLimit();
+    }
+
+    @Override
     public String getDefaultScroller(String action) {
         return descriptors.get(action).getDefaultScroller();
     }

--- a/modules/core/nuxeo-core-bulk/src/main/java/org/nuxeo/ecm/core/bulk/BulkServiceImpl.java
+++ b/modules/core/nuxeo-core-bulk/src/main/java/org/nuxeo/ecm/core/bulk/BulkServiceImpl.java
@@ -137,6 +137,9 @@ public class BulkServiceImpl implements BulkService {
                 command.setBatchSize(adminService.getBatchSize(command.getAction()));
             }
         }
+        if (command.getQueryLimit() == null) {
+            command.setQueryLimit(adminService.getQueryLimit(command.getAction()));
+        }
         if (command.getScroller() == null && !command.useExternalScroller()) {
             String actionScroller = adminService.getDefaultScroller(command.getAction());
             if (!isBlank(actionScroller)) {

--- a/modules/core/nuxeo-core-bulk/src/main/java/org/nuxeo/ecm/core/bulk/BulkServiceProcessor.java
+++ b/modules/core/nuxeo-core-bulk/src/main/java/org/nuxeo/ecm/core/bulk/BulkServiceProcessor.java
@@ -75,10 +75,15 @@ public class BulkServiceProcessor implements StreamProcessorTopology {
         int scrollProduceImmediateThreshold = confService.getInteger(BULK_SCROLL_PRODUCE_IMMEDIATE_THRESHOLD_PROPERTY)
                                                          .orElse(DEFAULT_PRODUCE_IMMEDIATE_THRESHOLD_PROPERTY);
         return Topology.builder()
-                       .addComputation( //
-                               () -> new BulkScrollerComputation(SCROLLER_NAME, actions.size() + 1, scrollBatchSize,
-                                       scrollKeepAlive, transactionTimeout, scrollProduceImmediate,
-                                       scrollProduceImmediateThreshold), //
+                       .addComputation(
+                               () -> BulkScrollerComputation.builder(SCROLLER_NAME, actions.size() + 1)
+                                                            .setScrollBatchSize(scrollBatchSize)
+                                                            .setScrollKeepAliveSeconds(scrollKeepAlive)
+                                                            .setTransactionTimeout(transactionTimeout)
+                                                            .setProduceImmediate(scrollProduceImmediate)
+                                                            .setProduceImmediateThreshold(
+                                                                    scrollProduceImmediateThreshold)
+                                                            .build(),
                                mapping)
                        .addComputation(() -> new BulkStatusComputation(STATUS_NAME),
                                Arrays.asList(INPUT_1 + ":" + STATUS_STREAM, //

--- a/modules/core/nuxeo-core-bulk/src/main/java/org/nuxeo/ecm/core/bulk/message/BulkCommand.java
+++ b/modules/core/nuxeo-core-bulk/src/main/java/org/nuxeo/ecm/core/bulk/message/BulkCommand.java
@@ -49,6 +49,10 @@ public class BulkCommand implements Serializable {
 
     protected String query;
 
+    // @scince 11.4
+    @Nullable
+    protected Long queryLimit;
+
     protected String username;
 
     @Nullable
@@ -82,6 +86,7 @@ public class BulkCommand implements Serializable {
         this.username = builder.username;
         this.repository = builder.repository;
         this.query = builder.query;
+        this.queryLimit = builder.queryLimit;
         this.action = builder.action;
         this.bucketSize = builder.bucketSize;
         this.batchSize = builder.batchSize;
@@ -150,6 +155,15 @@ public class BulkCommand implements Serializable {
         return batchSize;
     }
 
+    /**
+     * When greater than 0, the limit applied to the query results
+     *
+     * @since 11.4
+     */
+    public Long getQueryLimit() {
+        return queryLimit;
+    }
+
     @Override
     public int hashCode() {
         return HashCodeBuilder.reflectionHashCode(this);
@@ -163,6 +177,10 @@ public class BulkCommand implements Serializable {
     @Override
     public String toString() {
         return ToStringBuilder.reflectionToString(this);
+    }
+
+    public void setQueryLimit(Long limit) {
+        this.queryLimit = limit;
     }
 
     public void setBatchSize(int batchSize) {
@@ -185,6 +203,8 @@ public class BulkCommand implements Serializable {
         protected final String action;
 
         protected final String query;
+
+        protected Long queryLimit;
 
         protected String repository;
 
@@ -251,6 +271,29 @@ public class BulkCommand implements Serializable {
          */
         public Builder repository(String name) {
             this.repository = name;
+            return this;
+        }
+
+        /**
+         * Limits the query result.
+         *
+         * @since 11.4
+         */
+        public Builder queryLimit(long limit) {
+            if (limit <= 0) {
+                throw new IllegalArgumentException(String.format("Invalid limit: %d, must be > 0", limit));
+            }
+            this.queryLimit = limit;
+            return this;
+        }
+
+        /**
+         * Unlimited query results, this will override the action defaultQueryLimit.
+         *
+         * @since 11.4
+         */
+        public Builder queryUnlimited() {
+            this.queryLimit = 0L;
             return this;
         }
 

--- a/modules/core/nuxeo-core-bulk/src/main/java/org/nuxeo/ecm/core/bulk/message/BulkStatus.java
+++ b/modules/core/nuxeo-core-bulk/src/main/java/org/nuxeo/ecm/core/bulk/message/BulkStatus.java
@@ -27,6 +27,7 @@ import java.util.Map;
 
 import javax.validation.constraints.NotNull;
 
+import org.apache.avro.reflect.AvroDefault;
 import org.apache.avro.reflect.AvroEncode;
 import org.apache.avro.reflect.Nullable;
 import org.apache.commons.lang3.builder.EqualsBuilder;
@@ -110,6 +111,9 @@ public class BulkStatus implements AsyncStatus<String> {
 
     @Nullable
     protected Long processingDurationMillis;
+
+    @AvroDefault("false")
+    protected boolean queryLimitReached;
 
     @Nullable
     @AvroEncode(using = MapAsJsonAsStringEncoding.class)
@@ -208,6 +212,9 @@ public class BulkStatus implements AsyncStatus<String> {
         if (update.errorMessage != null && errorMessage == null) {
             errorMessage = update.errorMessage;
         }
+        if (update.queryLimitReached) {
+            queryLimitReached = true;
+        }
         checkForCompletedState();
     }
 
@@ -304,6 +311,22 @@ public class BulkStatus implements AsyncStatus<String> {
 
     public void setCompletedTime(@NotNull Instant completedTime) {
         this.completedTime = completedTime.toEpochMilli();
+    }
+
+    /**
+     * Returns true if the query used by the scroller has been limited.
+     *
+     * @since 11.4
+     */
+    public boolean isQueryLimitReached() {
+        return queryLimitReached;
+    }
+
+    /**
+     * @since 11.4
+     */
+    public void setQueryLimitReached(boolean queryLimitReached) {
+        this.queryLimitReached = queryLimitReached;
     }
 
     @Override

--- a/modules/core/nuxeo-core-bulk/src/test/java/org/nuxeo/ecm/core/bulk/action/TestWordCountAction.java
+++ b/modules/core/nuxeo-core-bulk/src/test/java/org/nuxeo/ecm/core/bulk/action/TestWordCountAction.java
@@ -19,6 +19,7 @@
 package org.nuxeo.ecm.core.bulk.action;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.nuxeo.ecm.core.bulk.message.BulkStatus.State.COMPLETED;
 
@@ -26,8 +27,12 @@ import java.io.BufferedWriter;
 import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.time.Duration;
 import java.util.Random;
+import java.util.stream.Stream;
 
 import javax.inject.Inject;
 
@@ -70,7 +75,98 @@ public class TestWordCountAction {
         assertTrue(bulkService.await(commandId, Duration.ofSeconds(20)));
         BulkStatus status = bulkService.getStatus(commandId);
         assertEquals(COMPLETED, status.getState());
+        assertFalse(status.isQueryLimitReached());
         assertEquals(wordCount, status.getResult().get("wordCount"));
+    }
+
+    @Test
+    public void testWordCountWithLimitedQuery() throws Exception {
+        int wordCount = 2732;
+        String myFile = createFile(wordCount);
+        int lines = countLines(myFile);
+
+        // Use an action limited by default to the first 100 first lines
+        BulkCommand command = new BulkCommand.Builder("testWordCountLimited", myFile, "system")
+                .useGenericScroller()
+                .build();
+        String commandId = bulkService.submit(command);
+        assertTrue(bulkService.await(commandId, Duration.ofSeconds(20)));
+        BulkStatus status = bulkService.getStatus(commandId);
+        assertEquals(COMPLETED, status.getState());
+        assertTrue(status.isQueryLimitReached());
+        int result100 = (Integer) status.getResult().get("wordCount");
+        assertTrue(result100 > 0);
+        // the number of word for the first 100 lines is inferior to the total number of words in the file
+        assertTrue(wordCount > result100);
+
+        // Now set an explicit limit to a lower number of lines
+        command = new BulkCommand.Builder("testWordCountLimited",  myFile, "system")
+                .useGenericScroller()
+                .queryLimit(10)
+                .build();
+        commandId = bulkService.submit(command);
+        assertTrue(bulkService.await(commandId, Duration.ofSeconds(20)));
+        status = bulkService.getStatus(commandId);
+        assertTrue(status.isQueryLimitReached());
+        assertEquals(COMPLETED, status.getState());
+        int result = (Integer) status.getResult().get("wordCount");
+        // there is less words in 10 lines than 100
+        assertTrue(result100 > result);
+
+        // Check edge cases when limit is set to n-1 lines
+        command = new BulkCommand.Builder("testWordCountLimited", myFile, "system")
+                .useGenericScroller()
+                .queryLimit(lines - 1)
+                .build();
+        commandId = bulkService.submit(command);
+        assertTrue(bulkService.await(commandId, Duration.ofSeconds(20)));
+        status = bulkService.getStatus(commandId);
+        // the limit is reached
+        assertTrue(status.isQueryLimitReached());
+        assertEquals(COMPLETED, status.getState());
+        result = (Integer) status.getResult().get("wordCount");
+        assertTrue(wordCount >= result);
+
+        // Check edge cases when limit is set to n lines
+        command = new BulkCommand.Builder("testWordCountLimited", myFile, "system")
+                .useGenericScroller()
+                .queryLimit(lines)
+                .build();
+        commandId = bulkService.submit(command);
+        assertTrue(bulkService.await(commandId, Duration.ofSeconds(20)));
+        status = bulkService.getStatus(commandId);
+        // the limit is reached
+        assertTrue(status.isQueryLimitReached());
+        assertEquals(COMPLETED, status.getState());
+        result = (Integer) status.getResult().get("wordCount");
+        assertEquals(wordCount, result);
+
+        // Check edge cases when limit is set to n+1 lines
+        command = new BulkCommand.Builder("testWordCountLimited", myFile, "system")
+                .useGenericScroller()
+                .queryLimit(lines + 1)
+                .build();
+        commandId = bulkService.submit(command);
+        assertTrue(bulkService.await(commandId, Duration.ofSeconds(20)));
+        status = bulkService.getStatus(commandId);
+        // the limit is not reached
+        assertFalse(status.isQueryLimitReached());
+        assertEquals(COMPLETED, status.getState());
+        result = (Integer) status.getResult().get("wordCount");
+        assertEquals(wordCount, result);
+
+        // Unlimited query
+        command = new BulkCommand.Builder("testWordCountLimited",  myFile, "system")
+                .useGenericScroller()
+                .queryUnlimited()
+                .build();
+        commandId = bulkService.submit(command);
+        assertTrue(bulkService.await(commandId, Duration.ofSeconds(20)));
+        status = bulkService.getStatus(commandId);
+        assertEquals(COMPLETED, status.getState());
+        assertFalse(status.isQueryLimitReached());
+        result = (Integer) status.getResult().get("wordCount");
+        assertEquals(wordCount, result);
     }
 
     protected String createFile(int wordCount) throws IOException {
@@ -84,5 +180,11 @@ public class TestWordCountAction {
             }
         }
         return tempFile.getAbsolutePath();
+    }
+
+    protected int countLines(String filename) throws IOException {
+        try (Stream<String> stream = Files.lines(Path.of(filename), StandardCharsets.UTF_8)) {
+            return Math.toIntExact(stream.count());
+        }
     }
 }

--- a/modules/core/nuxeo-core-bulk/src/test/resources/OSGI-INF/test-bulk-contrib.xml
+++ b/modules/core/nuxeo-core-bulk/src/test/resources/OSGI-INF/test-bulk-contrib.xml
@@ -5,11 +5,16 @@
   <extension target="org.nuxeo.ecm.core.bulk" point="actions">
     <action name="testWordCount" inputStream="test/wordCount" defaultScroller="myFileScroll" bucketSize="100"
       batchSize="25" />
+
+    <action name="testWordCountLimited" inputStream="test/wordCount" defaultScroller="myFileScroll" bucketSize="100"
+      batchSize="25" defaultQueryLimit="100" />
   </extension>
+
 
   <extension target="org.nuxeo.runtime.stream.service" point="streamProcessor">
     <streamProcessor name="fail" class="org.nuxeo.ecm.core.bulk.action.WordCountAction" defaultConcurrency="2"
       defaultPartitions="2" />
   </extension>
+
 
 </component>

--- a/modules/platform/nuxeo-platform-csv-export/src/main/resources/OSGI-INF/csv-export-config.xml
+++ b/modules/platform/nuxeo-platform-csv-export/src/main/resources/OSGI-INF/csv-export-config.xml
@@ -6,6 +6,7 @@
   <extension target="org.nuxeo.ecm.core.bulk" point="actions">
     <action name="csvExport" inputStream="bulk/csvExport" bucketSize="100" batchSize="50" httpEnabled="true"
       defaultScroller="${nuxeo.core.bulk.csvExport.scroller:=default}"
+      defaultQueryLimit="${nuxeo.core.bulk.csvExport.queryLimit:=100000}"
       validationClass="org.nuxeo.ecm.platform.csv.export.validation.CSVExportValidation" />
   </extension>
 

--- a/modules/platform/nuxeo-platform-imaging/nuxeo-platform-imaging-core/src/main/resources/OSGI-INF/imaging-bulk-contrib.xml
+++ b/modules/platform/nuxeo-platform-imaging/nuxeo-platform-imaging-core/src/main/resources/OSGI-INF/imaging-bulk-contrib.xml
@@ -10,7 +10,7 @@
 
   <extension target="org.nuxeo.runtime.stream.service" point="streamProcessor">
     <streamProcessor name="recomputeViews" class="org.nuxeo.ecm.platform.picture.recompute.RecomputeViewsAction"
-      defaultConcurrency="2" defaultPartitions="2">
+      defaultConcurrency="2" defaultPartitions="6">
       <policy name="default" maxRetries="3" delay="1s" maxDelay="10s" continueOnFailure="true" />
     </streamProcessor>
   </extension>

--- a/modules/platform/nuxeo-platform-imaging/nuxeo-platform-imaging-core/src/main/resources/OSGI-INF/picture-workmanager-contrib.xml
+++ b/modules/platform/nuxeo-platform-imaging/nuxeo-platform-imaging-core/src/main/resources/OSGI-INF/picture-workmanager-contrib.xml
@@ -3,7 +3,7 @@
 
   <extension target="org.nuxeo.ecm.core.work.service" point="queues">
     <queue id="pictureViewsGeneration">
-      <maxThreads>1</maxThreads>
+      <maxThreads>2</maxThreads>
       <category>pictureViewsGeneration</category>
     </queue>
   </extension>

--- a/modules/platform/nuxeo-platform-rendition/nuxeo-platform-rendition-core/src/main/resources/OSGI-INF/rendition-workmanager-contrib.xml
+++ b/modules/platform/nuxeo-platform-rendition/nuxeo-platform-rendition-core/src/main/resources/OSGI-INF/rendition-workmanager-contrib.xml
@@ -3,7 +3,7 @@
 
   <extension target="org.nuxeo.ecm.core.work.service" point="queues">
     <queue id="renditionBuilder">
-      <maxThreads>1</maxThreads>
+      <maxThreads>2</maxThreads>
       <category>renditionBuilder</category>
     </queue>
   </extension>

--- a/modules/platform/nuxeo-platform-video/src/main/resources/OSGI-INF/video-workmanager-config.xml
+++ b/modules/platform/nuxeo-platform-video/src/main/resources/OSGI-INF/video-workmanager-config.xml
@@ -3,7 +3,7 @@
 
   <extension target="org.nuxeo.ecm.core.work.service" point="queues">
     <queue id="videoConversion">
-      <maxThreads>1</maxThreads>
+      <maxThreads>2</maxThreads>
       <category>videoConversion</category>
     </queue>
   </extension>

--- a/modules/platform/nuxeo-thumbnail/src/main/resources/OSGI-INF/thumbnail-bulk-contrib.xml
+++ b/modules/platform/nuxeo-thumbnail/src/main/resources/OSGI-INF/thumbnail-bulk-contrib.xml
@@ -11,7 +11,7 @@
   <extension target="org.nuxeo.runtime.stream.service" point="streamProcessor">
     <streamProcessor name="recomputeThumbnails"
       class="org.nuxeo.ecm.platform.thumbnail.action.RecomputeThumbnailsAction" defaultConcurrency="2"
-      defaultPartitions="2">
+      defaultPartitions="6">
       <policy name="default" maxRetries="3" delay="1s" maxDelay="10s" continueOnFailure="true" />
     </streamProcessor>
   </extension>

--- a/server/nuxeo-nxr-server/src/main/resources/templates/common-base/nuxeo.defaults
+++ b/server/nuxeo-nxr-server/src/main/resources/templates/common-base/nuxeo.defaults
@@ -221,6 +221,7 @@ nuxeo.core.bulk.scroller.concurrencyMax=2
 nuxeo.core.bulk.status.concurrencyMax=2
 nuxeo.core.bulk.done.concurrencyMax=1
 nuxeo.core.bulk.csvExport.scroller=elastic
+nuxeo.core.bulk.csvExport.queryLimit=100000
 
 # Stream Health Check probe activation
 nuxeo.stream.health.check.enabled=true


### PR DESCRIPTION
A default limit can be set on action and overriden when building command,
a flag in the status indicate if the limit has been reached for a command.