### PR TITLE
NXP-30130: Add a timeout on commandline execution

### DIFF
--- a/modules/core/nuxeo-platform-commandline-executor/pom.xml
+++ b/modules/core/nuxeo-platform-commandline-executor/pom.xml
@@ -25,12 +25,33 @@
     </dependency>
     <dependency>
       <groupId>org.nuxeo.runtime</groupId>
+      <artifactId>nuxeo-runtime-jtajca</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.nuxeo.runtime</groupId>
       <artifactId>nuxeo-launcher-commons</artifactId>
     </dependency>
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-lang3</artifactId>
     </dependency>
+
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.nuxeo.runtime</groupId>
+      <artifactId>nuxeo-runtime-test</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.nuxeo.runtime</groupId>
+      <artifactId>nuxeo-runtime-datasource</artifactId>
+      <scope>test</scope>
+    </dependency>
+
   </dependencies>
 
 </project>

--- a/modules/core/nuxeo-platform-commandline-executor/src/main/java/org/nuxeo/ecm/platform/commandline/executor/api/ExecResult.java
+++ b/modules/core/nuxeo-platform-commandline-executor/src/main/java/org/nuxeo/ecm/platform/commandline/executor/api/ExecResult.java
@@ -109,4 +109,9 @@ public class ExecResult implements Serializable {
         return commandLine;
     }
 
+    public boolean isCommandInTimeout() {
+        // When a command is killed by timeout using SIGKILL the return code is 137 = 128 + SIGKILL(9)
+        return returnCode == 137;
+    }
+
 }

--- a/modules/core/nuxeo-platform-commandline-executor/src/main/java/org/nuxeo/ecm/platform/commandline/executor/service/CommandLineDescriptor.java
+++ b/modules/core/nuxeo-platform-commandline-executor/src/main/java/org/nuxeo/ecm/platform/commandline/executor/service/CommandLineDescriptor.java
@@ -20,6 +20,8 @@
 
 package org.nuxeo.ecm.platform.commandline.executor.service;
 
+import java.time.Duration;
+
 import org.apache.commons.lang3.SystemUtils;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
