### PR TITLE
NXP-30314: Wait for topic creation

### DIFF
--- a/nuxeo-runtime/nuxeo-stream/src/main/java/org/nuxeo/lib/stream/log/kafka/KafkaUtils.java
+++ b/nuxeo-runtime/nuxeo-stream/src/main/java/org/nuxeo/lib/stream/log/kafka/KafkaUtils.java
@@ -18,6 +18,7 @@
  */
 package org.nuxeo.lib.stream.log.kafka;
 
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -175,8 +176,29 @@ public class KafkaUtils implements AutoCloseable {
                 throw new StreamRuntimeException(e);
             }
         } catch (TimeoutException e) {
-            throw new StreamRuntimeException("Unable to create topics " + topic + " within the timeout", e);
+            throw new StreamRuntimeException("Unable to create topic " + topic + " within the timeout", e);
         }
+        if (partitions(topic) != partitions) {
+            waitForTopicCreation(topic, Duration.ofMinutes(2));
+        }
+    }
+
+    protected void waitForTopicCreation(String topic, Duration timeout) {
+        log.warn("Waiting for brokers to become aware that the topic " + topic + " has been created.");
+        long deadline = System.currentTimeMillis() + timeout.toMillis();
+        do {
+            if (System.currentTimeMillis() > deadline) {
+                throw new StreamRuntimeException(new TimeoutException(
+                        "Timeout while waiting for topic " + topic + " metadata propagation in the cluster"));
+            }
+            try {
+                Thread.sleep(5_000);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                throw new StreamRuntimeException("Interrupted while waiting for topic creation " + topic, e);
+            }
+        } while (!topicExists(topic));
+        log.debug("Topic is now available");
     }
 
     public boolean topicExists(String topic) {


### PR DESCRIPTION
It may take several seconds after createTopics returns success for all the brokers
to become aware that the topics have been created, especially in the case of
massive creation with replications