### PR TITLE
NXP-30449: Don't restore ecm:proxyIds on DBS

### DIFF
--- a/modules/core/nuxeo-core-storage-dbs/src/main/java/org/nuxeo/ecm/core/storage/dbs/DBSSession.java
+++ b/modules/core/nuxeo-core-storage-dbs/src/main/java/org/nuxeo/ecm/core/storage/dbs/DBSSession.java
@@ -688,6 +688,8 @@ public class DBSSession extends BaseSession {
         case KEY_PRIMARY_TYPE:
         case KEY_ACP:
         case KEY_READ_ACL:
+            // these are proxy-specific
+        case KEY_PROXY_IDS:
             // these are version-specific
         case KEY_VERSION_CREATED:
         case KEY_VERSION_DESCRIPTION:

--- a/modules/core/nuxeo-core-test/src/test/java/org/nuxeo/ecm/core/TestSQLRepositoryAPI.java
+++ b/modules/core/nuxeo-core-test/src/test/java/org/nuxeo/ecm/core/TestSQLRepositoryAPI.java
@@ -119,13 +119,10 @@ import org.nuxeo.ecm.core.event.test.CapturingEventListener;
 import org.nuxeo.ecm.core.model.Repository;
 import org.nuxeo.ecm.core.model.Session;
 import org.nuxeo.ecm.core.repository.RepositoryService;
-import org.nuxeo.ecm.core.schema.DocumentTypeDescriptor;
 import org.nuxeo.ecm.core.schema.FacetNames;
 import org.nuxeo.ecm.core.schema.SchemaManager;
-import org.nuxeo.ecm.core.schema.SchemaManagerImpl;
 import org.nuxeo.ecm.core.schema.types.Schema;
 import org.nuxeo.ecm.core.security.RetentionExpiredFinderListener;
-import org.nuxeo.ecm.core.storage.sql.IgnorePostgreSQL;
 import org.nuxeo.ecm.core.storage.sql.listeners.DummyBeforeModificationListener;
 import org.nuxeo.ecm.core.test.CoreFeature;
 import org.nuxeo.ecm.core.test.annotations.Granularity;
@@ -3633,6 +3630,54 @@ public class TestSQLRepositoryAPI {
         // check visible from live doc
         doc = session.getDocument(doc.getRef());
         assertEquals("the title again", doc.getProperty("dublincore", "title"));
+    }
+
+    // NXP-30449
+    @Test
+    public void testDeleteWorkingCopyOfProxyLiveAfterRestore() {
+        DocumentModel root = session.getRootDocument();
+        // create a document and version it to 0.1
+        DocumentModel doc = session.createDocumentModel(root.getPathAsString(), "proxy_test", "File");
+        doc.setProperty("dublincore", "title", "the title");
+        doc.putContextData(VersioningService.VERSIONING_OPTION, VersioningOption.MINOR);
+        doc = session.createDocument(doc);
+        session.save();
+
+        // create live proxy
+        DocumentModel proxy = session.createProxy(doc.getRef(), root.getRef());
+        assertTrue(proxy.isProxy());
+        assertFalse(proxy.isVersion());
+        assertFalse(proxy.isImmutable());
+        session.save();
+
+        // check we can't delete the working copy
+        try {
+            session.removeDocument(doc.getRef());
+            fail("Remove document targeted by a proxy should have failed");
+        } catch (DocumentExistsException e) {
+            assertEquals(String.format("Cannot remove %s, subdocument %s is the target of proxy %s", doc.getId(),
+                    doc.getId(), proxy.getId()), e.getMessage());
+        }
+
+        // do change on working copy and version it to 0.2
+        doc.setProperty("dublincore", "title", "new the title");
+        doc.putContextData(VersioningService.VERSIONING_OPTION, VersioningOption.MINOR);
+        doc = session.saveDocument(doc);
+
+        // restore to version 0.1
+        VersionModel versionModel = new VersionModelImpl();
+        versionModel.setLabel("0.1");
+        DocumentModel v1 = session.getDocumentWithVersion(doc.getRef(), versionModel);
+        doc = session.restoreToVersion(doc.getRef(), v1.getRef());
+
+        // check again we can't delete the working copy
+        try {
+            session.removeDocument(doc.getRef());
+            fail("Remove document targeted by a proxy should have failed");
+        } catch (DocumentExistsException e) {
+            assertEquals(String.format("Cannot remove %s, subdocument %s is the target of proxy %s", doc.getId(),
+                    doc.getId(), proxy.getId()), e.getMessage());
+        }
     }
 
     @Test


### PR DESCRIPTION
Created after investigation from #4805.