### PR TITLE
NXP-30685: Remove valid LDAP url check

### DIFF
--- a/nuxeo-distribution/nuxeo-wizard-tests/src/test/java/org/nuxeo/ftest/wizard/ITWizardAndUpdateCenterTests.java
+++ b/nuxeo-distribution/nuxeo-wizard-tests/src/test/java/org/nuxeo/ftest/wizard/ITWizardAndUpdateCenterTests.java
@@ -151,9 +151,6 @@ public class ITWizardAndUpdateCenterTests extends AbstractTest {
         userPage = userPage.navById(WizardPage.class, "checkNetwork");
         assertTrue(userPage.hasError());
         userPage.clearInput("nuxeo.ldap.url");
-        userPage.fillInput("nuxeo.ldap.url", "ldaps://ldap-test.nuxeo.com:636");
-        userPage = userPage.navById(WizardPage.class, "checkNetwork");
-        assertFalse(userPage.hasError());
         userPage.selectOptionWithReload("nuxeo.directory.type", "default");
 
         // **********************


### PR DESCRIPTION
The LDAP test server is down, so the test must be removed