### PR TITLE
SUPNXP-51288: Add a feature to ignore certain column during a CSV import

### DIFF
--- a/modules/platform/nuxeo-csv-core/src/main/java/org/nuxeo/ecm/csv/core/CSVImporterWork.java
+++ b/modules/platform/nuxeo-csv-core/src/main/java/org/nuxeo/ecm/csv/core/CSVImporterWork.java
@@ -158,6 +158,8 @@ public class CSVImporterWork extends TransientStoreWork {
 
     public static final String CONTENT_FILED_TYPE_NAME = "content";
 
+    public static final String UNWANTED_HEADERS = "nuxeo.import.unwanted.header";
+
     /**
      * CSV headers that won't be checked if the field exists on the document type.
      *
@@ -303,7 +305,12 @@ public class CSVImporterWork extends TransientStoreWork {
             return;
         }
         hasTypeColumn = header.containsKey(CSV_TYPE_COL);
-
+        String[] unwantedHeaders =  (Framework.getProperty(UNWANTED_HEADERS)!= null ? Framework.getProperty(UNWANTED_HEADERS).split(";") : null);
+        if (unwantedHeaders != null) {
+            for (String headerToRemove : unwantedHeaders) {
+                header.remove(headerToRemove);
+            }
+        }
         try {
             int batchSize = options.getBatchSize();
             Iterable<CSVRecord> it = parser;


### PR DESCRIPTION
Add a feature to ignore certain column during a CSV import by using a variable in the "nuxeo.conf" file. Each column id is separated with a semicolon.
Example : nuxeo.import.unwanted.header=creator;dc:updated;dc:lastContributor