### PR TITLE
NXP-31082: Bulk status comp handles unknown command

### DIFF
--- a/nuxeo-core/nuxeo-core-bulk/src/main/java/org/nuxeo/ecm/core/bulk/computation/BulkStatusComputation.java
+++ b/nuxeo-core/nuxeo-core-bulk/src/main/java/org/nuxeo/ecm/core/bulk/computation/BulkStatusComputation.java
@@ -69,10 +69,10 @@ public class BulkStatusComputation extends AbstractComputation {
         } else {
             status = bulkService.getStatus(recordStatus.getId());
             if (UNKNOWN.equals(status.getState())) {
-                // this requires a manual intervention, the kv store might have been lost
-                throw new IllegalStateException(
-                        String.format("Status with unknown command: %s, offset: %s, record: %s.", recordStatus.getId(),
-                                context.getLastOffset(), record));
+                log.warn("Skipping status with unknown command: {}, offset: {}.", recordStatus.getId(),
+                        context.getLastOffset());
+                context.askForCheckpoint();
+                return;
             }
             status.merge(recordStatus);
         }


### PR DESCRIPTION
Status record that refers to an unknown bulk command is possible
on edge cases and should not lead to a systematic failure.