### PR TITLE
 NXP-31550: Fix recomputeViews on deleted document

### DIFF
--- a/nuxeo-features/nuxeo-platform-imaging/nuxeo-platform-imaging-core/src/main/java/org/nuxeo/ecm/platform/picture/PictureViewsHelper.java
+++ b/nuxeo-features/nuxeo-platform-imaging/nuxeo-platform-imaging-core/src/main/java/org/nuxeo/ecm/platform/picture/PictureViewsHelper.java
@@ -58,7 +58,7 @@ public class PictureViewsHelper {
 
     public static final int DEFAULT_TX_TIMEOUT_SECONDS = 300;
 
-    protected static final String NOTHING_TO_PROCESS_MESSAGE = "Nothing to process";
+    public static final String NOTHING_TO_PROCESS_MESSAGE = "Nothing to process";
 
     protected Integer transactionTimeout;
 

--- a/nuxeo-features/nuxeo-platform-imaging/nuxeo-platform-imaging-core/src/main/java/org/nuxeo/ecm/platform/picture/recompute/RecomputeViewsAction.java
+++ b/nuxeo-features/nuxeo-platform-imaging/nuxeo-platform-imaging-core/src/main/java/org/nuxeo/ecm/platform/picture/recompute/RecomputeViewsAction.java
@@ -19,6 +19,7 @@
  */
 package org.nuxeo.ecm.platform.picture.recompute;
 
+import static org.nuxeo.ecm.platform.picture.PictureViewsHelper.NOTHING_TO_PROCESS_MESSAGE;
 import static org.nuxeo.lib.stream.computation.AbstractComputation.INPUT_1;
 import static org.nuxeo.lib.stream.computation.AbstractComputation.OUTPUT_1;
 
@@ -30,6 +31,7 @@ import java.util.Map;
 import org.nuxeo.ecm.core.api.CoreSession;
 import org.nuxeo.ecm.core.api.DocumentModel;
 import org.nuxeo.ecm.core.api.IdRef;
+import org.nuxeo.ecm.core.api.impl.DownloadBlobGuard;
 import org.nuxeo.ecm.core.bulk.BulkServiceImpl;
 import org.nuxeo.ecm.core.bulk.action.computation.AbstractBulkComputation;
 import org.nuxeo.ecm.core.bulk.message.BulkCommand;
@@ -71,6 +73,8 @@ public class RecomputeViewsAction implements StreamProcessorTopology {
 
         protected String xpath;
 
+        protected String lastPictureViewsStatus;
+
         public RecomputeViewsComputation() {
             super(ACTION_NAME);
         }
@@ -86,10 +90,21 @@ public class RecomputeViewsAction implements StreamProcessorTopology {
 
             for (String docId : ids) {
                 pictureViewsHelper.newTransaction();
-                pictureViewsHelper.computePictureViews(session, docId, xpath, s -> {
-                });
-                fireEvent(session, session.getDocument(new IdRef(docId)), PICTURE_VIEWS_GENERATION_DONE_EVENT);
+                pictureViewsHelper.computePictureViews(session, docId, xpath, this::setLastPictureViewsStatus);
+                if (!NOTHING_TO_PROCESS_MESSAGE.equals(getLastPictureViewsStatus())) {
+                    fireEvent(session, session.getDocument(new IdRef(docId)), PICTURE_VIEWS_GENERATION_DONE_EVENT);
+                }
+                // Avoid triggering fulltext extractor on the generated views
+                DownloadBlobGuard.enable();
             }
+        }
+
+        protected void setLastPictureViewsStatus(String status) {
+            lastPictureViewsStatus = status;
+        }
+
+        protected String getLastPictureViewsStatus() {
+            return lastPictureViewsStatus;
         }
 
         /**


### PR DESCRIPTION
Also, fix the fulltext extractor guard to work on all docs