### PR TITLE
NXP-30357: Fix blob MIME type with S3 direct upload

### DIFF
--- a/modules/core/nuxeo-core-binarymanager-cloud/nuxeo-core-binarymanager-s3/src/main/java/org/nuxeo/ecm/core/storage/sql/S3DirectBatchHandler.java
+++ b/modules/core/nuxeo-core-binarymanager-cloud/nuxeo-core-binarymanager-s3/src/main/java/org/nuxeo/ecm/core/storage/sql/S3DirectBatchHandler.java
@@ -44,6 +44,9 @@ import java.util.Objects;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.apache.http.HeaderElement;
+import org.apache.http.NameValuePair;
+import org.apache.http.message.BasicHeaderValueParser;
 import org.nuxeo.ecm.automation.server.jaxrs.batch.Batch;
 import org.nuxeo.ecm.automation.server.jaxrs.batch.handler.AbstractBatchHandler;
 import org.nuxeo.ecm.automation.server.jaxrs.batch.handler.BatchFileInfo;
@@ -155,6 +158,34 @@ public class S3DirectBatchHandler extends AbstractBatchHandler {
 
     // public for tests
     public String blobProviderId;
+
+    /**
+     * @since 11.5
+     */
+    public static String getMimeType(String contentType) {
+        Objects.requireNonNull(contentType);
+        HeaderElement headerElement = BasicHeaderValueParser.parseHeaderElement(contentType, null);
+        return headerElement.getName();
+    }
+
+    /**
+     * @since 11.5
+     */
+    public static String getCharset(String contentType) {
+        Objects.requireNonNull(contentType);
+        HeaderElement headerElement = BasicHeaderValueParser.parseHeaderElement(contentType, null);
+        String encoding = null;
+        for (NameValuePair param : headerElement.getParameters()) {
+            if (param.getName().equalsIgnoreCase("charset")) {
+                String s = param.getValue();
+                if (!isBlank(s)) {
+                    encoding = s;
+                }
+                break;
+            }
+        }
+        return encoding;
+    }
 
     @Override
     protected void initialize(Map<String, String> properties) {
@@ -274,8 +305,9 @@ public class S3DirectBatchHandler extends AbstractBatchHandler {
         // materialize the direct upload blob as a Nuxeo Blob
 
         BlobInfo blobInfo = new BlobInfo();
-        blobInfo.mimeType = metadata.getContentType();
-        blobInfo.encoding = metadata.getContentEncoding();
+        String contentType = metadata.getContentType();
+        blobInfo.mimeType = getMimeType(contentType);
+        blobInfo.encoding = getCharset(contentType);
         blobInfo.filename = fileInfo.getFilename();
         blobInfo.length = metadata.getContentLength();
         blobInfo.key = key;

--- a/modules/core/nuxeo-core-binarymanager-cloud/nuxeo-core-binarymanager-s3/src/test/java/org/nuxeo/ecm/blob/s3/TestS3DirectBatchHandler.java
+++ b/modules/core/nuxeo-core-binarymanager-cloud/nuxeo-core-binarymanager-s3/src/test/java/org/nuxeo/ecm/blob/s3/TestS3DirectBatchHandler.java
@@ -1,0 +1,53 @@
+/*
+ * (C) Copyright 2021 Nuxeo (http://nuxeo.com/) and others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Contributors:
+ *     Antoine Taillefer <ataillefer@nuxeo.com>
+ */
+package org.nuxeo.ecm.blob.s3;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+import org.junit.Test;
+import org.nuxeo.ecm.core.storage.sql.S3DirectBatchHandler;
+
+/**
+ * @since 11.5
+ */
+public class TestS3DirectBatchHandler {
+
+    // NXP-30357
+    @Test
+    public void testContentTypeHelpers() {
+        // text content types
+        assertEquals("text/plain", S3DirectBatchHandler.getMimeType("text/plain")); // NOSONAR
+        assertNull(S3DirectBatchHandler.getCharset("text/plain"));
+
+        assertEquals("text/plain", S3DirectBatchHandler.getMimeType("text/plain; charset=UTF-8"));
+        assertEquals("UTF-8", S3DirectBatchHandler.getCharset("text/plain; charset=UTF-8")); // NOSONAR
+
+        assertEquals("text/plain", S3DirectBatchHandler.getMimeType("text/plain ; CHARSET = UTF-8 ; foo=bar"));
+        assertEquals("UTF-8", S3DirectBatchHandler.getCharset("text/plain ; CHARSET = UTF-8 ; foo=bar"));
+
+        // PDF content types
+        assertEquals("application/pdf", S3DirectBatchHandler.getMimeType("application/pdf")); // NOSONAR
+        assertNull(S3DirectBatchHandler.getCharset("application/pdf"));
+
+        assertEquals("application/pdf", S3DirectBatchHandler.getMimeType("application/pdf; charset=UTF-8"));
+        assertEquals("UTF-8", S3DirectBatchHandler.getCharset("application/pdf; charset=UTF-8"));
+    }
+
+}


### PR DESCRIPTION
Split Content-Type header into MIME type and charset, dispatch them respectively to the blob's MIME type and encoding properties.