### PR TITLE
[Security]: Bump `commons-text` -> `1.10.1` (2021)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2213,7 +2213,7 @@
       <dependency>
         <groupId>org.apache.commons</groupId>
         <artifactId>commons-text</artifactId>
-        <version>1.9</version>
+        <version>1.10.0</version>
       </dependency>
       <!-- Keep the dependency for external libraries -->
       <dependency>


### PR DESCRIPTION
This changeset upgrades `commons-text` to the latest version to address an emerging vulnerability (CVE-2022-42889[1]). 10.10 backport available in #5178.

[1]: https://nvd.nist.gov/vuln/detail/CVE-2022-42889