### PR TITLE
NXP-30637: make MailMessageBlobHolder depends on MailMessage facet

### DIFF
--- a/nuxeo-features/nuxeo-platform-mail/nuxeo-platform-mail-core/src/main/java/org/nuxeo/ecm/platform/mail/adapter/MailMessageBlobHolderfactory.java
+++ b/nuxeo-features/nuxeo-platform-mail/nuxeo-platform-mail-core/src/main/java/org/nuxeo/ecm/platform/mail/adapter/MailMessageBlobHolderfactory.java
@@ -34,10 +34,9 @@ public class MailMessageBlobHolderfactory implements BlobHolderFactory {
 
     @Override
     public BlobHolder getBlobHolder(DocumentModel doc) {
-        String docType = doc.getType();
         BlobHolder blobHolder;
 
-        if (docType.equals(MailCoreConstants.MAIL_MESSAGE_TYPE)) {
+        if (doc.getFacets().contains(MailCoreConstants.MAIL_MESSAGE_FACET)) {
             blobHolder = new MailMessageBlobHolder(doc, MailCoreConstants.HTML_TEXT_PROPERTY_NAME, "body.html");
         } else {
             blobHolder = null;

--- a/nuxeo-features/nuxeo-platform-mail/nuxeo-platform-mail-core/src/main/java/org/nuxeo/ecm/platform/mail/utils/MailCoreConstants.java
+++ b/nuxeo-features/nuxeo-platform-mail/nuxeo-platform-mail-core/src/main/java/org/nuxeo/ecm/platform/mail/utils/MailCoreConstants.java
@@ -30,6 +30,11 @@ public final class MailCoreConstants {
 
     public static final String MAIL_MESSAGE_TYPE = "MailMessage";
 
+    /**
+     * @since 10.10-HF55
+     */
+    public static final String MAIL_MESSAGE_FACET = "MailMessage";
+
     public static final String MAIL_FOLDER_TYPE = "MailFolder";
 
     public static final String SENDER_PROPERTY_NAME = "mail:sender";

--- a/nuxeo-features/nuxeo-platform-mail/nuxeo-platform-mail-core/src/main/resources/OSGI-INF/nxmail-blobholder-contrib.xml
+++ b/nuxeo-features/nuxeo-platform-mail/nuxeo-platform-mail-core/src/main/resources/OSGI-INF/nxmail-blobholder-contrib.xml
@@ -4,7 +4,7 @@
   <extension
     target="org.nuxeo.ecm.core.api.blobholder.BlobHolderAdapterComponent"
     point="BlobHolderFactory">
-    <blobHolderFactory name="mailMessage" docType="MailMessage"
+    <blobHolderFactory name="mailMessage" facet="MailMessage"
       class="org.nuxeo.ecm.platform.mail.adapter.MailMessageBlobHolderfactory" />
   </extension>
 

--- a/nuxeo-features/nuxeo-platform-mail/nuxeo-platform-mail-core/src/test/java/org/nuxeo/ecm/platform/mail/adapter/TestMailMessageFactory.java
+++ b/nuxeo-features/nuxeo-platform-mail/nuxeo-platform-mail-core/src/test/java/org/nuxeo/ecm/platform/mail/adapter/TestMailMessageFactory.java
@@ -1,0 +1,64 @@
+/*
+ * (C) Copyright 2021 Nuxeo (http://nuxeo.com/) and others.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Contributors:
+ *     Thierry Martins
+ */
+package org.nuxeo.ecm.platform.mail.adapter;
+
+import static org.junit.Assert.assertTrue;
+
+import javax.inject.Inject;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.nuxeo.ecm.core.api.CoreSession;
+import org.nuxeo.ecm.core.api.DocumentModel;
+import org.nuxeo.ecm.core.api.blobholder.BlobHolder;
+import org.nuxeo.ecm.core.test.CoreFeature;
+import org.nuxeo.ecm.platform.mail.utils.MailCoreConstants;
+import org.nuxeo.runtime.test.runner.Deploy;
+import org.nuxeo.runtime.test.runner.Features;
+import org.nuxeo.runtime.test.runner.FeaturesRunner;
+
+/**
+ * 
+ * @since 10.10-HF55
+ */
+@RunWith(FeaturesRunner.class)
+@Features(CoreFeature.class)
+@Deploy("org.nuxeo.ecm.platform.mail.types")
+@Deploy("org.nuxeo.ecm.platform.mail:OSGI-INF/nxmail-blobholder-contrib.xml")
+@Deploy("org.nuxeo.ecm.platform.mail.test:OSGI-INF/nxmail-core-contrib.xml")
+public class TestMailMessageFactory {
+
+    private static final String CUSTOM_MAIL_MESSAGE_TYPE = "CustomMailMessage";
+
+    @Inject
+    protected CoreSession session;
+
+    @Test
+    public void testMailMessageBlobHolderFactory() {
+        DocumentModel mailMessage = session.createDocumentModel(MailCoreConstants.MAIL_MESSAGE_TYPE);
+        BlobHolder adapter = mailMessage.getAdapter(BlobHolder.class);
+        assertTrue(adapter instanceof MailMessageBlobHolder);
+
+        DocumentModel customMailMessage = session.createDocumentModel(CUSTOM_MAIL_MESSAGE_TYPE);
+        assertTrue(customMailMessage.getFacets().contains(MailCoreConstants.MAIL_MESSAGE_FACET));
+        adapter = customMailMessage.getAdapter(BlobHolder.class);
+        assertTrue(adapter instanceof MailMessageBlobHolder);
+    }
+
+}

--- a/nuxeo-features/nuxeo-platform-mail/nuxeo-platform-mail-core/src/test/resources/OSGI-INF/nxmail-core-contrib.xml
+++ b/nuxeo-features/nuxeo-platform-mail/nuxeo-platform-mail-core/src/test/resources/OSGI-INF/nxmail-core-contrib.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0"?>
+<component
+  name="org.nuxeo.ecm.platform.mail.core.types.contrib.test">
+
+  <require>org.nuxeo.ecm.platform.mail.core.types.contrib</require>
+
+  <extension target="org.nuxeo.ecm.core.schema.TypeService"
+    point="doctype">
+
+    <doctype name="CustomMailMessage" extends="MailMessage" />
+  </extension>
+</component>

--- a/nuxeo-features/nuxeo-platform-mail/nuxeo-platform-mail-types/src/main/resources/OSGI-INF/nxmail-core-types-contrib.xml
+++ b/nuxeo-features/nuxeo-platform-mail/nuxeo-platform-mail-types/src/main/resources/OSGI-INF/nxmail-core-types-contrib.xml
@@ -12,6 +12,8 @@
 
   <extension target="org.nuxeo.ecm.core.schema.TypeService" point="doctype">
 
+    <facet name="MailMessage" />
+
     <doctype name="MailMessage" extends="Document">
       <schema name="mail"/>
       <schema name="common"/>
@@ -21,6 +23,7 @@
       <facet name="Commentable" />
       <facet name="HiddenInCreation" />
       <facet name="NXTag" />
+      <facet name="MailMessage" />
     </doctype>
 
     <doctype name="MailFolder" extends="Folder">


### PR DESCRIPTION
instead of MailMessage document type