### PR TITLE
NXP-29978: add support for idempotency key in request controller filter

### DIFF
--- a/ftests/nuxeo-server-tests/src/test/java/org/nuxeo/ftest/server/ITNuxeoIdempotentRequestTest.java
+++ b/ftests/nuxeo-server-tests/src/test/java/org/nuxeo/ftest/server/ITNuxeoIdempotentRequestTest.java
@@ -1,0 +1,128 @@
+/*
+ * (C) Copyright 2021 Nuxeo (http://nuxeo.com/) and others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Contributors:
+ *     Anahide Tchertchian
+ */
+package org.nuxeo.ftest.server;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.nuxeo.ecm.platform.web.common.idempotency.NuxeoIdempotentFilter.HEADER_KEY;
+import static org.nuxeo.functionaltests.AbstractTest.NUXEO_URL;
+import static org.nuxeo.functionaltests.Constants.ADMINISTRATOR;
+
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.Test;
+import org.nuxeo.client.NuxeoClient;
+import org.nuxeo.client.objects.Document;
+import org.nuxeo.ecm.core.query.sql.NXQL;
+import org.nuxeo.ecm.platform.dublincore.constants.DublinCoreConstants;
+import org.nuxeo.functionaltests.RestHelper.NuxeoClientForNuxeo;
+
+/**
+ * Tests for idempotent request mechanism.
+ *
+ * @since 11.5
+ */
+public class ITNuxeoIdempotentRequestTest {
+
+    private static final String TEST_KEY = "idempotenttestkey" + new Date().getTime();
+
+    private static final NuxeoClient.Builder CLIENT_BUILDER = new NuxeoClientForNuxeo.BuilderForNuxeo().url(
+            NUXEO_URL).authentication(ADMINISTRATOR, ADMINISTRATOR).schemas("*");
+
+    private static final NuxeoClient CLIENT = CLIENT_BUILDER.connect();
+
+    private static final NuxeoClient IDEMPOTENT_CLIENT = CLIENT_BUILDER.header(HEADER_KEY, TEST_KEY).connect();
+
+    private static final String PARENT_PATH = "/default-domain/workspaces/";
+
+    private static final String QUERY_CHILDREN = String.format("SELECT * FROM Document WHERE %s STARTSWITH '%s'",
+            NXQL.ECM_PATH, PARENT_PATH);
+
+    private static final String TEST_TITLE = "testdoc";
+
+    private static final String TEST_TYPE = "File";
+
+    protected String createDocument(NuxeoClient client) {
+        Document document = Document.createWithName(TEST_TITLE, TEST_TYPE);
+        document.setProperties(Map.of(DublinCoreConstants.DUBLINCORE_TITLE_PROPERTY, TEST_TITLE));
+        Document created = client.repository().createDocumentByPath(PARENT_PATH, document);
+        waitForAsyncWork();
+        return created.getId();
+    }
+
+    /**
+     * Prevents from random failures when counting children.
+     */
+    protected void waitForAsyncWork() {
+        Map<String, Object> parameters = new HashMap<>();
+        parameters.put("timeoutSecond", Integer.valueOf(110));
+        parameters.put("refresh", Boolean.TRUE);
+        parameters.put("waitForAudit", Boolean.TRUE);
+        CLIENT.operation("Elasticsearch.WaitForIndexing").parameters(parameters).execute();
+    }
+
+    protected int getNumberOfChildren() {
+        return CLIENT.repository().query(QUERY_CHILDREN).size() - 1;
+    }
+
+    protected Document fetch(String id) {
+        return CLIENT.repository().fetchDocumentById(id);
+    }
+
+    protected void delete(String id) {
+        CLIENT.repository().deleteDocument(id);
+    }
+
+    @Test
+    public void testIdempotentRequest() {
+        String id = null;
+        String dupeId = null;
+        try {
+            assertEquals(0, getNumberOfChildren());
+
+            // create child document
+            id = createDocument(IDEMPOTENT_CLIENT);
+            assertEquals(TEST_TITLE, fetch(id).getTitle());
+            // doc created
+            assertEquals(1, getNumberOfChildren());
+
+            // try creating it again
+            dupeId = createDocument(IDEMPOTENT_CLIENT);
+            assertEquals(id, dupeId);
+            // dupe not created
+            assertEquals(1, getNumberOfChildren());
+
+            // create again without idempotency key
+            dupeId = createDocument(CLIENT);
+            assertNotEquals(id, dupeId);
+            // dupe created
+            assertEquals(2, getNumberOfChildren());
+        } finally {
+            if (id != null) {
+                delete(id);
+            }
+            if (dupeId != null && !dupeId.equals(id)) {
+                delete(dupeId);
+            }
+        }
+    }
+
+}

--- a/modules/platform/nuxeo-platform-web-common/pom.xml
+++ b/modules/platform/nuxeo-platform-web-common/pom.xml
@@ -1,4 +1,5 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
@@ -110,6 +111,10 @@
     <dependency>
       <groupId>io.opencensus</groupId>
       <artifactId>opencensus-contrib-http-servlet</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
     </dependency>
 
     <dependency>

