### PR TITLE
[10.10] NXP-30348: Return a HTTP 404 (not found) when handling uploads with a…

### DIFF
--- a/nuxeo-features/nuxeo-automation/nuxeo-automation-server/src/main/java/org/nuxeo/ecm/automation/server/jaxrs/batch/BatchManagerComponent.java
+++ b/nuxeo-features/nuxeo-automation/nuxeo-automation-server/src/main/java/org/nuxeo/ecm/automation/server/jaxrs/batch/BatchManagerComponent.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright 2015-2018 Nuxeo (http://nuxeo.com/) and others.
+ * (C) Copyright 2015-2021 Nuxeo (http://nuxeo.com/) and others.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,10 +16,12 @@
  * Contributors:
  *     Thierry Delprat <tdelprat@nuxeo.com>
  *     Antoine Taillefer <ataillefer@nuxeo.com>
+ *     Mickaël Schoentgen
  *
  */
 package org.nuxeo.ecm.automation.server.jaxrs.batch;
 
+import static javax.servlet.http.HttpServletResponse.SC_NOT_FOUND;
 import static org.apache.commons.lang3.StringUtils.isEmpty;
 
 import java.io.IOException;
@@ -320,7 +322,7 @@ public class BatchManagerComponent extends DefaultComponent implements BatchMana
                     "Unable to find batch associated with id '%s' or file associated with index '%s'", batchId,
                     fileIndex);
             log.error(message);
-            throw new NuxeoException(message);
+            throw new NuxeoException(message, SC_NOT_FOUND);
         }
         return execute(blob, chainOrOperationId, session, contextParams, operationParams);
     }


### PR DESCRIPTION
… missing associated file