### PR TITLE
NXP-31318: makeBlob is now resilient to unfinished blob

### DIFF
--- a/nuxeo-core/nuxeo-core-bulk/src/test/java/org/nuxeo/ecm/core/bulk/action/TestMakeBlob.java
+++ b/nuxeo-core/nuxeo-core-bulk/src/test/java/org/nuxeo/ecm/core/bulk/action/TestMakeBlob.java
@@ -66,7 +66,7 @@ public class TestMakeBlob {
         Record record2 = createRecord(command, "cdef", 4);
 
         // init the computation
-        MakeBlob comp = new MakeBlob();
+        MakeBlob comp = new MakeBlob(false);
         ComputationContextImpl context = new ComputationContextImpl(
                 new ComputationMetadataMapping(comp.metadata(), Collections.emptyMap()));
         comp.init(context);
@@ -128,7 +128,7 @@ public class TestMakeBlob {
         Record c2r4 = createRecord(command2, "qr", 2);
 
         // init the computation
-        MakeBlob comp = new MakeBlob();
+        MakeBlob comp = new MakeBlob(false);
         ComputationContextImpl context = new ComputationContextImpl(
                 new ComputationMetadataMapping(comp.metadata(), Collections.emptyMap()));
         comp.init(context);

--- a/nuxeo-features/nuxeo-platform-csv-export/src/main/java/org/nuxeo/ecm/platform/csv/export/action/CSVExportAction.java
+++ b/nuxeo-features/nuxeo-platform-csv-export/src/main/java/org/nuxeo/ecm/platform/csv/export/action/CSVExportAction.java
@@ -45,7 +45,7 @@ public class CSVExportAction implements StreamProcessorTopology {
 
     @Override
     public Topology getTopology(Map<String, String> options) {
-        boolean produceImmediate = getOptionAsBoolean(options, PRODUCE_IMMEDIATE_OPTION, false);
+        boolean produceImmediate = getOptionAsBoolean(options, PRODUCE_IMMEDIATE_OPTION, true);
         return Topology.builder()
                        .addComputation(CSVProjectionComputation::new, //
                                Arrays.asList(INPUT_1 + ":" + ACTION_NAME, //

--- a/nuxeo-features/nuxeo-platform-csv-export/src/main/resources/OSGI-INF/csv-export-config.xml
+++ b/nuxeo-features/nuxeo-platform-csv-export/src/main/resources/OSGI-INF/csv-export-config.xml
@@ -23,7 +23,7 @@
           <option name="thresholdSize">990000</option>
         </filter>
       </stream>
-      <option name="produceImmediate">false</option>
+      <option name="produceImmediate">true</option>
     </streamProcessor>
   </extension>
 


### PR DESCRIPTION
Produces downstream records immediatly by default, flush unfinished blob after 15min of inactivity.