--- a/modules/platform/nuxeo-platform-web-common/src/main/java/org/nuxeo/ecm/platform/web/common/idempotency/CopyingResponseWrapper.java
+++ b/modules/platform/nuxeo-platform-web-common/src/main/java/org/nuxeo/ecm/platform/web/common/idempotency/CopyingResponseWrapper.java
@@ -1,0 +1,119 @@
+/*
+ * (C) Copyright 2020 Nuxeo (http://nuxeo.com/) and others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Contributors:
+ *     Anahide Tchertchian
+ */
+package org.nuxeo.ecm.platform.web.common.idempotency;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.OutputStreamWriter;
+import java.io.PrintWriter;
+import java.nio.file.Files;
+
+import javax.servlet.ServletOutputStream;
+import javax.servlet.http.HttpServletResponse;
+import javax.servlet.http.HttpServletResponseWrapper;
+
+import org.apache.commons.io.FileUtils;
+import org.apache.commons.io.output.DeferredFileOutputStream;
+
+/**
+ * Response wrapper that can capture response result, using a {@link DeferredFileOutputStream}.
+ *
+ * @since 11.5
+ */
+public class CopyingResponseWrapper extends HttpServletResponseWrapper implements AutoCloseable {
+
+    // invariant: only one of output or writer may be non-null, never both at the same time
+    protected ServletOutputStream output;
+
+    protected PrintWriter writer;
+
+    protected final DeferredFileOutputStream copy;
+
+    public CopyingResponseWrapper(int threshold, HttpServletResponse response) {
+        super(response);
+        copy = new DeferredFileOutputStream(threshold, response.getBufferSize(), "nxidem", null, null);
+    }
+
+    protected CopyingServletOutputStream getCopyingOutputStream() throws IOException {
+        return new CopyingServletOutputStream(getResponse().getOutputStream(), copy);
+    }
+
+    @Override
+    public ServletOutputStream getOutputStream() throws IOException {
+        if (writer != null) {
+            throw new IllegalStateException("getWriter() has already been called on this response.");
+        }
+        if (output == null) {
+            output = getCopyingOutputStream();
+        }
+        return output;
+    }
+
+    @Override
+    public PrintWriter getWriter() throws IOException {
+        if (output != null) {
+            throw new IllegalStateException("getOutputStream() has already been called on this response.");
+        }
+        if (writer == null) {
+            writer = new PrintWriter(new OutputStreamWriter(getCopyingOutputStream(), getCharacterEncoding()));
+        }
+        return writer;
+    }
+
+    @Override
+    public void flushBuffer() throws IOException {
+        super.flushBuffer();
+
+        if (writer != null) {
+            writer.flush();
+        } else if (output != null) {
+            output.flush();
+        }
+    }
+
+    @Override
+    public void close() throws IOException {
+        if (writer != null) {
+            writer.close();
+        } else if (output != null) {
+            output.close();
+        }
+        if (!copy.isInMemory()) {
+            // tmp file cleanup
+            File file = copy.getFile();
+            if (file != null) {
+                Files.delete(file.toPath());
+            }
+        }
+    }
+
+    public long getCopySize() {
+        return copy.getByteCount();
+    }
+
+    public byte[] getCopyAsBytes() throws IOException {
+        if (copy.isInMemory()) {
+            return copy.getData();
+        } else {
+            copy.flush();
+            return FileUtils.readFileToByteArray(copy.getFile());
+        }
+    }
+
+}

--- a/modules/platform/nuxeo-platform-web-common/src/main/java/org/nuxeo/ecm/platform/web/common/idempotency/CopyingServletOutputStream.java
+++ b/modules/platform/nuxeo-platform-web-common/src/main/java/org/nuxeo/ecm/platform/web/common/idempotency/CopyingServletOutputStream.java
@@ -1,0 +1,84 @@
+/*
+ * (C) Copyright 2020 Nuxeo (http://nuxeo.com/) and others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Contributors:
+ *     Anahide Tchertchian
+ */
+package org.nuxeo.ecm.platform.web.common.idempotency;
+
+import java.io.IOException;
+
+import javax.servlet.ServletOutputStream;
+import javax.servlet.WriteListener;
+
+import org.apache.commons.io.output.DeferredFileOutputStream;
+
+/**
+ * Captures content written to the target stream.
+ *
+ * @since 11.5
+ */
+public class CopyingServletOutputStream extends ServletOutputStream {
+
+    protected final ServletOutputStream output;
+
+    protected final DeferredFileOutputStream copy;
+
+    public CopyingServletOutputStream(ServletOutputStream output, DeferredFileOutputStream copy) {
+        this.output = output;
+        this.copy = copy;
+    }
+
+    @Override
+    public void write(int b) throws IOException {
+        output.write(b);
+        copy.write(b);
+    }
+
+    @Override
+    public void write(byte[] b) throws IOException {
+        output.write(b);
+        copy.write(b);
+    }
+
+    @Override
+    public void write(byte[] b, int off, int len) throws IOException {
+        output.write(b, off, len);
+        copy.write(b, off, len);
+    }
+
+    @Override
+    public void flush() throws IOException {
+        output.flush();
+        copy.flush();
+    }
+
+    @Override
+    public void close() throws IOException {
+        output.close();
+        copy.close();
+    }
+
+    @Override
+    public boolean isReady() {
+        return output.isReady();
+    }
+
+    @Override
+    public void setWriteListener(WriteListener writeListener) {
+        output.setWriteListener(writeListener);
+    }
+
+}

