### PR TITLE
NXP-30686: Fix removing of relations via operations

### DIFF
--- a/nuxeo-features/nuxeo-automation/nuxeo-automation-features/src/main/java/org/nuxeo/ecm/automation/core/operations/services/CreateRelation.java
+++ b/nuxeo-features/nuxeo-automation/nuxeo-automation-features/src/main/java/org/nuxeo/ecm/automation/core/operations/services/CreateRelation.java
@@ -54,7 +54,9 @@ public class CreateRelation {
 
     @OperationMethod(collector = DocumentModelCollector.class)
     public DocumentModel run(DocumentModel doc) {
-        relations.addRelation(session, doc, object, predicate, outgoing);
+        // `outgoing` parameter indicates inverse relationship, which is
+        // the opposite of the outgoing value.
+        relations.addRelation(session, doc, object, predicate, !outgoing);
         return doc;
     }
 }

--- a/nuxeo-features/nuxeo-automation/nuxeo-automation-features/src/main/java/org/nuxeo/ecm/automation/core/operations/services/DeleteRelation.java
+++ b/nuxeo-features/nuxeo-automation/nuxeo-automation-features/src/main/java/org/nuxeo/ecm/automation/core/operations/services/DeleteRelation.java
@@ -53,7 +53,9 @@ public class DeleteRelation {
 
     @OperationMethod(collector = DocumentModelCollector.class)
     public DocumentModel run(DocumentModel doc) {
-        relations.deleteRelation(session, doc, object, predicate, outgoing);
+        DocumentModel from = outgoing ? doc : object;
+        DocumentModel to = outgoing ? object : doc;
+        relations.deleteRelation(session, from, to, predicate, true);
         return doc;
     }
 }

--- a/nuxeo-features/nuxeo-automation/nuxeo-automation-features/src/test/java/org/nuxeo/ecm/automation/core/test/RelationOperationsTest.java
+++ b/nuxeo-features/nuxeo-automation/nuxeo-automation-features/src/test/java/org/nuxeo/ecm/automation/core/test/RelationOperationsTest.java
@@ -19,6 +19,7 @@
 package org.nuxeo.ecm.automation.core.test;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 import javax.inject.Inject;
 
