### PR TITLE
[Java 17]: Swap Nashorn for GraalVM

### DIFF
--- a/modules/platform/nuxeo-automation/nuxeo-automation-scripting/pom.xml
+++ b/modules/platform/nuxeo-automation/nuxeo-automation-scripting/pom.xml
@@ -71,6 +71,18 @@
       <artifactId>nuxeo-platform-web-common</artifactId>
     </dependency>
 
+    <!-- GraalVM Runtime -->
+    <dependency>
+      <groupId>org.graalvm.js</groupId>
+      <artifactId>js</artifactId>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.graalvm.js</groupId>
+      <artifactId>js-scriptengine</artifactId>
+      <scope>runtime</scope>
+    </dependency>
+
     <!-- Tests -->
     <dependency>
       <groupId>org.nuxeo.ecm.platform</groupId>

--- a/modules/platform/nuxeo-automation/nuxeo-automation-scripting/src/main/java/org/nuxeo/automation/scripting/api/AutomationScriptingConstants.java
+++ b/modules/platform/nuxeo-automation/nuxeo-automation-scripting/src/main/java/org/nuxeo/automation/scripting/api/AutomationScriptingConstants.java
@@ -49,6 +49,6 @@ public class AutomationScriptingConstants {
 
     public static final String NASHORN_WARN_CACHE = "Nashorn cache is not available. jdk8u25 is required to optimize Automation Javascript performances.";
 
-    public static final String NASHORN_WARN_VERSION = "Cannot use Nashorn. jdk8 is required to activate Automation Javascript.";
+    public static final String NASHORN_WARN_ENGINE = "Cannot use Nashorn. jdk8-jdk15 is required to activate Automation Javascript, or GraalVM must be installed.";
 
 }

--- a/pom.xml
+++ b/pom.xml
@@ -162,6 +162,9 @@
     <metrics.version>5.0.0-rc3</metrics.version>
     <maven.surefire.version>2.22.2</maven.surefire.version>
     <opencensus.version>0.27.1</opencensus.version>
+
+    <!-- GraalVM -->
+    <graalvm.version>22.1.0.1</graalvm.version>
   </properties>
 
   <dependencyManagement>
@@ -4847,6 +4850,18 @@
         <groupId>com.datadoghq</groupId>
         <artifactId>dd-trace-api</artifactId>
         <version>0.93.0</version>
+      </dependency>
+
+      <!-- GraalVM -->
+      <dependency>
+        <groupId>org.graalvm.js</groupId>
+        <artifactId>js</artifactId>
+        <version>${graalvm.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.graalvm.js</groupId>
+        <artifactId>js-scriptengine</artifactId>
+        <version>${graalvm.version}</version>
       </dependency>
 
     </dependencies>


### PR DESCRIPTION
Hey there esteemed Nuxeo authors,

I would like to respectfully propose a pathway to Java 17 support. We have an internal set of patches to this effect which we can offer. Consequently we are sharing them here, with this being the first patch, as a starting point for feedback. Since Nashorn is dropped entirely in JDK15+, a swap to GraalVM makes sense, but if this change is not appropriate for merging up to main Nuxeo please just let us know 😁

With feedback, it should be possible to keep this change backwards-compatible with JDKs down to 11, perhaps 8.

---

This changeset drops Nashorn-specific classes which are no longer available in JDK15+ in accordance with [JEP372][1], and replaces them with [JSR223][2]-compatible calls.

These calls work with [GraalVM][3] to support a seamless switch to Graal JS when running on that platform. For other JDK17 runtimes, Graal JS dependencies can be included directly to run on a stock stock [JVM][4].

Changes enclosed:
- Drop references to Nashorn classes, replace with JSR223 calls
- Configure GraalJS with predicate-based class filter
- Fixup references to script mirrors as maps
- Compatibility with pre-JDK17 via Maven deps

[1]: https://openjdk.org/jeps/372
[2]: https://jcp.org/en/jsr/detail?id=223
[3]: https://www.graalvm.org/22.1/reference-manual/js/NashornMigrationGuide/
[4]: https://www.graalvm.org/22.1/reference-manual/js/RunOnJDK/