--- a/modules/platform/nuxeo-platform-web-common/src/main/java/org/nuxeo/ecm/platform/web/common/idempotency/NuxeoIdempotentFilter.java
+++ b/modules/platform/nuxeo-platform-web-common/src/main/java/org/nuxeo/ecm/platform/web/common/idempotency/NuxeoIdempotentFilter.java
@@ -1,0 +1,199 @@
+/*
+ * (C) Copyright 2020 Nuxeo (http://nuxeo.com/) and others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Contributors:
+ *     Anahide Tchertchian
+ */
+package org.nuxeo.ecm.platform.web.common.idempotency;
+
+import static javax.servlet.http.HttpServletResponse.SC_BAD_REQUEST;
+import static javax.servlet.http.HttpServletResponse.SC_CONFLICT;
+import static javax.servlet.http.HttpServletResponse.SC_INTERNAL_SERVER_ERROR;
+
+import java.io.IOException;
+import java.time.Duration;
+import java.util.Set;
+
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpFilter;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.apache.http.client.methods.HttpDelete;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.client.methods.HttpHead;
+import org.apache.http.client.methods.HttpOptions;
+import org.apache.http.client.methods.HttpPut;
+import org.apache.http.client.methods.HttpTrace;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.nuxeo.runtime.api.Framework;
+import org.nuxeo.runtime.kv.KeyValueService;
+import org.nuxeo.runtime.kv.KeyValueStore;
+import org.nuxeo.runtime.services.config.ConfigurationService;
+
+/**
+ * Filter handling an idempotency key in POST requests.
+ * <p>
+ * If {@link #HEADER_KEY} is found in the request header, will intercept request handling to:
+ * <ul>
+ * <li>mark the request as being processed
+ * <li>capture the response when request was processed without any error and store it
+ * <li>return the stored response if a subsequent request with the same key is processed again
+ * <li>return a conflict response if a request with the same key is processed while the first request is still in
+ * progress.
+ * </ul>
+ *
+ * @since 11.5
+ */
+public class NuxeoIdempotentFilter extends HttpFilter {
+
+    private static final long serialVersionUID = 1L;
+
+    private static final Logger log = LogManager.getLogger(NuxeoIdempotentFilter.class);
+
+    public static final String HEADER_KEY = "Idempotency-Key";
+
+    public static final String STORE_PROPERTY = "org.nuxeo.request.idempotency.keyvaluestore.name";
+
+    public static final String DEFAULT_STORE = "idempotentrequest";
+
+    protected static final Duration DEFAULT_TTL = Duration.ofDays(1);
+
+    public static final String TTL_DURATION_PROPERTY = "org.nuxeo.request.idempotency.ttl.duration";
+
+    public static final String INPROGRESS_MARKER = "{\"inprogress\":true}";
+
+    public static final String INFO_SUFFIX = "_info";
+
+    protected static final int DEFERRED_OUTPUT_STREAM_THRESHOLD = 1024 * 1024; // 1 MB
+
+    protected static final int MAX_CONTENT_SIZE = 1024 * 1024 * 5; // 5 MB
+
+    protected static final Set<String> IDEMPOTENT_METHODS = Set.of(
+            // safe methods according to RFC 7231 4.2.1
+            HttpGet.METHOD_NAME, HttpHead.METHOD_NAME, HttpOptions.METHOD_NAME, HttpTrace.METHOD_NAME,
+            // idempotent methods according to RFC 7231 4.2.2
+            HttpPut.METHOD_NAME, HttpDelete.METHOD_NAME);
+
+    protected Duration getTTL() {
+        ConfigurationService cs = Framework.getService(ConfigurationService.class);
+        if (cs != null) {
+            return cs.getDuration(TTL_DURATION_PROPERTY, DEFAULT_TTL);
+        }
+        return DEFAULT_TTL;
+    }
+
+    protected String getStoreName() {
+        ConfigurationService cs = Framework.getService(ConfigurationService.class);
+        if (cs != null) {
+            return cs.getString(STORE_PROPERTY, DEFAULT_STORE);
+        }
+        return DEFAULT_STORE;
+    }
+
+    @Override
+    protected void doFilter(HttpServletRequest request, HttpServletResponse response, FilterChain chain)
+            throws IOException, ServletException {
+        if (!doFilterIdempotent(request, response, chain)) {
+            chain.doFilter(request, response);
+        }
+    }
+
+    protected boolean doFilterIdempotent(HttpServletRequest request, HttpServletResponse response, FilterChain chain)
+            throws IOException, ServletException {
+        String method = request.getMethod();
+        if (IDEMPOTENT_METHODS.contains(method)) {
+            log.debug("No idempotent processing done: method is already idempotent: {}", method);
+            return false;
+        }
+        String key = request.getHeader(HEADER_KEY);
+        if (key == null) {
+            log.debug("No idempotent processing done: no {} header present", HEADER_KEY);
+            return false;
+        }
+        log.debug("Idempotent request key: {}", key);
+        KeyValueService kvs = Framework.getService(KeyValueService.class);
+        if (kvs == null) {
+            log.debug("KeyValueService not present");
+            return false;
+        }
+        KeyValueStore store = kvs.getKeyValueStore(getStoreName());
+        String storeStatus = store.getString(key + INFO_SUFFIX);
+        byte[] storeContent = store.get(key);
+        if (storeStatus == null) {
+            log.debug("Handle new request for key: {}", key);
+            long ttl = getTTL().toSeconds();
+            store.put(key + INFO_SUFFIX, INPROGRESS_MARKER, ttl);
+            try {
+                try (CopyingResponseWrapper wrapper = new CopyingResponseWrapper(DEFERRED_OUTPUT_STREAM_THRESHOLD,
+                        response)) {
+                    wrapper.setHeader(HEADER_KEY, key);
+                    chain.doFilter(request, wrapper);
+                    wrapper.flushBuffer();
+                    long size = wrapper.getCopySize();
+                    if (size > MAX_CONTENT_SIZE) {
+                        log.debug(
+                                "Not storing response for key: {} (status: {}, size in bytes: {}), max content size exceeded: {}",
+                                key, wrapper.getStatus(), size, MAX_CONTENT_SIZE);
+                        return true;
+                    }
+                    byte[] content = wrapper.getCopyAsBytes();
+                    store.put(key, content, ttl);
+                    store.put(key + INFO_SUFFIX, NuxeoIdempotentResponse.save(wrapper), ttl);
+                    log.debug("Stored response for key: {} (status: {}, size in bytes: {})", key, wrapper.getStatus(),
+                            content.length);
+                    return true;
+                }
+            } catch (IOException | ServletException e) {
+                if (!response.isCommitted()) {
+                    response.setStatus(SC_INTERNAL_SERVER_ERROR);
+                    response.setHeader(HEADER_KEY, key);
+                }
+                throw e;
+            } finally {
+                if (response.getStatus() >= SC_BAD_REQUEST) {
+                    // error request: cleanup store
+                    store.put(key, (String) null);
+                    store.put(key + INFO_SUFFIX, (String) null);
+                    log.debug("Cleanup store: error for key: {}", key);
+                }
+            }
+        } else if (INPROGRESS_MARKER.equals(storeStatus)) {
+            // request already in progress -> conflict
+            // Don't call response.sendError, because it commits the response
+            // which prevents NuxeoExceptionFilter from returning a custom error page.
+            response.setStatus(SC_CONFLICT);
+            response.setHeader(HEADER_KEY, key);
+            log.debug("Conflict response for key: {}", key);
+            return true;
+        } else {
+            try {
+                // request already done: return stored result
+                NuxeoIdempotentResponse.restore(response, storeStatus.getBytes());
+                response.setHeader(HEADER_KEY, key);
+                response.getOutputStream().write(storeContent);
+                log.debug("Returning stored response for key: {} (status: {}, size in bytes: {})", key,
+                        response.getStatus(), storeContent.length);
+                return true;
+            } catch (IOException e) {
+                log.error("Error processing stored result for key: {}", key, e);
+                return false;
+            }
+        }
+    }
+
+}

