### PR TITLE
NXP-30878: add a parameter to set max_expansions

### DIFF
--- a/nuxeo-features/nuxeo-elasticsearch/nuxeo-elasticsearch-core/src/main/java/org/nuxeo/elasticsearch/query/NxqlQueryConverter.java
+++ b/nuxeo-features/nuxeo-elasticsearch/nuxeo-elasticsearch-core/src/main/java/org/nuxeo/elasticsearch/query/NxqlQueryConverter.java
@@ -37,6 +37,7 @@ import org.apache.commons.lang3.ArrayUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.apache.lucene.search.FuzzyQuery;
 import org.elasticsearch.index.query.BoolQueryBuilder;
 import org.elasticsearch.index.query.MatchPhrasePrefixQueryBuilder;
 import org.elasticsearch.index.query.MoreLikeThisQueryBuilder;
@@ -82,6 +83,7 @@ import org.nuxeo.ecm.core.storage.sql.jdbc.NXQLQueryMaker;
 import org.nuxeo.elasticsearch.api.ElasticSearchAdmin;
 import org.nuxeo.elasticsearch.hint.MoreLikeThisESHintQueryBuilder;
 import org.nuxeo.runtime.api.Framework;
+import org.nuxeo.runtime.services.config.ConfigurationService;
 
 /**
  * Helper class that holds the conversion logic. Conversion is based on the existing NXQL Parser, we are just using a
@@ -486,6 +488,8 @@ public final class NxqlQueryConverter {
                 && !wildcard.contains("\\")) {
             MatchPhrasePrefixQueryBuilder query = QueryBuilders.matchPhrasePrefixQuery(fieldName,
                     wildcard.replace("*", ""));
+            ConfigurationService cs = Framework.getService(ConfigurationService.class);
+            query.maxExpansions(cs.getInteger("elasticsearch.max_expansions", FuzzyQuery.defaultMaxExpansions));
             if (hint != null && hint.analyzer != null) {
                 query.analyzer(hint.analyzer);
             }

--- a/nuxeo-features/nuxeo-elasticsearch/nuxeo-elasticsearch-core/src/test/java/org/nuxeo/elasticsearch/test/nxql/TestNxqlConversion.java
+++ b/nuxeo-features/nuxeo-elasticsearch/nuxeo-elasticsearch-core/src/test/java/org/nuxeo/elasticsearch/test/nxql/TestNxqlConversion.java
@@ -2017,6 +2017,22 @@ public class TestNxqlConversion {
     }
 
     @Test
+    @Deploy("org.nuxeo.elasticsearch.core.test:max-expansions-contrib.xml")
+    public void testMatchPhrasePrefixWithCustomMaxExpansions() {
+        String es = NxqlQueryConverter.toESQueryBuilder("select * from Document where f1 LIKE 'foo%'").toString();
+        assertEqualsEvenUnderWindows("{\n" +
+                "  \"match_phrase_prefix\" : {\n" +
+                "    \"f1\" : {\n" +
+                "      \"query\" : \"foo\",\n" +
+                "      \"slop\" : 0,\n" +
+                "      \"max_expansions\" : 200,\n" +
+                "      \"boost\" : 1.0\n" +
+                "    }\n" +
+                "  }\n" +
+                "}", es);
+    }
+
+    @Test
     public void shouldFailWhenESHintOperatorIsUnknown() {
         try {
             String es = NxqlQueryConverter.toESQueryBuilder(

--- a/nuxeo-features/nuxeo-elasticsearch/nuxeo-elasticsearch-core/src/test/resources/max-expansions-contrib.xml
+++ b/nuxeo-features/nuxeo-elasticsearch/nuxeo-elasticsearch-core/src/test/resources/max-expansions-contrib.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0"?>
+<component name="org.nuxeo.elasticsearch.test.max.expansions">
+    <extension target="org.nuxeo.runtime.ConfigurationService" point="configuration">
+        <property name="elasticsearch.max_expansions">200</property>
+    </extension>
+</component>


### PR DESCRIPTION
It will be used only on ES match_phrase_prefix queries