### PR TITLE
[DRAFT] NXP-30002: add retention's governance mode ability

### DIFF
--- a/modules/core/nuxeo-core-storage-dbs/src/main/java/org/nuxeo/ecm/core/storage/dbs/DBSDocument.java
+++ b/modules/core/nuxeo-core-storage-dbs/src/main/java/org/nuxeo/ecm/core/storage/dbs/DBSDocument.java
@@ -35,7 +35,6 @@ import java.util.Set;
 import java.util.function.Consumer;
 
 import org.apache.commons.lang3.StringUtils;
-import org.nuxeo.ecm.core.api.CoreSession;
 import org.nuxeo.ecm.core.api.DocumentNotFoundException;
 import org.nuxeo.ecm.core.api.LifeCycleException;
 import org.nuxeo.ecm.core.api.Lock;
@@ -1231,6 +1230,11 @@ public class DBSDocument extends BaseDocument<State> {
         docState.put(KEY_LOCK_CREATED, null);
         // return old lock
         return new Lock(oldOwner, oldCreated);
+    }
+
+    @Override
+    public boolean isUnderRetentionOrLegalHold() {
+      return super.isUnderRetentionOrLegalHold() || TRUE.equals(getStateOrTarget().get(KEY_IS_RETENTION_ACTIVE));
     }
 
     @Override