--- a/modules/platform/nuxeo-platform-web-common/src/main/java/org/nuxeo/ecm/platform/web/common/idempotency/NuxeoIdempotentResponse.java
+++ b/modules/platform/nuxeo-platform-web-common/src/main/java/org/nuxeo/ecm/platform/web/common/idempotency/NuxeoIdempotentResponse.java
@@ -1,0 +1,109 @@
+/*
+ * (C) Copyright 2020 Nuxeo (http://nuxeo.com/) and others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Contributors:
+ *     Anahide Tchertchian
+ */
+package org.nuxeo.ecm.platform.web.common.idempotency;
+
+import java.io.IOException;
+import java.util.Collection;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Set;
+
+import javax.servlet.http.HttpServletResponse;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.MapperFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectReader;
+import com.fasterxml.jackson.databind.ObjectWriter;
+import com.fasterxml.jackson.databind.SerializationFeature;
+
+/**
+ * POJO representing response to be serialized and served by {@link NuxeoIdempotentFilter}.
+ *
+ * @since 11.5
+ */
+public class NuxeoIdempotentResponse {
+
+    public static final Set<String> SKIPPED_HEADERS = Set.of("Transfer-Encoding");
+
+    protected int status;
+
+    protected Map<String, Collection<String>> headers = new LinkedHashMap<>();
+
+    protected static final ObjectMapper MAPPER = //
+            new ObjectMapper().configure(MapperFeature.SORT_PROPERTIES_ALPHABETICALLY, true)
+                              .configure(SerializationFeature.ORDER_MAP_ENTRIES_BY_KEYS, true);
+
+    protected static final ObjectReader READ_MAPPER = MAPPER.readerFor(NuxeoIdempotentResponse.class)
+                                                            .withoutRootName()
+                                                            .without(JsonParser.Feature.AUTO_CLOSE_SOURCE);
+
+    protected static final ObjectWriter WRITE_MAPPER = MAPPER.writerFor(NuxeoIdempotentResponse.class)
+                                                             .withoutRootName()
+                                                             .with(JsonGenerator.Feature.FLUSH_PASSED_TO_STREAM)
+                                                             .without(JsonGenerator.Feature.AUTO_CLOSE_TARGET);
+
+    public int getStatus() {
+        return status;
+    }
+
+    public void setStatus(int status) {
+        this.status = status;
+    }
+
+    public Map<String, Collection<String>> getHeaders() {
+        return headers;
+    }
+
+    public void setHeader(String name, Collection<String> value) {
+        headers.put(name, value);
+    }
+
+    public static final void restore(HttpServletResponse response, byte[] bytes) throws IOException {
+        NuxeoIdempotentResponse stored = READ_MAPPER.readValue(bytes);
+        response.setStatus(stored.getStatus());
+        stored.getHeaders().forEach((name, values) -> {
+            boolean isFirst = true;
+            for (String value : values) {
+                if (SKIPPED_HEADERS.contains(name)) {
+                    continue;
+                }
+                if (isFirst) {
+                    response.setHeader(name, value);
+                    isFirst = false;
+                } else {
+                    response.addHeader(name, value);
+                }
+            }
+        });
+    }
+
+    public static final byte[] save(HttpServletResponse response) throws JsonProcessingException {
+        NuxeoIdempotentResponse stored = new NuxeoIdempotentResponse();
+        stored.setStatus(response.getStatus());
+        response.getHeaderNames()
+                .stream()
+                .filter(h -> !SKIPPED_HEADERS.contains(h))
+                .forEach(name -> stored.setHeader(name, response.getHeaders(name)));
+        return WRITE_MAPPER.writeValueAsBytes(stored);
+    }
+
+}

