### PR TITLE
NXP-29980: Fix some broken GitHub links in READMEs

### DIFF
--- a/modules/core/nuxeo-core-bulk/README.md
+++ b/modules/core/nuxeo-core-bulk/README.md
@@ -3,7 +3,7 @@ nuxeo-core-bulk
 
 ## About
 
-This module provides the ability to execute actions asynchronously on a -possibly large- set of documents. This is done by leveraging [Nuxeo Streams](https://github.com/nuxeo/nuxeo/tree/master/nuxeo-runtime/nuxeo-runtime-stream#nuxeo-runtime-stream) that bring scalability and fault tolerance.
+This module provides the ability to execute actions asynchronously on a -possibly large- set of documents. This is done by leveraging [Nuxeo Streams](https://github.com/nuxeo/nuxeo/tree/master/modules/runtime/nuxeo-runtime-stream#nuxeo-runtime-stream) that bring scalability and fault tolerance.
 
 ## Definitions
 
@@ -120,7 +120,7 @@ You need to register a couple action / stream processor :
 See [`SetPropertiesAction`](./src/main/java/org/nuxeo/ecm/core/bulk/action/SetPropertiesAction.java) for a very basic action implementation.
 
 You can find more info on how to configure a stream processor in the following link:
-https://github.com/nuxeo/nuxeo/tree/master/nuxeo-runtime/nuxeo-runtime-stream#stream-processing
+https://github.com/nuxeo/nuxeo/tree/master/modules/runtime/nuxeo-runtime-stream#stream-processing
 
 
 ## Testing a bulk action with REST API

--- a/modules/platform/nuxeo-platform-importer/nuxeo-importer-stream/README.md
+++ b/modules/platform/nuxeo-platform-importer/nuxeo-importer-stream/README.md
@@ -204,7 +204,7 @@ Here is an overview of possible usage to generate mass import and load tests wit
 
 ![import diagram](import-diag.png)
 
-Visit [nuxe-jsf-ui-gatling](https://github.com/nuxeo/nuxeo/tree/master/nuxeo-distribution/nuxeo-jsf-ui-gatling-tests) for more information.
+Visit [nuxe-jsf-ui-gatling](https://github.com/nuxeo/nuxeo/tree/master/ftests/nuxeo-server-gatling-tests) for more information.
 
 
 

--- a/modules/platform/nuxeo-platform-importer/nuxeo-importer-xml-parser/ReadMe.md
+++ b/modules/platform/nuxeo-platform-importer/nuxeo-importer-xml-parser/ReadMe.md
@@ -372,7 +372,7 @@ ____
 
 ### Full examples
 
-You can look the unit test of the [XML Parser project](https://github.com/nuxeo/nuxeo-platform-importer/tree/master/nuxeo-importer-xml-parser/src/test) and also the [Adullact WebDelib addon](https://github.com/nuxeo/nuxeo-adullact/tree/master/nuxeo-adullact-webdelib-parent/nuxeo-adullact-webdelib-core/src) using deeply this service.
+You can look the unit test of the [XML Parser project](https://github.com/nuxeo/nuxeo/tree/master/modules/platform/nuxeo-platform-importer/nuxeo-importer-xml-parser/src/test).
 
 
 # Calling the service


### PR DESCRIPTION
Originally from #4504.