### PR TITLE
NXP-30513: output the error as JSON if client requests 'application/json'

### DIFF
--- a/nuxeo-services/nuxeo-platform-web-common/src/test/java/org/nuxeo/ecm/platform/web/common/exceptionhandling/TestNuxeoExceptionFilter.java
+++ b/nuxeo-services/nuxeo-platform-web-common/src/test/java/org/nuxeo/ecm/platform/web/common/exceptionhandling/TestNuxeoExceptionFilter.java
@@ -169,6 +169,7 @@ public class TestNuxeoExceptionFilter {
 
         verify(request, atLeastOnce()).getAttribute(anyString());
         verify(request, atLeastOnce()).setAttribute(anyString(), any());
+        verify(request, atLeastOnce()).getHeader(anyString());
         verifyNoMoreInteractions(request);
 
         verify(response).isCommitted();


### PR DESCRIPTION
T&P: https://qa2.nuxeo.org/jenkins/job/TestAndPush/job/ondemand-testandpush-troger-10.10/136/