--- a/modules/platform/nuxeo-platform-web-common/src/main/resources/META-INF/MANIFEST.MF
+++ b/modules/platform/nuxeo-platform-web-common/src/main/resources/META-INF/MANIFEST.MF
@@ -31,7 +31,8 @@ Nuxeo-Component: OSGI-INF/authentication-framework.xml,
  OSGI-INF/locale-framework.xml,
  OSGI-INF/locale-default-contrib.xml,
  OSGI-INF/login-screen-config.xml,
- OSGI-INF/cors-configuration.xml
+ OSGI-INF/cors-configuration.xml,
+ OSGI-INF/idempotency-configuration.xml
 Bundle-SymbolicName: org.nuxeo.ecm.platform.web.common;singleton:=true
 Import-Package: javax.faces.context,
  javax.security.auth,

--- a/modules/platform/nuxeo-platform-web-common/src/main/resources/OSGI-INF/deployment-fragment.xml
+++ b/modules/platform/nuxeo-platform-web-common/src/main/resources/OSGI-INF/deployment-fragment.xml
@@ -85,6 +85,14 @@
     </filter>
 
     <filter>
+      <display-name>Nuxeo Idempotent Filter</display-name>
+      <filter-name>NuxeoIdempotentFilter</filter-name>
+      <filter-class>
+        org.nuxeo.ecm.platform.web.common.idempotency.NuxeoIdempotentFilter
+      </filter-class>
+    </filter>
+
+    <filter>
       <display-name>Nuxeo Authentication Filter</display-name>
       <filter-name>NuxeoAuthenticationFilter</filter-name>
       <filter-class>
@@ -98,6 +106,11 @@
 
     <filter-mapping>
       <filter-name>NuxeoRequestController</filter-name>