--- a/modules/core/nuxeo-core-test/src/test/java/org/nuxeo/ecm/core/TestRetentionHelper.java
+++ b/modules/core/nuxeo-core-test/src/test/java/org/nuxeo/ecm/core/TestRetentionHelper.java
@@ -1,0 +1,223 @@
+/*
+ * (C) Copyright 2021 Nuxeo (http://nuxeo.com/) and others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Contributors:
+ *     Salem Aouana
+ */
+
+package org.nuxeo.ecm.core;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+import java.io.Serializable;
+import java.util.Calendar;
+
+import javax.inject.Inject;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.nuxeo.ecm.core.api.AbstractSession;
+import org.nuxeo.ecm.core.api.Blob;
+import org.nuxeo.ecm.core.api.Blobs;
+import org.nuxeo.ecm.core.api.CoreSession;
+import org.nuxeo.ecm.core.api.DocumentModel;
+import org.nuxeo.ecm.core.api.DocumentSecurityException;
+import org.nuxeo.ecm.core.api.security.ACE;
+import org.nuxeo.ecm.core.api.security.ACL;
+import org.nuxeo.ecm.core.api.security.ACP;
+import org.nuxeo.ecm.core.api.security.SecurityConstants;
+import org.nuxeo.ecm.core.helpers.RetentionHelper;
+import org.nuxeo.ecm.core.model.Document;
+import org.nuxeo.ecm.core.test.CoreFeature;
+import org.nuxeo.ecm.core.test.annotations.Granularity;
+import org.nuxeo.ecm.core.test.annotations.RepositoryConfig;
+import org.nuxeo.runtime.services.config.ConfigurationService;
+import org.nuxeo.runtime.test.runner.Deploy;
+import org.nuxeo.runtime.test.runner.Features;
+import org.nuxeo.runtime.test.runner.FeaturesRunner;
+
+/**
+ * @since 11.5
+ */
+@RunWith(FeaturesRunner.class)
+@Features(CoreFeature.class)
+@RepositoryConfig(cleanup = Granularity.METHOD)
+public class TestRetentionHelper {
+
+    public static final String JOHN = "John";
+
+    @Inject
+    protected CoreSession session;
+
+    @Inject
+    protected CoreFeature coreFeature;
+
+    @Inject
+    protected ConfigurationService configurationService;
+
+    @Test
+    public void iCanDeleteDocumentNotUnderRetentionOrLegalHold() {
+        DocumentModel documentModel = createDocument(session);
+        RetentionHelper.checkMainContentDeletion(getDocument(documentModel), session.getPrincipal());
+        RetentionHelper.checkDeletion(getDocument(documentModel), session.getPrincipal());
+
+        // Give the permission to another user
+        ACP acp = documentModel.getACP();
+        ACL acl = acp.getOrCreateACL();
+        acl.add(new ACE(JOHN, SecurityConstants.READ, true));
+        acl.add(new ACE(JOHN, SecurityConstants.REMOVE, true));
+        session.setACP(documentModel.getRef(), acp, false);
+        session.save();
+        CoreSession notAdminSession = coreFeature.getCoreSession(JOHN);
+        RetentionHelper.checkMainContentDeletion(getDocument(documentModel), notAdminSession.getPrincipal());
+        RetentionHelper.checkDeletion(getDocument(documentModel), notAdminSession.getPrincipal());
+    }
+
+    @Test
+    public void iCannotDeleteDocumentUnderRetentionOrLegalHold() {
+        // Make a document under legal hold
+        DocumentModel documentModel = createDocument(session);
+        session.makeRecord(documentModel.getRef());
+        session.setLegalHold(documentModel.getRef(), true, null);
+
+        try {
+            RetentionHelper.checkMainContentDeletion(getDocument(documentModel), session.getPrincipal());
+            fail();
+        } catch (DocumentSecurityException e) {
+            assertEquals(String.format("Cannot delete blob from document %s, it is under retention / hold",
+                    documentModel.getRef()), e.getMessage());
+        }
+
+        try {
+            RetentionHelper.checkDeletion(getDocument(documentModel), session.getPrincipal());
+            fail();
+        } catch (DocumentSecurityException e) {
+            assertEquals(String.format("Cannot remove %s, it is under retention / hold", documentModel.getRef()),
+                    e.getMessage());
+        }
+
+        // Make a document under retention
+        documentModel = createDocument(session);
+        Calendar retainUntil = Calendar.getInstance();
+        retainUntil.add(Calendar.DAY_OF_MONTH, 5);
+        session.makeRecord(documentModel.getRef());
+        session.setRetainUntil(documentModel.getRef(), retainUntil, "any comment");
+        try {
+            RetentionHelper.checkMainContentDeletion(getDocument(documentModel), session.getPrincipal());
+            fail();
+        } catch (DocumentSecurityException e) {
+            assertEquals(String.format("Cannot delete blob from document %s, it is under retention / hold",
+                    documentModel.getRef()), e.getMessage());
+        }
+
+        try {
+            RetentionHelper.checkDeletion(getDocument(documentModel), session.getPrincipal());
+            fail();
+        } catch (DocumentSecurityException e) {
+            assertEquals(String.format("Cannot remove %s, it is under retention / hold", documentModel.getRef()),
+                    e.getMessage());
+        }
+
+        // Give the permission to another user
+        ACP acp = documentModel.getACP();
+        ACL acl = acp.getOrCreateACL();
+        acl.add(new ACE(JOHN, SecurityConstants.READ, true));
+        acl.add(new ACE(JOHN, SecurityConstants.REMOVE, true));
+        session.setACP(documentModel.getRef(), acp, false);
+        session.save();
+        CoreSession notAdminSession = coreFeature.getCoreSession(JOHN);
+        try {
+            RetentionHelper.checkMainContentDeletion(getDocument(documentModel), notAdminSession.getPrincipal());
+            fail();
+        } catch (DocumentSecurityException e) {
+            assertEquals(String.format("Cannot delete blob from document %s, it is under retention / hold",
+                    documentModel.getRef()), e.getMessage());
+        }
+
+        try {
+            RetentionHelper.checkDeletion(getDocument(documentModel), notAdminSession.getPrincipal());
+            fail();
+        } catch (DocumentSecurityException e) {
+            assertEquals(String.format("Cannot remove %s, it is under retention / hold", documentModel.getRef()),
+                    e.getMessage());
+        }
+    }
+
+    @Test
+    @Deploy("org.nuxeo.ecm.core.test.tests:OSGI-INF/retention-enable-governance-mode.xml")
+    public void iCanDeleteDocumentUnderRetentionOrLegalHold() {
+        // Make a document under legal hold
+        DocumentModel documentModel = createDocument(session);
+        session.makeRecord(documentModel.getRef());
+        session.setLegalHold(documentModel.getRef(), true, null);
+        RetentionHelper.checkMainContentDeletion(getDocument(documentModel), session.getPrincipal());
+        RetentionHelper.checkDeletion(getDocument(documentModel), session.getPrincipal());
+
+        // Make a document under retention
+        documentModel = createDocument(session);
+        Calendar retainUntil = Calendar.getInstance();
+        retainUntil.add(Calendar.DAY_OF_MONTH, 8);
+        session.makeRecord(documentModel.getRef());
+        session.setRetainUntil(documentModel.getRef(), retainUntil, "any comment");
+        RetentionHelper.checkMainContentDeletion(getDocument(documentModel), session.getPrincipal());
+        RetentionHelper.checkDeletion(getDocument(documentModel), session.getPrincipal());
+
+        // Not Admin user without the right permissions, shouldn't remove the document
+        ACP acp = documentModel.getACP();
+        ACL acl = acp.getOrCreateACL();
+        acl.add(new ACE(JOHN, SecurityConstants.READ, true));
+        acl.add(new ACE(JOHN, SecurityConstants.REMOVE, true));
+        session.setACP(documentModel.getRef(), acp, false);
+        session.save();
+        CoreSession notAdminSession = coreFeature.getCoreSession(JOHN);
+        try {
+            RetentionHelper.checkMainContentDeletion(getDocument(documentModel), notAdminSession.getPrincipal());
+            fail();
+        } catch (DocumentSecurityException e) {
+            assertEquals(String.format("Cannot delete blob from document %s, it is under retention / hold",
+                    documentModel.getRef()), e.getMessage());
+        }
+
+        try {
+            RetentionHelper.checkDeletion(getDocument(documentModel), notAdminSession.getPrincipal());
+            fail();
+        } catch (DocumentSecurityException e) {
+            assertEquals(String.format("Cannot remove %s, it is under retention / hold", documentModel.getRef()),
+                    e.getMessage());
+        }
+
+        // Give the needed permission for document deletion under retention/legal hold
+        acl.add(new ACE(JOHN, RetentionHelper.REMOVE_RECORD_PERMISSION, true));
+        session.setACP(documentModel.getRef(), acp, false);
+        session.save();
+        RetentionHelper.checkMainContentDeletion(getDocument(documentModel), notAdminSession.getPrincipal());
+        RetentionHelper.checkDeletion(getDocument(documentModel), notAdminSession.getPrincipal());
+    }
+
+    protected DocumentModel createDocument(CoreSession session) {
+        DocumentModel documentModel = session.createDocumentModel("/", "myDocument", "File");
+        Blob blob = Blobs.createBlob("Any Content", "text/plain");
+        documentModel.setPropertyValue("file:content", (Serializable) blob);
+        documentModel = session.createDocument(documentModel);
+        documentModel = session.saveDocument(documentModel);
+        return documentModel;
+    }
+
+    protected Document getDocument(DocumentModel documentModel) {
+        return ((AbstractSession) session).getSession().getDocumentByUUID(documentModel.getId());
+    }
+
+}

