### PR TITLE
 NXP-30239: delay Quartz scheduler start for 5s by default

### DIFF
--- a/modules/core/nuxeo-core-event/src/main/java/org/nuxeo/ecm/core/scheduler/SchedulerServiceImpl.java
+++ b/modules/core/nuxeo-core-event/src/main/java/org/nuxeo/ecm/core/scheduler/SchedulerServiceImpl.java
@@ -42,6 +42,7 @@ import org.nuxeo.runtime.cluster.ClusterService;
 import org.nuxeo.runtime.model.ComponentContext;
 import org.nuxeo.runtime.model.ComponentManager;
 import org.nuxeo.runtime.model.DefaultComponent;
+import org.nuxeo.runtime.services.config.ConfigurationService;
 import org.quartz.JobDetail;
 import org.quartz.JobKey;
 import org.quartz.ObjectAlreadyExistsException;
@@ -70,6 +71,16 @@ public class SchedulerServiceImpl extends DefaultComponent implements SchedulerS
 
     /** @since 11.1 */
     public static final Duration CLUSTER_START_DURATION_DEFAULT = Duration.ofMinutes(1);
+
+    /** @since 11.5 */
+    public static final String CLUSTER_START_DELAY_PROP = "org.nuxeo.scheduler.start.delay";
+
+    /**
+     * Default value is set to 5 seconds to delay the start by default
+     *
+     * @since 11.5
+     */
+    public static final Duration CLUSTER_START_DELAY_DEFAULT = Duration.ofSeconds(5);
 
     protected static final String XP = "schedule";
 
@@ -102,7 +113,9 @@ public class SchedulerServiceImpl extends DefaultComponent implements SchedulerS
             schedulerFactory.initialize(props);
         }
         scheduler = schedulerFactory.getScheduler();
-        scheduler.start();
+        // delay Quartz scheduler start to avoid unique key constraints violation with qrtz_LOCKS table
+        ConfigurationService cs = Framework.getService(ConfigurationService.class);
+        scheduler.startDelayed((int) cs.getDuration(CLUSTER_START_DELAY_PROP, CLUSTER_START_DELAY_DEFAULT).toSeconds());
         // server = MBeanServerFactory.createMBeanServer();
         // server.createMBean("org.quartz.ee.jmx.jboss.QuartzService",
         // quartzObjectName);

--- a/modules/core/nuxeo-core-event/src/main/resources/OSGI-INF/scheduler-service.xml
+++ b/modules/core/nuxeo-core-event/src/main/resources/OSGI-INF/scheduler-service.xml
@@ -49,5 +49,15 @@
 
   </extension-point>
 
+  <extension target="org.nuxeo.runtime.ConfigurationService" point="configuration">
+    <documentation>
+      Delay Quartz scheduler start to avoid unique key constraint violation with qrtz_LOCKS table
+      <p />
+      Default behavior is to delay for 5 seconds.
+
+      @since 11.5
+    </documentation>
+    <property name="org.nuxeo.scheduler.start.delay">5s</property>
+  </extension>
 
 </component>

--- a/modules/core/nuxeo-core-event/src/test/java/org/nuxeo/ecm/core/scheduler/TestSchedulerService.java
+++ b/modules/core/nuxeo-core-event/src/test/java/org/nuxeo/ecm/core/scheduler/TestSchedulerService.java
@@ -119,5 +119,16 @@ public class TestSchedulerService {
         newCount = DummyEventListener.getNewCount();
         assertTrue(newCount >= 1);
     }
+    @Test
+    @Deploy("org.nuxeo.ecm.core.event.test:OSGI-INF/test-scheduler-with-delay-config.xml")
+    public void testSchedulerStartWithDelay() throws Exception {
 
+        waitUntilDummyEventListenerIsCalled(5); // wait 5 seconds for the event
+        long count = DummyEventListener.getCount();
+        assertTrue("count " + count, count == 0); // scheduler is started with a 10s delay, so no event is triggered
+
+        waitUntilDummyEventListenerIsCalled(10); // wait more
+        count = DummyEventListener.getCount();
+        assertTrue("count " + count, count >= 1);
+    }
 }

--- a/modules/core/nuxeo-core-event/src/test/resources/OSGI-INF/test-scheduler-eventlistener.xml
+++ b/modules/core/nuxeo-core-event/src/test/resources/OSGI-INF/test-scheduler-eventlistener.xml
@@ -1,9 +1,15 @@
 <?xml version="1.0"?>
 <component name="org.nuxeo.ecm.core.scheduler.test.listener">
+  <require>org.nuxeo.ecm.core.scheduler.SchedulerService</require>
   <extension target="org.nuxeo.ecm.core.event.EventServiceComponent"
     point="listener">
     <listener name="testListener" async="false" postCommit="false"
       class="org.nuxeo.ecm.core.scheduler.DummyEventListener">
     </listener>
+  </extension>
+
+  <extension target="org.nuxeo.runtime.ConfigurationService" point="configuration">
+    <!-- setting property to 0 in unit tests to keep the same behavior and faster tests -->
+    <property name="org.nuxeo.scheduler.start.delay">0s</property>
   </extension>
 </component>

--- a/modules/core/nuxeo-core-event/src/test/resources/OSGI-INF/test-scheduler-with-delay-config.xml
+++ b/modules/core/nuxeo-core-event/src/test/resources/OSGI-INF/test-scheduler-with-delay-config.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0"?>
+<component name="org.nuxeo.ecm.core.scheduler.test.with.delay.config">
+
+  <require>org.nuxeo.ecm.core.scheduler.SchedulerService</require>
+
+  <extension target="org.nuxeo.runtime.ConfigurationService" point="configuration">
+    <property name="org.nuxeo.scheduler.start.delay">10s</property>
+  </extension>
+
+  <extension
+    target="org.nuxeo.ecm.core.scheduler.SchedulerService" point="schedule">
+    <schedule id="testing">
+      <username>Administrator</username>
+      <eventId>testEvent</eventId>
+      <eventCategory>default</eventCategory>
+      <!-- every second -->
+      <cronExpression>*/1 * * * * ?</cronExpression>
+    </schedule>
+  </extension>
+</component>


### PR DESCRIPTION
This is configured by the property 'org.nuxeo.scheduler.start.delay'