+      <url-pattern>/*</url-pattern>
+      <dispatcher>REQUEST</dispatcher>
+    </filter-mapping>
+    <filter-mapping>
+      <filter-name>NuxeoIdempotentFilter</filter-name>
       <url-pattern>/*</url-pattern>
       <dispatcher>REQUEST</dispatcher>
     </filter-mapping>

--- a/modules/platform/nuxeo-platform-web-common/src/main/resources/OSGI-INF/idempotency-configuration.xml
+++ b/modules/platform/nuxeo-platform-web-common/src/main/resources/OSGI-INF/idempotency-configuration.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0"?>
+<component name="org.nuxeo.ecm.platform.web.idempotency">
+
+  <extension target="org.nuxeo.runtime.ConfigurationService" point="configuration">
+    <documentation>
+      Properties controlling idempotent requests TTL and KeyValue storename.
+
+      Default TTL in seconds matches 1 day.
+
+      @since 11.5
+    </documentation>
+    <property name="org.nuxeo.request.idempotency.ttl.duration">1d</property>
+    <property name="org.nuxeo.request.idempotency.keyvaluestore.name">idempotentrequest</property>
+  </extension>
+
+
+</component>

--- a/modules/platform/nuxeo-platform-web-common/src/test/java/org/nuxeo/ecm/platform/web/idempotency/TestNuxeoIdempotentFilter.java
+++ b/modules/platform/nuxeo-platform-web-common/src/test/java/org/nuxeo/ecm/platform/web/idempotency/TestNuxeoIdempotentFilter.java
@@ -1,0 +1,406 @@
+/*
+ * (C) Copyright 2020 Nuxeo (http://nuxeo.com/) and others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Contributors:
+ *     Anahide Tchertchian
+ */
+package org.nuxeo.ecm.platform.web.idempotency;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static javax.servlet.http.HttpServletResponse.SC_CONFLICT;
+import static javax.servlet.http.HttpServletResponse.SC_INTERNAL_SERVER_ERROR;
+import static javax.servlet.http.HttpServletResponse.SC_NOT_FOUND;
+import static javax.servlet.http.HttpServletResponse.SC_OK;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.fail;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyInt;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.nuxeo.ecm.platform.web.common.idempotency.NuxeoIdempotentResponse.SKIPPED_HEADERS;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.io.PrintWriter;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import javax.inject.Inject;
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.ServletOutputStream;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.client.methods.HttpPost;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+import org.nuxeo.ecm.platform.web.common.idempotency.NuxeoIdempotentFilter;
+import org.nuxeo.runtime.kv.KeyValueService;
+import org.nuxeo.runtime.kv.KeyValueStoreProvider;
+import org.nuxeo.runtime.test.runner.Deploy;
+import org.nuxeo.runtime.test.runner.Features;
+import org.nuxeo.runtime.test.runner.FeaturesRunner;
+import org.nuxeo.runtime.test.runner.RuntimeFeature;
+
+/**
+ * Checks idempotent requests management.
+ *
+ * @since 11.5
+ */
+@RunWith(FeaturesRunner.class)
+@Features(RuntimeFeature.class)
+@Deploy("org.nuxeo.runtime.kv")
+@Deploy("org.nuxeo.ecm.platform.web.common:OSGI-INF/idempotency-configuration.xml")
+public class TestNuxeoIdempotentFilter {
+
+    protected static final String KEY = "mykey";
+
+    protected static final String CONTENT = "test content";
+
+    protected static final Map<String, Collection<String>> RESPONSE_HEADERS = new LinkedHashMap<>();
+
+    static {
+        RESPONSE_HEADERS.put("Accept", List.of("text/html", "application/xhtml+xml", "*/*;q=0.8"));
+        RESPONSE_HEADERS.put("Connection", List.of("Keep-Alive"));
+        RESPONSE_HEADERS.put("Content-Encoding", List.of("gzip"));
+        RESPONSE_HEADERS.put("Content-Type", List.of("text/html; charset=utf-8"));
+        RESPONSE_HEADERS.put("Set-Cookie", List.of("sessionId=38afes7a8", "id=a3fWa; Max-Age=2592000"));
+        RESPONSE_HEADERS.put("Transfer-Encoding", List.of("chunked")); // should be filtered
+    }
+
+    protected static final Map<String, Collection<String>> KEY_RESPONSE_HEADERS = new LinkedHashMap<>();
+
+    static {
+        KEY_RESPONSE_HEADERS.put(NuxeoIdempotentFilter.HEADER_KEY, List.of(KEY));
+    }
+
+    protected static final Map<String, Collection<String>> FINAL_RESPONSE_HEADERS = new LinkedHashMap<>();
+
+    static {
+        FINAL_RESPONSE_HEADERS.putAll(RESPONSE_HEADERS);
+        FINAL_RESPONSE_HEADERS.putAll(KEY_RESPONSE_HEADERS);
+    }
+
+    protected static final Map<String, Collection<String>> FINAL_COPY_RESPONSE_HEADERS = new LinkedHashMap<>();
+
+    static {
+        FINAL_COPY_RESPONSE_HEADERS.putAll(FINAL_RESPONSE_HEADERS);
+        FINAL_COPY_RESPONSE_HEADERS.keySet().removeAll(SKIPPED_HEADERS);
+    }
+
+    protected NuxeoIdempotentFilter filter;
+
+    protected FilterChain chain;
+
+    protected HttpServletRequest request;
+
+    protected MockResponse mockResponse;
+
+    @Inject
+    protected KeyValueService kvs;
+
+    protected KeyValueStoreProvider store;
+
+    protected static class MockResponse {
+
+        protected HttpServletResponse response;
+
+        protected int status;
+
+        protected Map<String, Collection<String>> headers = new LinkedHashMap<>();
+
+        protected OutputStream output;
+
+        public MockResponse() throws IOException {
+            super();
+            response = mock(HttpServletResponse.class);
+            // output mock
+            output = new ByteArrayOutputStream();
+            ServletOutputStream servletOutput = mock(ServletOutputStream.class);
+            doAnswer(invocation -> {
+                output.write((Integer) invocation.getArguments()[0]);
+                return null;
+            }).when(servletOutput).write(anyInt());
+            doAnswer(invocation -> {
+                output.write((byte[]) invocation.getArguments()[0]);
+                return null;
+            }).when(servletOutput).write(any(byte[].class));
+            doAnswer(invocation -> {
+                output.write((byte[]) invocation.getArguments()[0], (Integer) invocation.getArguments()[1],
+                        (Integer) invocation.getArguments()[2]);
+                return null;
+            }).when(servletOutput).write(any(byte[].class), anyInt(), anyInt());
+            when(response.getOutputStream()).thenReturn(servletOutput);
+            PrintWriter writer = mock(PrintWriter.class);
+            doAnswer(invocation -> {
+                output.write(((String) invocation.getArguments()[0]).getBytes());
+                return null;
+            }).when(writer).write(anyString());
+            doAnswer(invocation -> writer).when(response).getWriter();
+            when(response.getCharacterEncoding()).thenReturn(UTF_8.name());
+            // status mock
+            doAnswer(invocation -> status).when(response).getStatus();
+            doAnswer(invocation -> {
+                status = (Integer) invocation.getArguments()[0];
+                return null;
+            }).when(response).setStatus(anyInt());
+            // headers mock
+            when(response.getHeaderNames()).thenReturn(headers.keySet());
+            doAnswer(invocation -> headers.get(invocation.getArguments()[0]).stream().findFirst().get()).when(
+                    response).getHeader(anyString());
+            doAnswer(invocation -> headers.get(invocation.getArguments()[0])).when(response).getHeaders(anyString());
+            doAnswer(invocation -> {
+                headers.put((String) invocation.getArguments()[0],
+                        new ArrayList<>(List.of((String) invocation.getArguments()[1])));
+                return null;
+            }).when(response).setHeader(anyString(), anyString());
+            doAnswer(invocation -> {
+                headers.computeIfAbsent((String) invocation.getArguments()[0], k -> new ArrayList<>())
+                       .add((String) invocation.getArguments()[1]);
+                return null;
+            }).when(response).addHeader(anyString(), anyString());
+        }
+
+        public int getStatus() {
+            return status;
+        }
+
+        public HttpServletResponse getResponse() {
+            return response;
+        }
+
+        public OutputStream getOutput() {
+            return output;
+        }
+
+    }
+
+    @Before
+    public void setUp() throws IOException {
+        filter = new NuxeoIdempotentFilter();
+        chain = mock(FilterChain.class);
+        request = mock(HttpServletRequest.class);
+        mockResponse = new MockResponse();
+        // handle store
+        store = (KeyValueStoreProvider) kvs.getKeyValueStore(NuxeoIdempotentFilter.DEFAULT_STORE);
+        store.clear();
+    }
+
+    @After
+    public void tearDown() {
+        if (filter != null) {
+            filter.destroy();
+        }
+        if (store != null) {
+            store.clear();
+        }
+    }
+
+    protected void checkResponse(MockResponse mockResponse, Integer status, String content,
+            Map<String, Collection<String>> headers) {
+        assertEquals(status, (Integer) mockResponse.getStatus());
+        assertEquals(content, mockResponse.getOutput().toString());
+        HttpServletResponse response = mockResponse.getResponse();
+        assertEquals(headers.keySet(), response.getHeaderNames());
+        headers.forEach((k, v) -> assertEquals(v, response.getHeaders(k)));
+    }
+
+    protected void checkStore(String status, String content) {
+        assertEquals(content, store.getString(KEY));
+        String ikey = KEY + NuxeoIdempotentFilter.INFO_SUFFIX;
+        if (status == null) {
+            assertNull(store.getString(ikey));
+        } else {
+            if (NuxeoIdempotentFilter.INPROGRESS_MARKER.equals(status)) {
+                assertEquals(status, store.getString(ikey));
+            } else {
+                String info = "{\"headers\":" //
+                        + "{\"Accept\":[\"text/html\",\"application/xhtml+xml\",\"*/*;q=0.8\"]," //
+                        + "\"Connection\":[\"Keep-Alive\"]," //
+                        + "\"Content-Encoding\":[\"gzip\"]," //
+                        + "\"Content-Type\":[\"text/html; charset=utf-8\"]," //
+                        + "\"Idempotency-Key\":[\"mykey\"],"
+                        + "\"Set-Cookie\":[\"sessionId=38afes7a8\",\"id=a3fWa; Max-Age=2592000\"]" //
+                        + "},\"status\":%s}";
+                assertEquals(String.format(info, status), store.getString(ikey));
+            }
+        }
+    }
+
+    @Test
+    public void testGetRequestWithoutKey() throws IOException, ServletException {
+        when(request.getMethod()).thenReturn(HttpGet.METHOD_NAME);
+        verify(chain, times(0)).doFilter(any(), any());
+        filter.doFilter(request, mockResponse.getResponse(), chain);
+        verify(chain, times(1)).doFilter(any(), any());
+        checkStore(null, null);
+    }
+
+    @Test
+    public void testPostRequestWithoutKey() throws IOException, ServletException {
+        when(request.getMethod()).thenReturn(HttpPost.METHOD_NAME);
+        verify(chain, times(0)).doFilter(any(), any());
+        filter.doFilter(request, mockResponse.getResponse(), chain);
+        verify(chain, times(1)).doFilter(any(), any());
+        checkStore(null, null);
+    }
+
+    @Test
+    public void testGetRequest() throws IOException, ServletException {
+        when(request.getMethod()).thenReturn(HttpGet.METHOD_NAME);
+        when(request.getHeader(NuxeoIdempotentFilter.HEADER_KEY)).thenReturn(KEY);
+        verify(chain, times(0)).doFilter(any(), any());
+        filter.doFilter(request, mockResponse.getResponse(), chain);
+        verify(chain, times(1)).doFilter(any(), any());
+        checkStore(null, null);
+    }
+
+    protected void setResult(HttpServletResponse response, int status, String content) throws IOException {
+        response.setStatus(status);
+        response.getWriter().write(content);
+        // mock headers
+        RESPONSE_HEADERS.forEach((k, v) -> v.forEach(vitem -> response.addHeader(k, vitem)));
+    }
+
+    @Test
+    public void testPostRequest() throws IOException, ServletException {
+        when(request.getMethod()).thenReturn(HttpPost.METHOD_NAME);
+        when(request.getHeader(NuxeoIdempotentFilter.HEADER_KEY)).thenReturn(KEY);
+        // mock final call
+        doAnswer(new Answer<String>() {
+            @Override
+            public String answer(InvocationOnMock invocation) throws IOException {
+                setResult((HttpServletResponse) invocation.getArguments()[1], SC_OK, CONTENT);
+                return null;
+            }
+        }).when(chain).doFilter(any(), any());
+
+        verify(chain, times(0)).doFilter(any(), any());
+        filter.doFilter(request, mockResponse.getResponse(), chain);
+        verify(chain, times(1)).doFilter(any(), any());
+        checkResponse(mockResponse, SC_OK, CONTENT, FINAL_RESPONSE_HEADERS);
+        checkStore(String.valueOf(SC_OK), CONTENT);
+        // call filter again: stored value will be sent back again
+        MockResponse mockResponse2 = new MockResponse();
+        filter.doFilter(request, mockResponse2.getResponse(), chain);
+        // chain filter not called again
+        verify(chain, times(1)).doFilter(any(), any());
+        checkResponse(mockResponse2, SC_OK, CONTENT, FINAL_COPY_RESPONSE_HEADERS);
+        checkStore(String.valueOf(SC_OK), CONTENT);
+    }
+
+    @Test
+    public void testPostRequestInProgress() throws IOException, ServletException {
+        when(request.getMethod()).thenReturn(HttpPost.METHOD_NAME);
+        when(request.getHeader(NuxeoIdempotentFilter.HEADER_KEY)).thenReturn(KEY);
+
+        doAnswer(new Answer<String>() {
+            @Override
+            public String answer(InvocationOnMock invocation) throws IOException, ServletException {
+                // during first execution, execute another request
+                MockResponse mockResponse2 = new MockResponse();
+                verify(chain, times(1)).doFilter(any(), any());
+                filter.doFilter(request, mockResponse2.getResponse(), mock(FilterChain.class));
+                verify(chain, times(1)).doFilter(any(), any());
+                checkResponse(mockResponse2, SC_CONFLICT, "", KEY_RESPONSE_HEADERS);
+                checkStore(NuxeoIdempotentFilter.INPROGRESS_MARKER, null);
+
+                // finish first call
+                setResult((HttpServletResponse) invocation.getArguments()[1], SC_OK, CONTENT);
+                return null;
+            }
+        }).when(chain).doFilter(any(), any());
+
+        verify(chain, times(0)).doFilter(any(), any());
+        filter.doFilter(request, mockResponse.getResponse(), chain);
+        verify(chain, times(1)).doFilter(any(), any());
+        checkResponse(mockResponse, SC_OK, CONTENT, FINAL_RESPONSE_HEADERS);
+        checkStore(String.valueOf(SC_OK), CONTENT);
+    }
+
+    @Test
+    public void testPostRequestException() throws IOException, ServletException {
+        when(request.getMethod()).thenReturn(HttpPost.METHOD_NAME);
+        when(request.getHeader(NuxeoIdempotentFilter.HEADER_KEY)).thenReturn(KEY);
+
+        doAnswer(new Answer<String>() {
+            @Override
+            public String answer(InvocationOnMock invocation) throws IOException, ServletException {
+                throw new ServletException("test error");
+            }
+        }).when(chain).doFilter(any(), any());
+
+        verify(chain, times(0)).doFilter(any(), any());
+        try {
+            filter.doFilter(request, mockResponse.getResponse(), chain);
+            fail("should have thrown Servlet Exception");
+        } catch (ServletException e) {
+            // ok
+        }
+        verify(chain, times(1)).doFilter(any(), any());
+        checkResponse(mockResponse, SC_INTERNAL_SERVER_ERROR, "", KEY_RESPONSE_HEADERS);
+        checkStore(null, null);
+
+        // try again
+        doAnswer(new Answer<String>() {
+            @Override
+            public String answer(InvocationOnMock invocation) throws IOException {
+                setResult((HttpServletResponse) invocation.getArguments()[1], SC_OK, CONTENT);
+                return null;
+            }
+        }).when(chain).doFilter(any(), any());
+        verify(chain, times(1)).doFilter(any(), any());
+        filter.doFilter(request, mockResponse.getResponse(), chain);
+        verify(chain, times(2)).doFilter(any(), any());
+        checkResponse(mockResponse, SC_OK, CONTENT, FINAL_RESPONSE_HEADERS);
+        checkStore(String.valueOf(SC_OK), CONTENT);
+    }
+
+    @Test
+    public void testPostRequestError() throws IOException, ServletException {
+        when(request.getMethod()).thenReturn(HttpPost.METHOD_NAME);
+        when(request.getHeader(NuxeoIdempotentFilter.HEADER_KEY)).thenReturn(KEY);
+
+        doAnswer(new Answer<String>() {
+            @Override
+            public String answer(InvocationOnMock invocation) throws IOException, ServletException {
+                setResult((HttpServletResponse) invocation.getArguments()[1], SC_NOT_FOUND, "not found");
+                return null;
+            }
+        }).when(chain).doFilter(any(), any());
+
+        verify(chain, times(0)).doFilter(any(), any());
+        filter.doFilter(request, mockResponse.getResponse(), chain);
+        verify(chain, times(1)).doFilter(any(), any());
+        checkResponse(mockResponse, SC_NOT_FOUND, "not found", FINAL_RESPONSE_HEADERS);
+        checkStore(null, null);
+    }
+
+}


### PR DESCRIPTION
Early draft, to be discussed:
- should filter init params be initialized differently? (through ConfigurationService props for instance)
- does the logic match what you originally had in mind?
- should the response status be stored too?
- is HttpServletResponse.SC_CONFLICT the response status we'd like to have while the request is in progress? What about the content (some RFCs do have specifications for the content in this case)

Thanks