### PR TITLE
[Security]: Bump `commons-text` -> `1.10.1` (10.10)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2056,7 +2056,7 @@
       <dependency>
         <groupId>org.apache.commons</groupId>
         <artifactId>commons-text</artifactId>
-        <version>1.4</version>
+        <version>1.10.0</version>
       </dependency>
       <!-- Keep the dependency for external libraries -->
       <dependency>


### PR DESCRIPTION
This changeset upgrades `commons-text` to the latest version to address an emerging vulnerability (CVE-2022-42889[1]).

Backports change from nuxeo/nuxeo#5177.

[1]: https://nvd.nist.gov/vuln/detail/CVE-2022-42889