### PR TITLE
SUPNXP-51287: Add a group mail support for errors when importing CSV

### DIFF
--- a/modules/platform/nuxeo-csv-core/src/main/java/org/nuxeo/ecm/csv/core/CSVImporterWork.java
+++ b/modules/platform/nuxeo-csv-core/src/main/java/org/nuxeo/ecm/csv/core/CSVImporterWork.java
@@ -70,6 +70,7 @@ import org.nuxeo.ecm.core.api.DocumentModel;
 import org.nuxeo.ecm.core.api.DocumentRef;
 import org.nuxeo.ecm.core.api.NuxeoException;
 import org.nuxeo.ecm.core.api.NuxeoPrincipal;
+import org.nuxeo.ecm.core.api.NuxeoGroup;
 import org.nuxeo.ecm.core.api.PathRef;
 import org.nuxeo.ecm.core.query.sql.NXQL;
 import org.nuxeo.ecm.core.schema.DocumentType;
@@ -107,6 +108,8 @@ import org.nuxeo.runtime.api.Framework;
 public class CSVImporterWork extends TransientStoreWork {
 
     public static final String NUXEO_CSV_MAIL_TO = "nuxeo.csv.mail.to";
+
+    public static final String NUXEO_GROUP_MAIL_ADMINS = "nuxeo.csv.mail.group";
 
     public static final String LABEL_CSV_IMPORTER_NOT_EXISTING_FIELD = "label.csv.importer.notExistingField";
 
@@ -230,17 +233,25 @@ public class CSVImporterWork extends TransientStoreWork {
                                                .withIgnoreSurroundingSpaces();
         try (Reader in = newReader(getBlob()); CSVParser parser = csvFormat.parse(in)) {
             doImport(parser);
+            store.putParameter(id, "logs", importLogs);
+            for (CSVImportLog log : importLogs){
+                if (log.getStatus() == ERROR){
+                    sendMailToAdminGroup();
+                    break;
+                }
+            }
         } catch (IOException e) {
             logError(0, "Error while doing the import: %s", LABEL_CSV_IMPORTER_ERROR_DURING_IMPORT, e.getMessage());
+            sendMailToAdminGroup();
             log.debug(e, e);
         } catch (IllegalArgumentException e) {
             logError(0, "Invalid CSV file: %s", LABEL_CSV_IMPORTER_ERROR_DURING_IMPORT, e.getMessage());
+            sendMailToAdminGroup();
             log.debug(e, e);
         }
-        store.putParameter(id, "logs", importLogs);
         if (options.sendEmail()) {
             setStatus("Sending email");
-            sendMail();
+            sendMail(username);
         }
         setStatus(null);
     }
@@ -674,12 +685,24 @@ public class CSVImporterWork extends TransientStoreWork {
                 new CSVImportStatus(CSVImportStatus.State.ERROR, docsCreatedCount, docsCreatedCount));
     }
 
-    protected void sendMail() {
+    protected void sendMailToAdminGroup(){
+        String adminGroup = Framework.getProperty(NUXEO_GROUP_MAIL_ADMINS);
+        if (adminGroup != null) {
+            //sending mail to each admin member
+            UserManager userManager = Framework.getService(UserManager.class);
+            NuxeoGroup grp = userManager.getGroup(adminGroup);
+            for (String member : grp.getMemberUsers()) {
+                sendMail(member);
+            }
+        }
+    }
+
+    protected void sendMail(String userName) {
         UserManager userManager = Framework.getService(UserManager.class);
-        NuxeoPrincipal principal = userManager.getPrincipal(username);
+        NuxeoPrincipal principal = userManager.getPrincipal(userName);
         String email = principal.getEmail();
         if (email == null) {
-            log.info("Not sending import result email to '{}', no email configured", username);
+            log.info("Not sending import result email to '{}', no email configured", userName);
             return;
         }
 
@@ -695,13 +718,12 @@ public class CSVImporterWork extends TransientStoreWork {
             ctx.put("skippedAndErrorImportLogs", skippedAndErrorImportLogs);
             ctx.put("csvFilename", getBlob().getFilename());
             ctx.put("startDate", DateFormat.getInstance().format(startDate));
-            ctx.put("username", username);
-
+            ctx.put("username", userName);
             DocumentModel importFolder = session.getDocument(new PathRef(parentPath));
             String importFolderUrl = getDocumentUrl(importFolder);
             ctx.put("importFolderTitle", importFolder.getTitle());
             ctx.put("importFolderUrl", importFolderUrl);
-            ctx.put("userUrl", getUserUrl());
+            ctx.put("userUrl", getUserUrl(userName));
 
             StringList to = buildRecipientsList(email);
             Expression from = Scripting.newExpression("Env[\"mail.from\"]");
@@ -718,7 +740,7 @@ public class CSVImporterWork extends TransientStoreWork {
             Framework.getService(AutomationService.class).run(ctx, chain);
         } catch (Exception e) {
             ExceptionUtils.checkInterrupt(e);
-            log.error("Unable to notify user '{}' for import result of '{}': {}", () -> username,
+            log.error("Unable to notify user '{}' for import result of '{}': {}", () -> userName,
                     () -> getBlob().getFilename(), e::getMessage);
             log.debug(e, e);
             throw ExceptionUtils.runtimeException(e);
@@ -736,7 +758,7 @@ public class CSVImporterWork extends TransientStoreWork {
         return MailTemplateHelper.getDocumentUrl(doc, null);
     }
 
-    protected String getUserUrl() {
+    protected String getUserUrl(String userName) {
         DocumentViewCodecManager codecService = Framework.getService(DocumentViewCodecManager.class);
         DocumentViewCodec codec = codecService.getCodec(NotificationEventListener.NOTIFICATION_DOCUMENT_ID_CODEC_NAME);
         boolean isNotificationCodec = codec != null;
@@ -750,7 +772,7 @@ public class CSVImporterWork extends TransientStoreWork {
                 userUrl.append("ui/");
                 userUrl.append("#!/");
             }
-            userUrl.append("user/").append(username);
+            userUrl.append("user/").append(userName);
         }
         return userUrl.toString();
     }

--- a/modules/platform/nuxeo-csv-core/src/main/resources/templates/csvImportResult.ftl
+++ b/modules/platform/nuxeo-csv-core/src/main/resources/templates/csvImportResult.ftl
@@ -75,7 +75,7 @@
                   <tr>
                     <td style="background-color:#f7f7f7;border-top:1px dashed #e9ecef;text-align:center;padding:8px 20px;">
                       <div style="font-size:12px;color:#bbb;">
-                      You received this notification because you ran a CSV import.</div>
+                      You received this notification because ${username} ran a CSV import.</div>
                     </td>
                   </tr>
                 </tbody>


### PR DESCRIPTION
Add an optional support group where each member will receive a mail when a CSV import is in error.
Implementing a new variable in the "nuxeo.conf" file to obtain the group name.
I've also made some changes on the mail template message to be more accurate.