### PR TITLE
NXP-29966: compute video info, previews, storyboard and conversions only when needed

### DIFF
--- a/modules/platform/nuxeo-platform-video/src/main/java/org/nuxeo/ecm/platform/video/VideoHelper.java
+++ b/modules/platform/nuxeo-platform-video/src/main/java/org/nuxeo/ecm/platform/video/VideoHelper.java
@@ -104,7 +104,6 @@ public class VideoHelper {
     public static void updateStoryboard(DocumentModel docModel, Blob video) {
         if (video == null) {
             docModel.setPropertyValue(VideoConstants.STORYBOARD_PROPERTY, null);
-            docModel.setPropertyValue(VideoConstants.DURATION_PROPERTY, 0);
             return;
         }
 

--- a/modules/platform/nuxeo-platform-video/src/main/java/org/nuxeo/ecm/platform/video/service/VideoService.java
+++ b/modules/platform/nuxeo-platform-video/src/main/java/org/nuxeo/ecm/platform/video/service/VideoService.java
@@ -52,7 +52,21 @@ public interface VideoService {
      *
      * @param doc the video document to be converted
      */
-    void launchAutomaticConversions(DocumentModel doc);
+    default void launchAutomaticConversions(DocumentModel doc) {
+        launchAutomaticConversions(doc, false);
+    }
+
+    /**
+     * Launch registered automatic video conversions on the given {@code doc}.
+     * <p>
+     * If {@code onlyMissing} is {@code true}, launch only the automatic video conversions that are not on the video
+     * document, otherwise launch all the registered automatic video conversions
+     *
+     * @param doc the video document to be converted
+     * @param onlyMissing whether to launch only the missing video conversions
+     * @since 11.5
+     */
+    void launchAutomaticConversions(DocumentModel doc, boolean onlyMissing);
 
     /**
      * Convert the {@code originalVideo} using the given {@code conversionName}.

--- a/modules/platform/nuxeo-platform-video/src/main/java/org/nuxeo/ecm/platform/video/service/VideoService.java
+++ b/modules/platform/nuxeo-platform-video/src/main/java/org/nuxeo/ecm/platform/video/service/VideoService.java
@@ -63,7 +63,6 @@ public interface VideoService {
      */
     TranscodedVideo convert(Video originalVideo, String conversionName);
 
-
     /**
      * Returns the status of the video conversion with the given conversion name on the given document.
      *

--- a/modules/platform/nuxeo-platform-video/src/main/java/org/nuxeo/ecm/platform/video/service/VideoServiceImpl.java
+++ b/modules/platform/nuxeo-platform-video/src/main/java/org/nuxeo/ecm/platform/video/service/VideoServiceImpl.java
@@ -43,6 +43,7 @@ import org.nuxeo.ecm.core.work.api.WorkManager;
 import org.nuxeo.ecm.platform.video.TranscodedVideo;
 import org.nuxeo.ecm.platform.video.Video;
 import org.nuxeo.ecm.platform.video.VideoConversionStatus;
+import org.nuxeo.ecm.platform.video.VideoDocument;
 import org.nuxeo.ecm.platform.video.VideoHelper;
 import org.nuxeo.ecm.platform.video.VideoInfo;
 import org.nuxeo.runtime.api.Framework;
@@ -147,11 +148,14 @@ public class VideoServiceImpl extends DefaultComponent implements VideoService {
     }
 
     @Override
-    public void launchAutomaticConversions(DocumentModel doc) {
+    public void launchAutomaticConversions(DocumentModel doc, boolean onlyMissing) {
         List<AutomaticVideoConversion> conversions = new ArrayList<>(automaticVideoConversions.registry.values());
         Collections.sort(conversions);
+        VideoDocument videoDocument = doc.getAdapter(VideoDocument.class);
         for (AutomaticVideoConversion conversion : conversions) {
-            launchConversion(doc, conversion.getName());
+            if (!onlyMissing || videoDocument.getTranscodedVideo(conversion.getName()) == null) {
+                launchConversion(doc, conversion.getName());
+            }
         }
     }
 

--- a/modules/platform/nuxeo-platform-video/src/main/java/org/nuxeo/ecm/platform/video/service/VideoStoryboardWork.java
+++ b/modules/platform/nuxeo-platform-video/src/main/java/org/nuxeo/ecm/platform/video/service/VideoStoryboardWork.java
@@ -22,6 +22,9 @@ package org.nuxeo.ecm.platform.video.service;
 import static org.nuxeo.ecm.core.api.CoreSession.ALLOW_VERSION_WRITE;
 
 import java.io.IOException;
+import java.io.Serializable;
+import java.util.List;
+import java.util.Map;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -30,6 +33,7 @@ import org.nuxeo.ecm.core.api.DocumentModel;
 import org.nuxeo.ecm.core.api.IdRef;
 import org.nuxeo.ecm.core.api.blobholder.BlobHolder;
 import org.nuxeo.ecm.core.work.AbstractWork;
+import org.nuxeo.ecm.platform.video.VideoConstants;
 import org.nuxeo.ecm.platform.video.VideoHelper;
 
 /**
@@ -81,28 +85,51 @@ public class VideoStoryboardWork extends AbstractWork {
 
         // update storyboard
         setStatus("Updating storyboard");
-        log.debug(String.format("Updating storyboard of Video document %s.", doc));
-        VideoHelper.updateStoryboard(doc, video);
-        log.debug(String.format("End updating storyboard of Video document %s.", doc));
+        boolean save = updateStoryboard(doc, video);
 
         // update previews
         setStatus("Updating previews");
+        save |= updatePreviews(doc, video);
+
+        if (save) {
+            // save document
+            if (doc.isVersion()) {
+                doc.putContextData(ALLOW_VERSION_WRITE, Boolean.TRUE);
+            }
+            session.saveDocument(doc);
+        }
+
+        setStatus("Done");
+    }
+
+    protected boolean updateStoryboard(DocumentModel doc, Blob blob) {
+        var storyboard = (List<Map<String, Serializable>>) doc.getPropertyValue(VideoConstants.STORYBOARD_PROPERTY);
+        if (storyboard != null && !storyboard.isEmpty()) {
+            return false;
+        }
+
+        log.debug(String.format("Updating storyboard of Video document %s.", doc));
+        VideoHelper.updateStoryboard(doc, blob);
+        log.debug(String.format("End updating storyboard of Video document %s.", doc));
+        return true;
+    }
+
+    protected boolean updatePreviews(DocumentModel doc, Blob blob) {
+        var previews = (List<Map<String, Serializable>>) doc.getPropertyValue("picture:views");
+        if (previews != null && !previews.isEmpty()) {
+            return false;
+        }
+
         log.debug(String.format("Updating previews of Video document %s.", doc));
         try {
-            VideoHelper.updatePreviews(doc, video);
+            VideoHelper.updatePreviews(doc, blob);
             log.debug(String.format("End updating previews of Video document %s.", doc));
+            return true;
         } catch (IOException e) {
             // this should only happen if the hard drive is full
             log.debug(String.format("Failed to extract previews of Video document %s.", doc), e);
+            return false;
         }
-
-        // save document
-        if (doc.isVersion()) {
-            doc.putContextData(ALLOW_VERSION_WRITE, Boolean.TRUE);
-        }
-        session.saveDocument(doc);
-
-        setStatus("Done");
     }
 
 }

--- a/modules/platform/nuxeo-platform-video/src/test/java/org/nuxeo/ecm/platform/video/extension/TestVideoImporterAndListeners.java
+++ b/modules/platform/nuxeo-platform-video/src/test/java/org/nuxeo/ecm/platform/video/extension/TestVideoImporterAndListeners.java
@@ -375,7 +375,7 @@ public class TestVideoImporterAndListeners {
     @Deploy("org.nuxeo.ecm.platform.video:test-video-conversions-enabled.xml")
     @Deploy("org.nuxeo.ecm.platform.video:test-video-listeners-contrib.xml")
     @SuppressWarnings("unchecked")
-    public void testVideoConversions() throws IOException, InterruptedException {
+    public void testVideoConversions() throws IOException {
         DocumentModel doc = session.createDocumentModel("/", "testVideoDoc", VIDEO_TYPE);
         Blob blob = getBlobFromPath("test-data/sample.mpg", "video/mpeg");
         doc.setPropertyValue("file:content", (Serializable) blob);

--- a/modules/platform/nuxeo-platform-video/src/test/java/org/nuxeo/ecm/platform/video/extension/TestVideoImporterAndListeners.java
+++ b/modules/platform/nuxeo-platform-video/src/test/java/org/nuxeo/ecm/platform/video/extension/TestVideoImporterAndListeners.java
@@ -33,7 +33,9 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.Serializable;
+import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -48,6 +50,8 @@ import org.nuxeo.ecm.core.api.Blob;
 import org.nuxeo.ecm.core.api.Blobs;
 import org.nuxeo.ecm.core.api.CoreSession;
 import org.nuxeo.ecm.core.api.DocumentModel;
+import org.nuxeo.ecm.core.api.DocumentRef;
+import org.nuxeo.ecm.core.api.VersioningOption;
 import org.nuxeo.ecm.core.schema.DocumentType;
 import org.nuxeo.ecm.core.test.annotations.Granularity;
 import org.nuxeo.ecm.core.test.annotations.RepositoryConfig;
@@ -60,6 +64,7 @@ import org.nuxeo.ecm.platform.video.Video;
 import org.nuxeo.ecm.platform.video.VideoConstants;
 import org.nuxeo.ecm.platform.video.VideoDocument;
 import org.nuxeo.ecm.platform.video.VideoFeature;
+import org.nuxeo.ecm.platform.video.VideoInfo;
 import org.nuxeo.ecm.platform.video.listener.VideoChangedListener;
 import org.nuxeo.ecm.platform.video.service.VideoService;
 import org.nuxeo.runtime.api.Framework;
@@ -480,6 +485,296 @@ public class TestVideoImporterAndListeners {
         assertEquals(2, transcodedVideos.size());
         storyboard = (List<Map<String, Serializable>>) doc.getPropertyValue(VideoConstants.STORYBOARD_PROPERTY);
         assertEquals(2, storyboard.size());
+    }
+
+    // NXP-29966
+    @Test
+    public void testVideoInfoUpdateWhenCreating() throws IOException {
+        DocumentModel doc = session.createDocumentModel("/", "testVideoDoc", VIDEO_TYPE);
+        Blob blob = getBlobFromPath("test-data/sample.mpg", "video/mpeg");
+        doc.setPropertyValue("file:content", (Serializable) blob);
+        Map<String, Serializable> videoInfoMap = new HashMap<>();
+        videoInfoMap.put(VideoInfo.WIDTH, 100);
+        videoInfoMap.put(VideoInfo.HEIGHT, 50);
+        videoInfoMap.put(VideoInfo.DURATION, 150);
+        videoInfoMap.put(VideoInfo.FORMAT, "foo");
+        doc.setPropertyValue(VideoConstants.INFO_PROPERTY, (Serializable) videoInfoMap);
+        doc = session.createDocument(doc);
+        txFeature.nextTransaction();
+
+        // video info not computed as it was provided at creation time
+        doc = session.getDocument(doc.getRef());
+        VideoDocument videoDocument = doc.getAdapter(VideoDocument.class);
+        Video video = videoDocument.getVideo();
+        assertEquals(100, video.getWidth());
+        assertEquals(50, video.getHeight());
+        assertEquals(150, video.getDuration(), 0.1);
+
+        // make the main blob dirty, triggers the video info recompute
+        doc.setPropertyValue("file:content", (Serializable) blob);
+        session.saveDocument(doc);
+        txFeature.nextTransaction();
+
+        doc = session.getDocument(doc.getRef());
+        videoDocument = doc.getAdapter(VideoDocument.class);
+        video = videoDocument.getVideo();
+        assertEquals(320, video.getWidth());
+        assertEquals(200, video.getHeight());
+        assertEquals(0.05, video.getDuration(), 0.1);
+    }
+
+    // NXP-29966
+    @Test
+    @SuppressWarnings("unchecked")
+    public void testPreviewsUpdateWhenCreating() throws IOException {
+        DocumentModel doc = session.createDocumentModel("/", "testVideoDoc", VIDEO_TYPE);
+        Blob blob = getBlobFromPath("test-data/sample.mpg", "video/mpeg");
+        doc.setPropertyValue("file:content", (Serializable) blob);
+        List<Map<String, Serializable>> pictureviews = new ArrayList<>();
+        Map<String, Serializable> pictureView = new HashMap<>();
+        pictureView.put("title", "StaticPlayerView");
+        pictureView.put("content", (Serializable) Blobs.createBlob("dummy"));
+        pictureviews.add(pictureView);
+        doc.setPropertyValue("picture:views", (Serializable) pictureviews);
+        doc = session.createDocument(doc);
+        txFeature.nextTransaction();
+
+        // previews not computed as it was provided at creation time
+        doc = session.getDocument(doc.getRef());
+        pictureviews = (List<Map<String, Serializable>>) doc.getPropertyValue("picture:views");
+        assertEquals(1, pictureviews.size());
+        assertEquals("StaticPlayerView", pictureviews.get(0).get("title"));
+
+        // make the main blob dirty, triggers the previews recompute
+        doc.setPropertyValue("file:content", (Serializable) blob);
+        session.saveDocument(doc);
+        txFeature.nextTransaction();
+
+        doc = session.getDocument(doc.getRef());
+        pictureviews = (List<Map<String, Serializable>>) doc.getPropertyValue("picture:views");
+        assertEquals(2, pictureviews.size());
+        assertEquals("Small", pictureviews.get(0).get("title"));
+        assertEquals("StaticPlayerView", pictureviews.get(1).get("title"));
+    }
+
+    // NXP-29966
+    @Test
+    @Deploy("org.nuxeo.ecm.platform.video:video-configuration-override.xml")
+    @SuppressWarnings("unchecked")
+    public void testStoryboardUpdateWhenCreating() throws IOException {
+        DocumentModel doc = session.createDocumentModel("/", "testVideoDoc", VIDEO_TYPE);
+        Blob blob = getBlobFromPath("test-data/sample.mpg", "video/mpeg");
+        doc.setPropertyValue("file:content", (Serializable) blob);
+        Map<String, Serializable> item = new HashMap<>();
+        item.put("content", (Serializable) Blobs.createBlob("dummy"));
+        item.put("timecode", 5);
+        List<Map<String, Serializable>> storyboard = new ArrayList<>();
+        storyboard.add(item);
+        doc.setPropertyValue(STORYBOARD_PROPERTY, (Serializable) storyboard);
+        doc = session.createDocument(doc);
+        txFeature.nextTransaction();
+
+        // storyboard not computed as it was provided at creation time
+        doc = session.getDocument(doc.getRef());
+        storyboard = (List<Map<String, Serializable>>) doc.getPropertyValue(STORYBOARD_PROPERTY);
+        assertEquals(1, storyboard.size());
+        Blob storyboardBlob = (Blob) storyboard.get(0).get("content");
+        assertEquals("dummy", storyboardBlob.getString());
+
+        // make the main blob dirty, triggers the storyboard recompute
+        doc.setPropertyValue("file:content", (Serializable) blob);
+        session.saveDocument(doc);
+        txFeature.nextTransaction();
+
+        doc = session.getDocument(doc.getRef());
+        storyboard = (List<Map<String, Serializable>>) doc.getPropertyValue(STORYBOARD_PROPERTY);
+        assertEquals(2, storyboard.size());
+    }
+
+    // NXP-29966
+    @Test
+    @Deploy("org.nuxeo.ecm.platform.video:test-video-conversions-enabled.xml")
+    @SuppressWarnings("unchecked")
+    public void testVideoConversionsUpdateWhenCreating() throws IOException {
+        DocumentModel doc = session.createDocumentModel("/", "testVideoDoc", VIDEO_TYPE);
+        Blob blob = getBlobFromPath("test-data/sample.mpg", "video/mpeg");
+        doc.setPropertyValue("file:content", (Serializable) blob);
+        List<Map<String, Serializable>> transcodedVideos = new ArrayList<>();
+        Map<String, Serializable> transcodedVideo = new HashMap<>();
+        transcodedVideo.put("name", "MP4 480p");
+        transcodedVideo.put("content", (Serializable) Blobs.createBlob("dummy"));
+        transcodedVideos.add(transcodedVideo);
+        doc.setPropertyValue(TRANSCODED_VIDEOS_PROPERTY, (Serializable) transcodedVideos);
+        doc = session.createDocument(doc);
+        txFeature.nextTransaction();
+
+        // only missing conversion is computed as the other was provided at creation time
+        doc = session.getDocument(doc.getRef());
+        transcodedVideos = (List<Map<String, Serializable>>) doc.getPropertyValue(TRANSCODED_VIDEOS_PROPERTY);
+        assertEquals(2, transcodedVideos.size());
+        assertEquals("MP4 480p", transcodedVideos.get(0).get("name"));
+        Blob transcodedVideoBlob = (Blob) transcodedVideos.get(0).get("content");
+        assertEquals("text/plain", transcodedVideoBlob.getMimeType());
+        assertEquals("dummy", transcodedVideoBlob.getString());
+        assertEquals("WebM 480p", transcodedVideos.get(1).get("name"));
+        transcodedVideoBlob = (Blob) transcodedVideos.get(1).get("content");
+        assertNotNull(transcodedVideoBlob);
+        assertEquals("video/webm", transcodedVideoBlob.getMimeType());
+
+        // make the main blob dirty, triggers the video conversions
+        doc.setPropertyValue("file:content", (Serializable) blob);
+        session.saveDocument(doc);
+        txFeature.nextTransaction();
+
+        doc = session.getDocument(doc.getRef());
+        transcodedVideos = (List<Map<String, Serializable>>) doc.getPropertyValue(TRANSCODED_VIDEOS_PROPERTY);
+        assertEquals(2, transcodedVideos.size());
+        assertEquals("MP4 480p", transcodedVideos.get(0).get("name"));
+        transcodedVideoBlob = (Blob) transcodedVideos.get(0).get("content");
+        assertEquals("video/mp4", transcodedVideoBlob.getMimeType());
+        assertEquals("WebM 480p", transcodedVideos.get(1).get("name"));
+        transcodedVideoBlob = (Blob) transcodedVideos.get(1).get("content");
+        assertEquals("video/webm", transcodedVideoBlob.getMimeType());
+    }
+
+    // NXP-29966
+    @Test
+    @Deploy("org.nuxeo.ecm.platform.video:test-video-conversions-enabled.xml")
+    @Deploy("org.nuxeo.ecm.platform.video:video-configuration-override.xml")
+    @SuppressWarnings("unchecked")
+    public void testComputeAllOnVersion() throws IOException {
+        DocumentModel doc = session.createDocumentModel("/", "testVideoDoc", VIDEO_TYPE);
+        Blob blob = getBlobFromPath("test-data/sample.mpg", "video/mpeg");
+        doc.setPropertyValue("file:content", (Serializable) blob);
+        doc.putContextData(VideoChangedListener.DISABLE_VIDEO_CONVERSIONS_GENERATION_LISTENER, true);
+        doc = session.createDocument(doc);
+        txFeature.nextTransaction();
+
+        // nothing computed
+        doc = session.getDocument(doc.getRef());
+        Map<String, Serializable> videoInfo = (Map<String, Serializable>) doc.getPropertyValue(
+                VideoConstants.INFO_PROPERTY);
+        assertNull(videoInfo.get("width"));
+        assertNull(videoInfo.get("height"));
+        List<Map<String, Serializable>> pictureViews = (List<Map<String, Serializable>>) doc.getPropertyValue(
+                "picture:views");
+        assertTrue(pictureViews.isEmpty());
+        List<Map<String, Serializable>> storyboard = (List<Map<String, Serializable>>) doc.getPropertyValue(
+                STORYBOARD_PROPERTY);
+        assertTrue(storyboard.isEmpty());
+        List<Map<String, Serializable>> transcodedVideos = (List<Map<String, Serializable>>) doc.getPropertyValue(
+                TRANSCODED_VIDEOS_PROPERTY);
+        assertTrue(transcodedVideos.isEmpty());
+
+        // create a version
+        DocumentRef versionRef = session.checkIn(doc.getRef(), VersioningOption.NONE, null);
+        txFeature.nextTransaction();
+
+        // everything is computed
+        doc = session.getDocument(versionRef);
+        // check video info
+        VideoDocument videoDocument = doc.getAdapter(VideoDocument.class);
+        Video video = videoDocument.getVideo();
+        assertEquals(320, video.getWidth());
+        assertEquals(200, video.getHeight());
+        assertEquals(0.05, video.getDuration(), 0.1);
+        // check previews
+        pictureViews = (List<Map<String, Serializable>>) doc.getPropertyValue("picture:views");
+        assertEquals(2, pictureViews.size());
+        assertEquals("Small", pictureViews.get(0).get("title"));
+        assertEquals("StaticPlayerView", pictureViews.get(1).get("title"));
+        // check storyboard
+        storyboard = (List<Map<String, Serializable>>) doc.getPropertyValue(STORYBOARD_PROPERTY);
+        assertEquals(2, storyboard.size());
+
+        transcodedVideos = (List<Map<String, Serializable>>) doc.getPropertyValue(TRANSCODED_VIDEOS_PROPERTY);
+        assertEquals(2, transcodedVideos.size());
+        assertEquals("MP4 480p", transcodedVideos.get(0).get("name"));
+        Blob transcodedVideoBlob = (Blob) transcodedVideos.get(0).get("content");
+        assertEquals("video/mp4", transcodedVideoBlob.getMimeType());
+        assertEquals("WebM 480p", transcodedVideos.get(1).get("name"));
+        transcodedVideoBlob = (Blob) transcodedVideos.get(1).get("content");
+        assertEquals("video/webm", transcodedVideoBlob.getMimeType());
+    }
+
+    // NXP-29966
+    @Test
+    @Deploy("org.nuxeo.ecm.platform.video:test-video-conversions-enabled.xml")
+    @Deploy("org.nuxeo.ecm.platform.video:video-configuration-override.xml")
+    @SuppressWarnings("unchecked")
+    public void testComputeMissingOnVersion() throws IOException {
+        DocumentModel doc = session.createDocumentModel("/", "testVideoDoc", VIDEO_TYPE);
+        Blob blob = getBlobFromPath("test-data/sample.mpg", "video/mpeg");
+        doc.setPropertyValue("file:content", (Serializable) blob);
+        doc.putContextData(VideoChangedListener.DISABLE_VIDEO_CONVERSIONS_GENERATION_LISTENER, true);
+        // prefill video info and previews
+        Map<String, Serializable> videoInfoMap = new HashMap<>();
+        videoInfoMap.put(VideoInfo.WIDTH, 100);
+        videoInfoMap.put(VideoInfo.HEIGHT, 50);
+        videoInfoMap.put(VideoInfo.DURATION, 150);
+        videoInfoMap.put(VideoInfo.FORMAT, "foo");
+        doc.setPropertyValue(VideoConstants.INFO_PROPERTY, (Serializable) videoInfoMap);
+        List<Map<String, Serializable>> pictureviews = new ArrayList<>();
+        Map<String, Serializable> pictureView = new HashMap<>();
+        pictureView.put("title", "StaticPlayerView");
+        pictureView.put("content", (Serializable) Blobs.createBlob("dummy"));
+        pictureviews.add(pictureView);
+        doc.setPropertyValue("picture:views", (Serializable) pictureviews);
+        doc = session.createDocument(doc);
+        txFeature.nextTransaction();
+
+        // only video info and previews are set
+        doc = session.getDocument(doc.getRef());
+        VideoDocument videoDocument = doc.getAdapter(VideoDocument.class);
+        Video video = videoDocument.getVideo();
+        assertEquals(100, video.getWidth());
+        assertEquals(50, video.getHeight());
+        assertEquals(150, video.getDuration(), 0.1);
+        assertEquals("foo", video.getFormat());
+        List<Map<String, Serializable>> pictureViews = (List<Map<String, Serializable>>) doc.getPropertyValue(
+                "picture:views");
+        assertEquals(1, pictureViews.size());
+        assertEquals("StaticPlayerView", pictureViews.get(0).get("title"));
+        Blob pictureViewBlob = (Blob) pictureViews.get(0).get("content");
+        assertEquals("dummy", pictureViewBlob.getString());
+        List<Map<String, Serializable>> storyboard = (List<Map<String, Serializable>>) doc.getPropertyValue(
+                STORYBOARD_PROPERTY);
+        assertTrue(storyboard.isEmpty());
+        List<Map<String, Serializable>> transcodedVideos = (List<Map<String, Serializable>>) doc.getPropertyValue(
+                TRANSCODED_VIDEOS_PROPERTY);
+        assertTrue(transcodedVideos.isEmpty());
+
+        // create a version
+        DocumentRef versionRef = session.checkIn(doc.getRef(), VersioningOption.NONE, null);
+        txFeature.nextTransaction();
+
+        // only missing storyboard and conversions are computed
+        doc = session.getDocument(versionRef);
+        // check video info
+        videoDocument = doc.getAdapter(VideoDocument.class);
+        video = videoDocument.getVideo();
+        assertEquals(100, video.getWidth());
+        assertEquals(50, video.getHeight());
+        assertEquals(150, video.getDuration(), 0.1);
+        assertEquals("foo", video.getFormat());
+        // check previews
+        pictureViews = (List<Map<String, Serializable>>) doc.getPropertyValue("picture:views");
+        assertEquals(1, pictureViews.size());
+        assertEquals("StaticPlayerView", pictureViews.get(0).get("title"));
+        pictureViewBlob = (Blob) pictureViews.get(0).get("content");
+        assertEquals("dummy", pictureViewBlob.getString());
+        // check storyboard
+        storyboard = (List<Map<String, Serializable>>) doc.getPropertyValue(STORYBOARD_PROPERTY);
+        assertEquals(2, storyboard.size());
+
+        transcodedVideos = (List<Map<String, Serializable>>) doc.getPropertyValue(TRANSCODED_VIDEOS_PROPERTY);
+        assertEquals(2, transcodedVideos.size());
+        assertEquals("MP4 480p", transcodedVideos.get(0).get("name"));
+        Blob transcodedVideoBlob = (Blob) transcodedVideos.get(0).get("content");
+        assertEquals("video/mp4", transcodedVideoBlob.getMimeType());
+        assertEquals("WebM 480p", transcodedVideos.get(1).get("name"));
+        transcodedVideoBlob = (Blob) transcodedVideos.get(1).get("content");
+        assertEquals("video/webm", transcodedVideoBlob.getMimeType());
     }
 
 }


### PR DESCRIPTION
When creating a document (new document or version), we compute:
- the video info only if the width and height is set to 0
- the video previews only if empty
- the video storyboard only if empty
- only the missing automatic conversions not present on the document

When updating the main blob document, everything is reset and recomputed.