@@ -78,6 +80,10 @@ public class CommandLineDescriptor {
 
     @XNode("installationDirective")
     protected String installationDirective;
+
+    // @since 11.5
+    @XNode("timeout")
+    public Duration timeout;
 
     public String getName() {
         if (name == null) {
@@ -181,4 +187,12 @@ public class CommandLineDescriptor {
         this.installErrorMessage = installErrorMessage;
     }
 
+    /**
+     * Returns the time limit for the command
+     *
+     * @since 11.5
+     */
+    public Duration getTimeout() {
+        return timeout;
+    }
 }

--- a/modules/core/nuxeo-platform-commandline-executor/src/main/resources/OSGI-INF/commandline-default-contrib.xml
+++ b/modules/core/nuxeo-platform-commandline-executor/src/main/resources/OSGI-INF/commandline-default-contrib.xml
@@ -23,4 +23,12 @@
     </commandTester>
   </extension>
 
+  <extension target="org.nuxeo.ecm.platform.commandline.executor.service.CommandLineExecutorComponent" point="command">
+    <!-- timeout is used to set a time limit when running command, this definition checks if timeout is available -->
+    <command name="timeout" enabled="true">
+      <commandLine>timeout</commandLine>
+      <parameterString>--version</parameterString>
+    </command>
+  </extension>
+
 </component>

--- a/modules/core/nuxeo-platform-commandline-executor/src/test/java/org/nuxeo/ecm/platform/commandline/executor/tests/TestCommands.java
+++ b/modules/core/nuxeo-platform-commandline-executor/src/test/java/org/nuxeo/ecm/platform/commandline/executor/tests/TestCommands.java
@@ -19,6 +19,7 @@
 package org.nuxeo.ecm.platform.commandline.executor.tests;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
@@ -31,6 +32,7 @@ import java.util.List;
 import javax.inject.Inject;
 
 import org.apache.commons.lang3.SystemUtils;
+import org.junit.Assume;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.nuxeo.common.Environment;
@@ -42,7 +44,8 @@ import org.nuxeo.runtime.api.Framework;
 import org.nuxeo.runtime.test.runner.Deploy;
 import org.nuxeo.runtime.test.runner.Features;
 import org.nuxeo.runtime.test.runner.FeaturesRunner;
-import org.nuxeo.runtime.test.runner.RuntimeFeature;
+import org.nuxeo.runtime.test.runner.TransactionalFeature;
+import org.nuxeo.runtime.transaction.TransactionHelper;
 
 /**
  * Tests commands parsing.
@@ -51,7 +54,7 @@ import org.nuxeo.runtime.test.runner.RuntimeFeature;
  * @author Vincent Dutat
  */
 @RunWith(FeaturesRunner.class)
-@Features(RuntimeFeature.class)
+@Features(TransactionalFeature.class)
 @Deploy("org.nuxeo.ecm.platform.commandline.executor")
 public class TestCommands {
 
@@ -117,6 +120,45 @@ public class TestCommands {
         // window's echo displays things exactly as is including quotes
         String expected = SystemUtils.IS_OS_WINDOWS ? "\"a   b\" \"c   d\" e" : "a   b c   d e";
         assertEquals(expected, line);
+    }
+
+
+    @Test
+    @Deploy("org.nuxeo.ecm.platform.commandline.executor:OSGI-INF/commandline-command-test-contrib.xml")
+    public void testTimeoutOnBlockingCommand() throws Exception {
+        Assume.assumeTrue("Requires timeout", cles.getAvailableCommands().contains("timeout"));
+        List<String> cmds = cles.getRegistredCommands();
+        assertTrue(cmds.contains("block"));
+
+        ExecResult result = cles.execCommand("block", cles.getDefaultCmdParameters());
+        assertFalse(result.isSuccessful());
+        // Command terminated with SIGKILL = 128 + 9
+        assertEquals(137, result.getReturnCode());
+        assertTrue(result.isCommandInTimeout());
+    }
+
+    @Test
+    @Deploy("org.nuxeo.ecm.platform.commandline.executor:OSGI-INF/commandline-command-test-contrib.xml")
+    public void testTimeoutOnTransaction() throws Exception {
+        Assume.assumeTrue("Requires timeout", cles.getAvailableCommands().contains("timeout"));
+        List<String> cmds = cles.getRegistredCommands();
+        assertTrue(cmds.contains("tooLong"));
+
+        // Execute a long command
+        ExecResult result = cles.execCommand("tooLong", cles.getDefaultCmdParameters());
+        assertTrue(result.isSuccessful());
+        assertFalse(result.isCommandInTimeout());
+
+        // Execute the command again but within a short transaction
+        TransactionHelper.commitOrRollbackTransaction();
+        TransactionHelper.startTransaction(1);
+        result = cles.execCommand("tooLong", cles.getDefaultCmdParameters());
+        assertFalse(result.isSuccessful());
+        assertTrue(result.isCommandInTimeout());
+
+        // Start a new transaction to prevent tx timeout during test tear down
+        TransactionHelper.commitOrRollbackTransaction();
+        TransactionHelper.startTransaction();
     }
 
 }

--- a/modules/core/nuxeo-platform-commandline-executor/src/test/java/org/nuxeo/ecm/platform/commandline/executor/tests/TestService.java
+++ b/modules/core/nuxeo-platform-commandline-executor/src/test/java/org/nuxeo/ecm/platform/commandline/executor/tests/TestService.java
@@ -64,7 +64,7 @@ public class TestService {
 
         List<String> cmds = cles.getRegistredCommands();
         assertNotNull(cmds);
-        assertEquals(1, cmds.size());
+        assertEquals(2, cmds.size());
         assertTrue(cmds.contains("aspell"));
 
         hotDeployer.deploy(
@@ -72,7 +72,7 @@ public class TestService {
 
         cmds = cles.getRegistredCommands();
         assertNotNull(cmds);
-        assertEquals(2, cmds.size());
+        assertEquals(3, cmds.size());
         assertTrue(cmds.contains("identify"));
 
         hotDeployer.deploy(
@@ -80,15 +80,14 @@ public class TestService {
 
         cmds = cles.getRegistredCommands();
         assertNotNull(cmds);
-        assertEquals(1, cmds.size());
+        assertEquals(2, cmds.size());
         assertFalse(cmds.contains("identify"));
     }
 
     @Test
     @Deploy("org.nuxeo.ecm.platform.commandline.executor:OSGI-INF/commandline-dummy-test-contrib.xml")
     public void testCmdAvailable() {
-        assertEquals(List.of("cmdThatDoNotExist"), cles.getRegistredCommands());
-        assertTrue(cles.getAvailableCommands().isEmpty());
+        assertTrue(cles.getRegistredCommands().contains("cmdThatDoNotExist"));
 
         CommandAvailability ca1 = cles.getCommandAvailability("cmdThatDoNotExist");
         assertFalse(ca1.isAvailable());
@@ -96,7 +95,8 @@ public class TestService {
                 + "(descriptor CommandLineDescriptor[available=false,command=cmdThatDoNotExistAtAllForSure,enabled=true,"
                 + "installErrorMessage=<null>,installationDirective=You need to install this command that does not exist!"
                 + ",name=cmdThatDoNotExist,parameterString=,readOutput=true,testParameterString=,tester=<null>,"
-                + "winCommand=<null>,winParameterString=<null>,winTestParameterString=<null>])", ca1.getErrorMessage());
+                + "timeout=<null>,winCommand=<null>,winParameterString=<null>,winTestParameterString=<null>])",
+                ca1.getErrorMessage());
         assertEquals("You need to install this command that does not exist!", ca1.getInstallMessage());
         assertTrue(ca1.getInstallMessage().contains("need to install this command that does not"));
 

--- a/modules/core/nuxeo-platform-commandline-executor/src/test/resources/OSGI-INF/commandline-command-test-contrib.xml
+++ b/modules/core/nuxeo-platform-commandline-executor/src/test/resources/OSGI-INF/commandline-command-test-contrib.xml
@@ -19,4 +19,17 @@
     </command>
   </extension>
 
+  <extension target="org.nuxeo.ecm.platform.commandline.executor.service.CommandLineExecutorComponent" point="command">
+    <command name="block" enabled="true">
+      <commandLine>sleep</commandLine>
+      <parameterString>3</parameterString>
+      <timeout>1s</timeout>
+    </command>
+
+    <command name="tooLong" enabled="true">
+      <commandLine>sleep</commandLine>
+      <parameterString>3</parameterString>
+    </command>
+  </extension>
+
 </component>


### PR DESCRIPTION
When available (on linux or macos) commands are invoked using timeout
to limit the execution time.
The timeout duration is the minimum of the transaction ttl or an
explicit timeout duration in the command definition.