### PR TITLE
NXP-30213: fix Redis key/value store fetch of empty key list (10.10)

### DIFF
--- a/nuxeo-core/nuxeo-core-redis/src/main/java/org/nuxeo/ecm/core/redis/contribs/RedisKeyValueStore.java
+++ b/nuxeo-core/nuxeo-core-redis/src/main/java/org/nuxeo/ecm/core/redis/contribs/RedisKeyValueStore.java
@@ -213,6 +213,9 @@ public class RedisKeyValueStore extends AbstractKeyValueStoreProvider {
      * @since 9.10
      */
     protected List<byte[]> getValuesForKeys(Collection<String> keys) {
+        if (keys.isEmpty()) {
+            return Collections.emptyList();
+        }
         byte[][] byteKeys = new byte[keys.size()][];
         int i = 0;
         for (String key : keys) {

--- a/nuxeo-runtime/nuxeo-runtime-kv/src/test/java/org/nuxeo/runtime/kv/AbstractKeyValueStoreTest.java
+++ b/nuxeo-runtime/nuxeo-runtime-kv/src/test/java/org/nuxeo/runtime/kv/AbstractKeyValueStoreTest.java
@@ -318,6 +318,9 @@ public abstract class AbstractKeyValueStoreTest {
 
     @Test
     public void testGetMany() {
+        assertTrue(store.get(Collections.emptyList()).isEmpty());
+        assertTrue(store.getStrings(Collections.emptyList()).isEmpty());
+
         String key1 = "foo1";
         String key2 = "foo2";
         String key3 = "foo3";
@@ -350,6 +353,8 @@ public abstract class AbstractKeyValueStoreTest {
     @SuppressWarnings("boxing")
     @Test
     public void testGetManyLong() {
+        assertTrue(store.getLongs(Collections.emptyList()).isEmpty());
+
         String key1 = "foo1";
         String key2 = "foo2";
         String key3 = "foo3";


### PR DESCRIPTION
Backport of #4695