### PR TITLE
NXP-29097: fix operation Repository.Query when parameter 'searchTerm'…

### DIFF
--- a/nuxeo-features/nuxeo-automation/nuxeo-automation-features/src/main/java/org/nuxeo/ecm/automation/core/operations/services/query/DocumentPaginatedQuery.java
+++ b/nuxeo-features/nuxeo-automation/nuxeo-automation-features/src/main/java/org/nuxeo/ecm/automation/core/operations/services/query/DocumentPaginatedQuery.java
@@ -35,6 +35,8 @@ import org.nuxeo.ecm.core.query.sql.NXQL;
 import org.nuxeo.ecm.platform.query.api.PageProvider;
 import org.nuxeo.ecm.platform.query.api.PageProviderDefinition;
 import org.nuxeo.ecm.platform.query.api.PageProviderService;
+import org.nuxeo.runtime.api.Framework;
+import org.nuxeo.runtime.services.config.ConfigurationService;
 
 import java.util.Collections;
 import java.util.Map;
@@ -118,6 +120,15 @@ public class DocumentPaginatedQuery {
 
         Long targetPage = currentPageIndex != null ? currentPageIndex.longValue() : null;
         Long targetPageSize = pageSize != null ? pageSize.longValue() : null;
+
+        // NXP-29097: handle empty "searchTerm" parameters in query (referenced by ? character)
+        // test if the query does not wait for any parameter, then it probably contains the searchTerm set to
+        // "", let's nullify "strParameters" variable
+        if (query.indexOf("?") == -1 && strParameters != null && strParameters.size() == 1) {
+            if (Framework.getService(ConfigurationService.class).isBooleanTrue("org.nuxeo.ignore.empty.searchterm")) {
+                strParameters = null;
+            }
+        }
 
         PageProvider<DocumentModel> pp = (PageProvider<DocumentModel>) PageProviderHelper.getPageProvider(session, def,
                 namedParameters, sortBy, sortOrder, targetPageSize, targetPage,

--- a/nuxeo-features/nuxeo-automation/nuxeo-automation-features/src/main/resources/OSGI-INF/operations-contrib.xml
+++ b/nuxeo-features/nuxeo-automation/nuxeo-automation-features/src/main/resources/OSGI-INF/operations-contrib.xml
@@ -228,4 +228,8 @@
     </chain>
   </extension>
 
+  <extension target="org.nuxeo.runtime.ConfigurationService" point="configuration">
+    <property name="org.nuxeo.ignore.empty.searchterm">true</property>
+  </extension>
+
 </component>

--- a/nuxeo-features/nuxeo-automation/nuxeo-automation-features/src/test/java/org/nuxeo/ecm/automation/core/test/SearchOperationTest.java
+++ b/nuxeo-features/nuxeo-automation/nuxeo-automation-features/src/test/java/org/nuxeo/ecm/automation/core/test/SearchOperationTest.java
@@ -172,6 +172,27 @@ public class SearchOperationTest {
     }
 
     /**
+     * @since 2021.11
+     */
+    @Test
+    public void testQueryWithSearchTerm() throws Exception {
+        OperationContext ctx = new OperationContext(session);
+        Map<String, Object> params = new HashMap<String, Object>();
+
+        // first test, with search term set to an empty string
+        params.put("searchTerm", "");
+        params.put("query", "SELECT * FROM Workspace");
+        DocumentModelList list = (DocumentModelList) service.run(ctx, DocumentPaginatedQuery.ID, params);
+        assertEquals(5, list.size());
+
+        // second test, normal use of the operation with a searchTerm for the NXQL query
+        params.put("searchTerm", "WS2");
+        params.put("query", "SELECT * FROM Workspace WHERE dc:title = ?");
+        list = (DocumentModelList) service.run(ctx, DocumentPaginatedQuery.ID, params);
+        assertEquals(1, list.size());
+    }
+
+    /**
      * @since 8.2
      */
     @Test


### PR DESCRIPTION
… is set to an empty string