--- a/modules/core/nuxeo-core-test/src/test/resources/OSGI-INF/retention-enable-governance-mode.xml
+++ b/modules/core/nuxeo-core-test/src/test/resources/OSGI-INF/retention-enable-governance-mode.xml
@@ -1,0 +1,7 @@
+<component name="org.nuxeo.runtime.configuration.contribution.retention.mode">
+
+  <extension target="org.nuxeo.runtime.ConfigurationService" point="configuration">
+    <property name="nuxeo.retention.mode">governance</property>
+  </extension>
+
+</component>

--- a/modules/core/nuxeo-core/src/main/java/org/nuxeo/ecm/core/blob/DocumentBlobManagerComponent.java
+++ b/modules/core/nuxeo-core/src/main/java/org/nuxeo/ecm/core/blob/DocumentBlobManagerComponent.java
@@ -31,6 +31,8 @@ import java.util.function.Supplier;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.nuxeo.ecm.core.api.Blob;
+import org.nuxeo.ecm.core.api.CoreInstance;
+import org.nuxeo.ecm.core.api.CoreSession;
 import org.nuxeo.ecm.core.api.DocumentModel;
 import org.nuxeo.ecm.core.api.DocumentSecurityException;
 import org.nuxeo.ecm.core.api.NuxeoException;
@@ -38,6 +40,7 @@ import org.nuxeo.ecm.core.api.model.PropertyNotFoundException;
 import org.nuxeo.ecm.core.blob.BlobDispatcher.BlobDispatch;
 import org.nuxeo.ecm.core.blob.binary.BinaryGarbageCollector;
 import org.nuxeo.ecm.core.blob.binary.BinaryManagerStatus;
+import org.nuxeo.ecm.core.helpers.RetentionHelper;
 import org.nuxeo.ecm.core.model.Document;
 import org.nuxeo.ecm.core.model.Document.BlobAccessor;
 import org.nuxeo.ecm.core.model.Repository;