@@ -90,44 +91,168 @@ public class RelationOperationsTest {
     // ------ Tests comes here --------
 
     @Test
-    public void testRelationOperations() throws Exception {
+    public void testRelationOutboundOperation() throws Exception {
         OperationContext ctx = new OperationContext(session);
         ctx.setInput(src);
         OperationChain chain = new OperationChain("createRelation");
         chain.add(FetchContextDocument.ID);
-        chain.add(CreateRelation.ID).set("predicate", conformsTo).set("object", dst.getId());
+        chain.add(CreateRelation.ID).set("predicate", conformsTo).set("object", dst.getId()).set("outgoing", true);
         DocumentModel doc = (DocumentModel) service.run(ctx, chain);
 
         assertEquals(doc, src);
 
-        ctx = new OperationContext(session);
+        ctx.clear();
         ctx.setInput(src);
         chain = new OperationChain("getRelation");
         chain.add(FetchContextDocument.ID);
-        chain.add(GetRelations.ID).set("predicate", conformsTo);
+        chain.add(GetRelations.ID).set("predicate", conformsTo).set("outgoing", true);
         DocumentModelList docs = (DocumentModelList) service.run(ctx, chain);
 
         assertEquals(1, docs.size());
         assertEquals(dst, docs.get(0));
 
-        ctx = new OperationContext(session);
+        ctx.clear();
         ctx.setInput(src);
         chain = new OperationChain("getRelationWithGraphName");
         chain.add(FetchContextDocument.ID);
-        chain.add(GetRelations.ID).set("predicate", conformsTo).set("graphName", null);
+        chain.add(GetRelations.ID).set("predicate", conformsTo).set("graphName", null).set("outgoing", true);
         DocumentModelList docs2 = (DocumentModelList) service.run(ctx, chain);
 
         assertEquals(docs, docs2);
 
-        ctx = new OperationContext(session);
+        ctx.clear();
         ctx.setInput(src);
         chain = new OperationChain("deleteRelation");
         chain.add(FetchContextDocument.ID);
-        chain.add(DeleteRelation.ID).set("predicate", conformsTo).set("object", dst.getId());
+        chain.add(DeleteRelation.ID).set("predicate", conformsTo).set("object", dst.getId()).set("outgoing", true);
         DocumentModel doc2 = (DocumentModel) service.run(ctx, chain);
 
         assertEquals(doc2, src);
 
+        ctx.clear();
+        ctx.setInput(src);
+        chain = new OperationChain("getRelation");
+        chain.add(FetchContextDocument.ID);
+        chain.add(GetRelations.ID).set("predicate", conformsTo);
+        DocumentModelList docs3 = (DocumentModelList) service.run(ctx, chain);
+
+        assertTrue(docs3.isEmpty());
     }
 
+    @Test
+    public void testRelationIncomingOperation() throws Exception {
+        OperationContext ctx = new OperationContext(session);
+        ctx.setInput(src);
+        OperationChain chain = new OperationChain("createRelation");
+        chain.add(FetchContextDocument.ID);
+        chain.add(CreateRelation.ID).set("predicate", conformsTo).set("object", dst.getId()).set("outgoing", false);
+        DocumentModel doc = (DocumentModel) service.run(ctx, chain);
+
+        assertEquals(doc, src);
+
+        ctx.clear();
+        ctx.setInput(src);
+        chain = new OperationChain("getRelation");
+        chain.add(FetchContextDocument.ID);
+        chain.add(GetRelations.ID).set("predicate", conformsTo).set("outgoing", false);
+        DocumentModelList docs = (DocumentModelList) service.run(ctx, chain);
+
+        assertEquals(1, docs.size());
+        assertEquals(dst, docs.get(0));
+
+        ctx.clear();
+        ctx.setInput(src);
+        chain = new OperationChain("getRelationWithGraphName");
+        chain.add(FetchContextDocument.ID);
+        chain.add(GetRelations.ID).set("predicate", conformsTo).set("graphName", null).set("outgoing", false);
+        DocumentModelList docs2 = (DocumentModelList) service.run(ctx, chain);
+
+        assertEquals(docs, docs2);
+
+        ctx.clear();
+        ctx.setInput(src);
+        chain = new OperationChain("deleteRelation");
+        chain.add(FetchContextDocument.ID);
+        chain.add(DeleteRelation.ID).set("predicate", conformsTo).set("object", dst.getId()).set("outgoing", false);
+        DocumentModel doc2 = (DocumentModel) service.run(ctx, chain);
+
+        assertEquals(doc2, src);
+
+        ctx.clear();
+        ctx.setInput(src);
+        chain = new OperationChain("getRelation");
+        chain.add(FetchContextDocument.ID);
+        chain.add(GetRelations.ID).set("predicate", conformsTo);
+        DocumentModelList docs3 = (DocumentModelList) service.run(ctx, chain);
+
+        assertTrue(docs3.isEmpty());
+    }
+
+    @Test
+    public void testRelationMismatchOperation() throws Exception {
+        OperationContext ctx = new OperationContext(session);
+        ctx.setInput(src);
+        OperationChain chain = new OperationChain("createRelation");
+        chain.add(FetchContextDocument.ID);
+        chain.add(CreateRelation.ID).set("predicate", conformsTo).set("object", dst.getId()).set("outgoing", true);
+        DocumentModel doc = (DocumentModel) service.run(ctx, chain);
+
+        assertEquals(doc, src);
+
+        ctx.clear();
+        ctx.setInput(src);
+        chain = new OperationChain("getRelation");
+        chain.add(FetchContextDocument.ID);
+        chain.add(GetRelations.ID).set("predicate", conformsTo).set("outgoing", true);
+        DocumentModelList docs = (DocumentModelList) service.run(ctx, chain);
+
+        assertEquals(1, docs.size());
+        assertEquals(dst, docs.get(0));
+
+        ctx.clear();
+        ctx.setInput(src);
+        chain = new OperationChain("getRelationWithGraphName");
+        chain.add(FetchContextDocument.ID);
+        chain.add(GetRelations.ID).set("predicate", conformsTo).set("graphName", null).set("outgoing", true);
+        DocumentModelList docs2 = (DocumentModelList) service.run(ctx, chain);
+
+        assertEquals(docs, docs2);
+
+        ctx.clear();
+        ctx.setInput(src);
+        chain = new OperationChain("deleteRelation");
+        chain.add(FetchContextDocument.ID);
+        chain.add(DeleteRelation.ID).set("predicate", conformsTo).set("object", dst.getId()).set("outgoing", false);
+        DocumentModel doc2 = (DocumentModel) service.run(ctx, chain);
+
+        assertEquals(doc2, src);
+
+        ctx.clear();
+        ctx.setInput(src);
+        chain = new OperationChain("getRelation");
+        chain.add(FetchContextDocument.ID);
+        chain.add(GetRelations.ID).set("predicate", conformsTo).set("outgoing", true);
+        DocumentModelList docs3 = (DocumentModelList) service.run(ctx, chain);
+
+        assertEquals(1, docs3.size());
+        assertEquals(dst, docs3.get(0));
+
+        ctx.clear();
+        ctx.setInput(src);
+        chain = new OperationChain("deleteRelation");
+        chain.add(FetchContextDocument.ID);
+        chain.add(DeleteRelation.ID).set("predicate", conformsTo).set("object", dst.getId()).set("outgoing", true);
+        DocumentModel doc3 = (DocumentModel) service.run(ctx, chain);
+
+        assertEquals(doc3, src);
+
+        ctx.clear();
+        ctx.setInput(src);
+        chain = new OperationChain("getRelation");
+        chain.add(FetchContextDocument.ID);
+        chain.add(GetRelations.ID).set("predicate", conformsTo).set("outgoing", true);
+        DocumentModelList docs4 = (DocumentModelList) service.run(ctx, chain);
+
+        assertTrue(docs4.isEmpty());
+    }
 }


### PR DESCRIPTION
relations.deleteRelation signature does not handle forward or inverse relationships.  Fix is to properly set the subject and object based upon the outgoing parameter.  `outgoing` within the deleteRelation function call is replaced with `true` to propagate the events `BEFORE_RELATION_REMOVAL` and `AFTER_RELATION_REMOVAL`.

* Fix adding relation and add unit test

Problem discovered with the `AddRelation` operation that inverted the meaning of the outgoing field.  This commit fixes the inverse parameter, which needs to negate the outgoing parameter.  Also, added functional unit tests that demonstrate the correct handling of relationships.  Previous unit test did not properly test for valid graph structures.

* Document.DeleteRelation not removing relation

relations.deleteRelation signature does not handle forward or inverse relationships.  Fix is to properly set the subject and object based upon the outgoing parameter.  `outgoing` within the deleteRelation function call is replaced with `true` to propagate the events `BEFORE_RELATION_REMOVAL` and `AFTER_RELATION_REMOVAL`.