### PR TITLE
NXP-29924: avoid storing intermediate chain results

### DIFF
--- a/modules/platform/nuxeo-automation/nuxeo-automation-server/src/main/java/org/nuxeo/ecm/automation/server/jaxrs/adapters/AsyncOperationAdapter.java
+++ b/modules/platform/nuxeo-automation/nuxeo-automation-server/src/main/java/org/nuxeo/ecm/automation/server/jaxrs/adapters/AsyncOperationAdapter.java
@@ -148,6 +148,8 @@ public class AsyncOperationAdapter extends DefaultAdapter {
 
         opCtx.setCallback(new OperationCallback() {
 
+            private Object output;
+
             @Override
             public void onChainEnter(OperationType chain) {
                 //
@@ -155,6 +157,7 @@ public class AsyncOperationAdapter extends DefaultAdapter {
 
             @Override
             public void onChainExit() {
+                setOutput(executionId, (Serializable) output);
                 setCompleted(executionId);
             }
 
@@ -166,7 +169,7 @@ public class AsyncOperationAdapter extends DefaultAdapter {
 
             @Override
             public void onOperationExit(Object output) {
-                setOutput(executionId, (Serializable) output);
+                this.output = output;
             }
 
             @Override

--- a/modules/platform/nuxeo-automation/nuxeo-automation-test/src/test/resources/operation-contrib.xml
+++ b/modules/platform/nuxeo-automation/nuxeo-automation-test/src/test/resources/operation-contrib.xml
@@ -30,6 +30,11 @@
       </operation>
 
     </chain>
+
+    <chain id="testFetchDocumentChain">
+      <operation id="Context.FetchDocument" />
+      <operation id="Document.GetBlob" />
+    </chain>
   </extension>
 
   <extension


### PR DESCRIPTION
This should make async chain execution a bit more efficient as we just need the final chain output, no need to keep putting op outputs in the transient store.

Original bug was due to us detaching the document just so we could put it in the transient store but we never attached it again until the end of the chain.





