### PR TITLE
 NXP-31163: Avoid tx timeout when checking mails

### DIFF
--- a/nuxeo-features/nuxeo-platform-mail/nuxeo-platform-mail-core/src/main/java/org/nuxeo/ecm/platform/mail/listener/MailEventListener.java
+++ b/nuxeo-features/nuxeo-platform-mail/nuxeo-platform-mail-core/src/main/java/org/nuxeo/ecm/platform/mail/listener/MailEventListener.java
@@ -37,6 +37,7 @@ import org.nuxeo.ecm.core.api.DocumentModelList;
 import org.nuxeo.ecm.core.event.Event;
 import org.nuxeo.ecm.core.event.EventListener;
 import org.nuxeo.ecm.platform.mail.utils.MailCoreHelper;
+import org.nuxeo.runtime.transaction.TransactionHelper;
 
 /**
  * Listener that listens for MailReceivedEvent.
@@ -95,6 +96,8 @@ public class MailEventListener implements EventListener {
                     log.warn("Error connecting to email account", e);
                     continue;
                 }
+                TransactionHelper.commitOrRollbackTransaction();
+                TransactionHelper.startTransaction();
             }
         } catch (MessagingException e) {
             log.error("MailEventListener error...", e);


### PR DESCRIPTION
Add a configurable limit for the total number of mail to check,
commit the transaction after each mailbox.