### PR TITLE
SUPNXP-51287: Add a group mail support for errors when importing CSV

### DIFF
--- a/modules/platform/nuxeo-csv-core/src/main/resources/templates/csvImportResult.ftl
+++ b/modules/platform/nuxeo-csv-core/src/main/resources/templates/csvImportResult.ftl
@@ -75,7 +75,7 @@
                   <tr>
                     <td style="background-color:#f7f7f7;border-top:1px dashed #e9ecef;text-align:center;padding:8px 20px;">
                       <div style="font-size:12px;color:#bbb;">
-                      You received this notification because you ran a CSV import.</div>
+                      You received this notification because ${username} ran a CSV import.</div>
                     </td>
                   </tr>
                 </tbody>


### PR DESCRIPTION
Add an optional support group where each member will receive a mail when a CSV import is in error.
Implementing a new variable in the "nuxeo.conf" file to obtain the group name.
Renaming the variable nuxeo.csv.mail.to to be more accurate.
I've also made some changes on the mail template message to be more accurate.