### PR TITLE
NXBT-3523: Upgrade Skaffold in Javadoc build

### DIFF
--- a/ci/Jenkinsfiles/javadoc.groovy
+++ b/ci/Jenkinsfiles/javadoc.groovy
@@ -182,7 +182,10 @@ pipeline {
           Image tag: ${VERSION}"""
           sh "mv target/site/apidocs ci/docker/javadoc/apidocs"
           dir('ci/docker/javadoc') {
-            sh "skaffold build -f skaffold.yaml"
+            sh '''
+              envsubst < skaffold.yaml > skaffold.yaml~gen
+              skaffold build -f skaffold.yaml~gen
+            '''
           }
 
           echo """

--- a/ci/Jenkinsfiles/javadoc.groovy
+++ b/ci/Jenkinsfiles/javadoc.groovy
@@ -42,6 +42,12 @@ void setGitHubBuildStatus(String context, String message, String state) {
   }
 }
 
+String getCurrentNamespace() {
+  container('maven') {
+    return sh(returnStdout: true, script: "kubectl get pod ${NODE_NAME} -ojsonpath='{..namespace}'")
+  }
+}
+
 String getVersion() {
   return "${BRANCH_NAME}-" + readMavenPom().getVersion()
 }
@@ -54,6 +60,7 @@ pipeline {
     timeout(time: 1, unit: 'HOURS')
   }
   environment {
+    CURRENT_NAMESPACE = getCurrentNamespace()
     // force ${HOME}=/root - for an unexplained reason, ${HOME} is resolved as /home/jenkins though sh 'env' shows HOME=/root
     HOME = '/root'
     // set Xmx lower than pod memory limit of 3Gi, to leave some memory for javadoc command

--- a/ci/docker/javadoc/skaffold.yaml
+++ b/ci/docker/javadoc/skaffold.yaml
@@ -11,19 +11,27 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-apiVersion: skaffold/v1beta14
+apiVersion: skaffold/v2beta17
 kind: Config
 build:
   tagPolicy:
     envTemplate:
-      template: "{{.DOCKER_REGISTRY}}/nuxeo/{{.IMAGE_NAME}}:{{.VERSION}}"
+      template: "{{.VERSION}}"
   artifacts:
-    - image: nuxeo-javadoc
+    - image: "$DOCKER_REGISTRY/nuxeo/nuxeo-javadoc"
       context: .
       kaniko:
+        useNewRun: true
+        singleSnapshot: true
+        snapshotMode: "time"
         buildContext:
           localDir: {}
   cluster:
     namespace: platform
     dockerConfig:
       secretName: jenkins-docker-cfg
+    tolerations:
+      - key: team
+        operator: "Equal"
+        value: platform
+        effect: "NoSchedule"

--- a/ci/docker/javadoc/skaffold.yaml
+++ b/ci/docker/javadoc/skaffold.yaml
@@ -27,7 +27,7 @@ build:
         buildContext:
           localDir: {}
   cluster:
-    namespace: platform
+    namespace: $CURRENT_NAMESPACE
     dockerConfig:
       secretName: jenkins-docker-cfg
     tolerations:


### PR DESCRIPTION
Following Skaffold uprade to 1.27.0 on base builder.

Also, improve kaniko build by:
  - Allowing to bind the kaniko pod to the Platform dedicated node pool, using tolerations.
  - Using the kaniko optimization options for filesystem snapshotting (skaffold version upgrade required).