### PR TITLE
NXP-29867: make EventServiceImpl#fireEvent do not throw RuntimeException

### DIFF
--- a/modules/core/nuxeo-core-event/src/test/java/org/nuxeo/ecm/core/event/pipe/TestEventListenerViaLocalPipe.java
+++ b/modules/core/nuxeo-core-event/src/test/java/org/nuxeo/ecm/core/event/pipe/TestEventListenerViaLocalPipe.java
@@ -18,7 +18,9 @@
  */
 package org.nuxeo.ecm.core.event.pipe;
 
-import org.junit.Assert;
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
 import org.nuxeo.ecm.core.event.impl.EventServiceImpl;
 import org.nuxeo.ecm.core.event.pipe.local.LocalEventBundlePipe;
 import org.nuxeo.ecm.core.event.test.TestEventServiceComponent;
@@ -32,14 +34,13 @@ import org.nuxeo.runtime.test.runner.Deploy;
 @Deploy("org.nuxeo.ecm.core.event.test:test-LocalPipes.xml")
 public class TestEventListenerViaLocalPipe extends TestEventServiceComponent {
 
-    @Override
-    protected EventServiceImpl getService() {
-        EventServiceImpl service = super.getService();
-        Assert.assertEquals(service.getEventBundleDispatcher().getClass(),
+    @Test
+    public void testEventBundlePipe() {
+        EventServiceImpl eventServiceImpl = (EventServiceImpl) eventService;
+        assertEquals(eventServiceImpl.getEventBundleDispatcher().getClass(),
                 TestableSimpleEventBundlePipeDispatcher.class);
-        TestableSimpleEventBundlePipeDispatcher dispatcher = (TestableSimpleEventBundlePipeDispatcher) service.getEventBundleDispatcher();
-        Assert.assertEquals(dispatcher.getPipes().get(0).getClass(), LocalEventBundlePipe.class);
-        return service;
+        TestableSimpleEventBundlePipeDispatcher dispatcher = (TestableSimpleEventBundlePipeDispatcher) eventServiceImpl.getEventBundleDispatcher();
+        assertEquals(dispatcher.getPipes().get(0).getClass(), LocalEventBundlePipe.class);
     }
 
 }

--- a/modules/core/nuxeo-core-event/src/test/java/org/nuxeo/ecm/core/event/pipe/TestEventListenerViaQueue.java
+++ b/modules/core/nuxeo-core-event/src/test/java/org/nuxeo/ecm/core/event/pipe/TestEventListenerViaQueue.java
@@ -18,7 +18,9 @@
  */
 package org.nuxeo.ecm.core.event.pipe;
 
-import org.junit.Assert;
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
 import org.nuxeo.ecm.core.event.impl.EventServiceImpl;
 import org.nuxeo.ecm.core.event.test.TestEventServiceComponent;
 import org.nuxeo.runtime.test.runner.Deploy;
@@ -31,14 +33,13 @@ import org.nuxeo.runtime.test.runner.Deploy;
 @Deploy("org.nuxeo.ecm.core.event.test:test-LocalQueues.xml")
 public class TestEventListenerViaQueue extends TestEventServiceComponent {
 
-    @Override
-    protected EventServiceImpl getService() {
-        EventServiceImpl service = super.getService();
-        Assert.assertEquals(service.getEventBundleDispatcher().getClass(),
+    @Test
+    public void testEventBundlePipe() {
+        EventServiceImpl eventServiceImpl = (EventServiceImpl) eventService;
+        assertEquals(eventServiceImpl.getEventBundleDispatcher().getClass(),
                 TestableSimpleEventBundlePipeDispatcher.class);
-        TestableSimpleEventBundlePipeDispatcher dispatcher = (TestableSimpleEventBundlePipeDispatcher) service.getEventBundleDispatcher();
-        Assert.assertEquals(dispatcher.getPipes().get(0).getClass(), QueueBaseEventBundlePipe.class);
-        return service;
+        TestableSimpleEventBundlePipeDispatcher dispatcher = (TestableSimpleEventBundlePipeDispatcher) eventServiceImpl.getEventBundleDispatcher();
+        assertEquals(dispatcher.getPipes().get(0).getClass(), QueueBaseEventBundlePipe.class);
     }
 
 }

--- a/modules/core/nuxeo-core-event/src/test/java/org/nuxeo/ecm/core/event/test/RollbackListener.java
+++ b/modules/core/nuxeo-core-event/src/test/java/org/nuxeo/ecm/core/event/test/RollbackListener.java
@@ -1,0 +1,44 @@
+/*
+ * (C) Copyright 2021 Nuxeo (http://nuxeo.com/) and others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Contributors:
+ *     Thomas Roger
+ */
+package org.nuxeo.ecm.core.event.test;
+
+import org.nuxeo.ecm.core.api.NuxeoException;
+import org.nuxeo.ecm.core.event.Event;
+import org.nuxeo.ecm.core.event.EventListener;
+
+import java.io.Serializable;
+import java.util.Map;
+
+/**
+ * @since 11.5
+ */
+public class RollbackListener implements EventListener {
+
+    @Override
+    public void handleEvent(Event event) {
+        Map<String, Serializable> properties = event.getContext().getProperties();
+
+        event.markRollBack();
+        if (properties.get("RuntimeException") != null) {
+            throw new RuntimeException("RuntimeException");
+        }
+        throw new NuxeoException("NuxeoException", 400);
+    }
+
+}

--- a/modules/core/nuxeo-core-event/src/test/java/org/nuxeo/ecm/core/event/test/TestEventServiceComponent.java
+++ b/modules/core/nuxeo-core-event/src/test/java/org/nuxeo/ecm/core/event/test/TestEventServiceComponent.java
@@ -33,6 +33,7 @@ import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.nuxeo.ecm.core.api.ConcurrentUpdateException;
+import org.nuxeo.ecm.core.api.NuxeoException;
 import org.nuxeo.ecm.core.event.Event;
 import org.nuxeo.ecm.core.event.EventService;
 import org.nuxeo.ecm.core.event.EventServiceAdmin;
@@ -49,6 +50,7 @@ import org.nuxeo.runtime.test.runner.FeaturesRunner;
 import org.nuxeo.runtime.test.runner.HotDeployer;
 import org.nuxeo.runtime.test.runner.LogCaptureFeature;
 import org.nuxeo.runtime.test.runner.TransactionalFeature;
+import org.nuxeo.runtime.transaction.TransactionHelper;
 
 @RunWith(FeaturesRunner.class)
 @Features({ TransactionalFeature.class, RuntimeStreamFeature.class, LogCaptureFeature.class })
@@ -281,6 +283,40 @@ public class TestEventServiceComponent {
             fail("should throw ConcurrentUpdateException");
         } catch (ConcurrentUpdateException e) {
             assertEquals("too fast bro", e.getMessage());
+        }
+    }
+
+    @Test
+    @Deploy("org.nuxeo.ecm.core.event:test-rollback-listener.xml")
+    public void testMarkRollbackWithNuxeoException() {
+        Event event = new EventImpl("markRollback", new EventContextImpl());
+        try {
+            eventService.fireEvent(event);
+            fail("should throw NuxeoException");
+        } catch (NuxeoException e) {
+            assertEquals("NuxeoException", e.getMessage());
+            assertEquals(400, e.getStatusCode());
+            assertTrue(TransactionHelper.isTransactionMarkedRollback());
+        }
+    }
+
+    @Test
+    @Deploy("org.nuxeo.ecm.core.event:test-rollback-listener.xml")
+    public void testMarkRollbackWithRuntimeException() {
+        Event event = new EventImpl("markRollback", new EventContextImpl());
+        event.getContext().setProperty("RuntimeException", true);
+        try {
+            eventService.fireEvent(event);
+            fail("should throw NuxeoException");
+        } catch (NuxeoException e) {
+            assertEquals(
+                    "Exception during testRollbackListener sync listener execution, transaction will be rolled back",
+                    e.getMessage());
+            assertEquals(500, e.getStatusCode());
+            assertTrue(TransactionHelper.isTransactionMarkedRollback());
+            Throwable cause = e.getCause();
+            assertTrue(cause instanceof RuntimeException);
+            assertEquals("RuntimeException", cause.getMessage());
         }
     }
 

--- a/modules/core/nuxeo-core-event/src/test/resources/test-rollback-listener.xml
+++ b/modules/core/nuxeo-core-event/src/test/resources/test-rollback-listener.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0"?>
+<component name="test-rollback-listener">
+
+  <extension target="org.nuxeo.ecm.core.event.EventServiceComponent" point="listener">
+    <listener class="org.nuxeo.ecm.core.event.test.RollbackListener" name="testRollbackListener">
+      <event>markRollback</event>
+    </listener>
+  </extension>
+
+</component>

--- a/modules/platform/nuxeo-quota/src/test/java/org/nuxeo/ecm/quota/count/TestDocumentsSizeUpdater.java
+++ b/modules/platform/nuxeo-quota/src/test/java/org/nuxeo/ecm/quota/count/TestDocumentsSizeUpdater.java
@@ -1063,9 +1063,8 @@ public class TestDocumentsSizeUpdater {
             secondFile = session.createDocument(secondFile);
             session.saveDocument(secondFile);
             fail("Should have failed due to quota exceeded");
-        } catch (Exception e) {
-            assertTrue("Should have failed with a QuotaExceededException cause",
-                    e.getCause() instanceof QuotaExceededException);
+        } catch (QuotaExceededException e) {
+            assertEquals("Current event documentCreated would break Quota restriction, rolling back, QuotaExceeded", e.getMessage());
         }
 
         try {
@@ -1074,9 +1073,8 @@ public class TestDocumentsSizeUpdater {
             firstFile = session.createDocument(firstFile);
             session.saveDocument(firstFile);
             fail("Should have failed due to quota exceeded");
-        } catch (Exception e) {
-            assertTrue("Should have failed with a QuotaExceededException cause",
-                    e.getCause() instanceof QuotaExceededException);
+        } catch (QuotaExceededException e) {
+            assertEquals("Current event documentCreated would break Quota restriction, rolling back, QuotaExceeded", e.getMessage());
         }
     }
 


### PR DESCRIPTION
Do not throw a RuntimeException anymore:
- if it's already a NuxeoException, rethrow it
- otherwise wrap the exception in a NuxeoException
