### PR TITLE
Add missing quotes to protect path with spaces

### DIFF
--- a/server/nuxeo-server-tomcat/src/main/resources/tomcat/bin/nuxeoctl.bat
+++ b/server/nuxeo-server-tomcat/src/main/resources/tomcat/bin/nuxeoctl.bat
@@ -175,7 +175,7 @@ echo Could not find java.exe in the path, the environment or the registry
 goto END
 
 :FIND_JAVA_HOME
-%JAVA% -XshowSettings:properties -version 2>&1 | find "java.home" | "%NUXEO_HOME%\bin\repl.bat" "^ *java.home = (.*)" "set JAVA_HOME=$1"  | "%NUXEO_HOME%\bin\repl.bat" "\\jre$" "" > "%NUXEO_HOME%\bin\java-home.bat"
+"%JAVA%" -XshowSettings:properties -version 2>&1 | find "java.home" | "%NUXEO_HOME%\bin\repl.bat" "^ *java.home = (.*)" "set JAVA_HOME=$1"  | "%NUXEO_HOME%\bin\repl.bat" "\\jre$" "" > "%NUXEO_HOME%\bin\java-home.bat"
 call "%NUXEO_HOME%\bin\java-home.bat"
 goto HAS_JAVA_HOME
 


### PR DESCRIPTION
# Trouble fixed 

* I install Nuxeo in C:\Program Files\Nuxeo instead C:\Nuxeo
* In command file, I launch the following command 

`
.\bin\nuxeoctl.bat console
`

The feedback is the NUXEO_CONF path and the server is not starting.
This is because the embedded java is in 3party folder and contains a space (Program Files).