@@ -183,9 +186,9 @@ public class DocumentBlobManagerComponent extends DefaultComponent implements Do
     @Override
     public String writeBlob(Blob blob, Document doc, String xpath) throws IOException {
         if (blob == null) {
-            if (MAIN_BLOB_XPATH.equals(xpath) && doc.isUnderRetentionOrLegalHold()) {
-                throw new DocumentSecurityException(
-                        "Cannot delete blob from document " + doc.getUUID() + ", it is under retention / hold");
+            if (MAIN_BLOB_XPATH.equals(xpath)) {
+                CoreSession session = CoreInstance.getCoreSession(doc.getSession().getRepositoryName());
+                RetentionHelper.checkMainContentDeletion(doc, session.getPrincipal());
             }
             return null;
         }

--- a/modules/core/nuxeo-core/src/main/java/org/nuxeo/ecm/core/helpers/RetentionHelper.java
+++ b/modules/core/nuxeo-core/src/main/java/org/nuxeo/ecm/core/helpers/RetentionHelper.java
@@ -1,0 +1,110 @@
+/*
+ * (C) Copyright 2021 Nuxeo (http://nuxeo.com/) and others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Contributors:
+ *     Salem Aouana
+ */
+
+package org.nuxeo.ecm.core.helpers;
+
+import org.nuxeo.ecm.core.api.DocumentSecurityException;
+import org.nuxeo.ecm.core.api.NuxeoPrincipal;
+import org.nuxeo.ecm.core.model.Document;
+import org.nuxeo.ecm.core.security.SecurityService;
+import org.nuxeo.runtime.api.Framework;
+import org.nuxeo.runtime.services.config.ConfigurationService;
+
+/**
+ * Manages the CRUD actions on documents under retention or legal hold.
+ * 
+ * @since 11.5
+ */
+public class RetentionHelper {
+
+    public static final String RETENTION_MODE_PROPERTY = "nuxeo.retention.mode";
+
+    public static final String RETENTION_GOVERNANCE_MODE = "governance";
+
+    public static final String REMOVE_RECORD_PERMISSION = "RemoveRecords";
+
+    protected static final String MAIN_BLOB_XPATH = "content";
+
+    /**
+     * Checks if the document's deletion action is allowed. A document can be deleted if:
+     * <ul>
+     * <li>The document is not under retention / legal hold.</li>
+     * <li>The document is under retention / legal hold and the action is made by a granted user under
+     * {@code governance} mode</li>
+     * </ul>
+     *
+     * @param document the document to check
+     * @param principal the Nuxeo principal
+     * @see Document#isUnderRetentionOrLegalHold()
+     * @throws DocumentSecurityException if the deletion action is not allowed
+     */
+    public static void checkDeletion(Document document, NuxeoPrincipal principal) {
+        if (!canDelete(document, principal)) {
+            throw new DocumentSecurityException(
+                    String.format("Cannot remove %s, it is under retention / hold", document.getUUID()));
+        }
+    }
+
+    /**
+     * Checks if the document's main content deletion is allowed. A main content can be deleted if:
+     * <ul>
+     * <li>The document is not under retention / legal hold.</li>
+     * <li>The document is under retention / legal hold and the action is made by a granted user under
+     * {@code governance} mode</li>
+     * </ul>
+     *
+     * @param document the document
+     * @param principal the Nuxeo principal
+     * @see Document#isUnderRetentionOrLegalHold()
+     * @throws DocumentSecurityException if the deletion action is not allowed
+     */
+    public static void checkMainContentDeletion(Document document, NuxeoPrincipal principal) {
+        if (!canDelete(document, principal)) {
+            throw new DocumentSecurityException(String.format(
+                    "Cannot delete blob from document %s, it is under retention / hold", document.getUUID()));
+        }
+    }
+
+    /**
+     * Checks if the document's deletion action is allowed, a document or its main content can be deleted if:
+     * <ul>
+     * <li>The document is not under retention / legal hold.</li>
+     * <li>The document is under retention / legal hold and the action is made by a granted user under
+     * {@code governance} mode</li>
+     * </ul>
+     *
+     * @param document the document
+     * @param principal the Nuxeo principal
+     * @see Document#isUnderRetentionOrLegalHold()
+     * @return {@code true} if the we can delete the document, {@code false} otherwise
+     */
+    public static boolean canDelete(Document document, NuxeoPrincipal principal) {
+        if (!document.isUnderRetentionOrLegalHold()) {
+            return true;
+        }
+        String mode = Framework.getService(ConfigurationService.class).getString(RETENTION_MODE_PROPERTY, "");
+        SecurityService securityService = Framework.getService(SecurityService.class);
+        return RETENTION_GOVERNANCE_MODE.equalsIgnoreCase(mode)
+                && securityService.checkPermission(document, principal, REMOVE_RECORD_PERMISSION);
+    }
+
+    private RetentionHelper() {
+        // no instance allowed
+    }
+}


### PR DESCRIPTION
**PLEASE WAIT BEFORE REVIEWING THIS PR.** The Acceptance criteria have changed, since I opened this PR. 



This PR is related to the JIRA ticket NXP-30002. It purpose it to add the ability and implement the governance mode at the low level. The governance mode allows the deletion of a given document or it content, where this document is under retention / legal hold.

I have extracted a new class where I added the check, the main purpose is to put the whole rules in one place and avoid duplication. Also note that this class can be improved later where we we will add the content replacement (wait for a validation from Julien).

 