### PR TITLE
Support database-level pagination for user/group search

### DIFF
--- a/modules/platform/nuxeo-platform-usermanager/src/main/java/org/nuxeo/ecm/platform/usermanager/UserManagerImpl.java
+++ b/modules/platform/nuxeo-platform-usermanager/src/main/java/org/nuxeo/ecm/platform/usermanager/UserManagerImpl.java
@@ -950,8 +950,8 @@ public class UserManagerImpl implements UserManager, MultiTenantUserManager, Adm
         }
     }
 
-    protected QueryBuilder getQueryForPattern(String pattern, String dirName, Map<String, MatchType> searchFields,
-            OrderByExpr orderBy) {
+    public QueryBuilder getQueryForPattern(String pattern, String dirName, Map<String, MatchType> searchFields,
+            OrderByExpr orderBy, Long limit, Long offset) {
         QueryBuilder queryBuilder = new QueryBuilder();
         if (!StringUtils.isBlank(pattern)) {
             // build query
@@ -996,6 +996,12 @@ public class UserManagerImpl implements UserManager, MultiTenantUserManager, Adm
             queryBuilder.filter(new MultiExpression(Operator.OR, predicates));
         }
         queryBuilder.order(orderBy);
+        if (limit != null) {
+            queryBuilder.limit(limit);
+        }
+        if (offset != null) {
+            queryBuilder.offset(offset);
+        }
         return queryBuilder;
     }
 
@@ -1102,7 +1108,7 @@ public class UserManagerImpl implements UserManager, MultiTenantUserManager, Adm
 
     @Override
     public DocumentModelList searchUsers(String pattern, DocumentModel context) {
-        QueryBuilder queryBuilder = getQueryForPattern(pattern, userDirectoryName, userSearchFields, getUserOrderBy());
+        QueryBuilder queryBuilder = getQueryForPattern(pattern, userDirectoryName, userSearchFields, getUserOrderBy(), null, null);
         return searchUsers(queryBuilder, context);
     }
 
@@ -1303,7 +1309,7 @@ public class UserManagerImpl implements UserManager, MultiTenantUserManager, Adm
     @Override
     public DocumentModelList searchGroups(String pattern, DocumentModel context) {
         QueryBuilder queryBuilder = getQueryForPattern(pattern, groupDirectoryName, groupSearchFields,
-                getGroupOrderBy());
+                getGroupOrderBy(), null, null);
         return searchGroups(queryBuilder, context);
     }
 

--- a/modules/platform/nuxeo-platform-usermanager/src/main/java/org/nuxeo/ecm/platform/usermanager/providers/AbstractGroupsPageProvider.java
+++ b/modules/platform/nuxeo-platform-usermanager/src/main/java/org/nuxeo/ecm/platform/usermanager/providers/AbstractGroupsPageProvider.java
@@ -29,10 +29,19 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.nuxeo.ecm.core.api.DocumentModel;
+import org.nuxeo.ecm.core.api.DocumentModelList;
 import org.nuxeo.ecm.directory.SizeLimitExceededException;
+import org.nuxeo.ecm.core.query.sql.model.MultiExpression;
+import org.nuxeo.ecm.core.query.sql.model.Operator;
+import org.nuxeo.ecm.core.query.sql.model.OrderByExpr;
+import org.nuxeo.ecm.core.query.sql.model.OrderByExprs;
+import org.nuxeo.ecm.core.query.sql.model.Predicate;
+import org.nuxeo.ecm.core.query.sql.model.Predicates;
+import org.nuxeo.ecm.core.query.sql.model.QueryBuilder;
 import org.nuxeo.ecm.platform.query.api.AbstractPageProvider;
 import org.nuxeo.ecm.platform.usermanager.UserManager;
 import org.nuxeo.runtime.api.Framework;
+import java.util.stream.Collectors;
 
 /**
  * Abstract Page provider listing groups.
@@ -67,36 +76,43 @@ public abstract class AbstractGroupsPageProvider<T> extends AbstractPageProvider
             errorMessage = null;
             pageGroups = new ArrayList<>();
 
-            List<DocumentModel> groups = new ArrayList<>();
             try {
+                UserManager userManager = Framework.getService(UserManager.class);
                 String groupListingMode = getGroupListingMode();
-                if (ALL_MODE.equals(groupListingMode)) {
-                    groups = searchAllGroups();
-                } else if (SEARCH_ONLY_MODE.equals(groupListingMode)) {
-                    groups = searchGroups();
+                String searchString = getFirstParameter();
+                if (ALL_MODE.equals(groupListingMode) || "*".equals(searchString)) {
+                    searchString = null;
+                } else if (StringUtils.isEmpty(searchString)) {
+                    setResultsCount(0);
+                    return pageGroups;
                 }
+                long pageSize = getMinMaxPageSize();
+                long offset = getCurrentPageOffset();
+                OrderByExpr order = OrderByExprs.asc(
+                        StringUtils.defaultString(userManager.getGroupSortField(), userManager.getGroupIdField()));
+                QueryBuilder qb = new QueryBuilder();
+                if (StringUtils.isNotBlank(searchString)) {
+                    String pattern = searchString.trim().toLowerCase() + '%';
+                    List<Predicate> predicates = userManager.getGroupSearchFields()
+                                                             .stream()
+                                                             .map(f -> Predicates.ilike(f, pattern))
+                                                             .collect(Collectors.toList());
+                    qb.filter(new MultiExpression(Operator.OR, predicates));
+                }
+                qb.order(order).countTotal(true);
+                if (pageSize > 0) {
+                    qb.limit(pageSize);
+                }
+                if (offset > 0) {
+                    qb.offset(offset);
+                }
+                DocumentModelList groups = userManager.searchGroups(qb);
+                setResultsCount(groups.totalSize());
+                pageGroups.addAll(groups);
             } catch (SizeLimitExceededException slee) {
                 error = slee;
                 errorMessage = SEARCH_OVERFLOW_ERROR_MESSAGE;
                 log.warn(slee.getMessage(), slee);
-            }
-
-            if (!hasError()) {
-                long resultsCount = groups.size();
-                setResultsCount(resultsCount);
-                // post-filter the results "by hand" to handle pagination
-                long pageSize = getMinMaxPageSize();
-                if (pageSize == 0) {
-                    pageGroups.addAll(groups);
-                } else {
-                    // handle offset
-                    long offset = getCurrentPageOffset();
-                    if (offset <= resultsCount) {
-                        for (int i = (int) offset; i < resultsCount && i < offset + pageSize; i++) {
-                            pageGroups.add(groups.get(i));
-                        }
-                    }
-                }
             }
         }
         return pageGroups;

--- a/modules/platform/nuxeo-platform-usermanager/src/main/java/org/nuxeo/ecm/platform/usermanager/providers/AbstractUsersPageProvider.java
+++ b/modules/platform/nuxeo-platform-usermanager/src/main/java/org/nuxeo/ecm/platform/usermanager/providers/AbstractUsersPageProvider.java
@@ -34,9 +34,17 @@ import org.nuxeo.ecm.core.api.DocumentModel;
 import org.nuxeo.ecm.core.api.DocumentModelList;
 import org.nuxeo.ecm.core.api.impl.DocumentModelListImpl;
 import org.nuxeo.ecm.directory.SizeLimitExceededException;
+import org.nuxeo.ecm.core.query.sql.model.MultiExpression;
+import org.nuxeo.ecm.core.query.sql.model.Operator;
+import org.nuxeo.ecm.core.query.sql.model.OrderByExpr;
+import org.nuxeo.ecm.core.query.sql.model.OrderByExprs;
+import org.nuxeo.ecm.core.query.sql.model.Predicate;
+import org.nuxeo.ecm.core.query.sql.model.Predicates;
+import org.nuxeo.ecm.core.query.sql.model.QueryBuilder;
 import org.nuxeo.ecm.platform.query.api.AbstractPageProvider;
 import org.nuxeo.ecm.platform.usermanager.UserManager;
 import org.nuxeo.runtime.api.Framework;
+import java.util.stream.Collectors;
 
 /**
  * @since 5.8
@@ -70,39 +78,48 @@ public abstract class AbstractUsersPageProvider<T> extends AbstractPageProvider<
             errorMessage = null;
             pageUsers = new ArrayList<>();
 
-            List<DocumentModel> users = new ArrayList<>();
             try {
                 UserManager userManager = Framework.getService(UserManager.class);
                 String userListingMode = getUserListingMode();
-                if (ALL_MODE.equals(userListingMode)) {
-                    users = searchAllUsers(userManager);
-                } else if (SEARCH_ONLY_MODE.equals(userListingMode)) {
-                    users = searchUsers(userManager);
-                } else if (TABBED_MODE.equals(userListingMode)) {
-                    users = searchUsersFromCatalog(userManager);
+                String searchString = getFirstParameter();
+                if (TABBED_MODE.equals(userListingMode)) {
+                    pageUsers.addAll(searchUsersFromCatalog(userManager));
+                    setResultsCount(pageUsers.size());
+                } else {
+                    if (ALL_MODE.equals(userListingMode) || "*".equals(searchString)) {
+                        searchString = null;
+                    } else if (StringUtils.isEmpty(searchString)) {
+                        setResultsCount(0);
+                        return pageUsers;
+                    }
+                    long pageSize = getMinMaxPageSize();
+                    long offset = getCurrentPageOffset();
+                    OrderByExpr order = OrderByExprs.asc(
+                            StringUtils.defaultString(userManager.getUserSortField(), userManager.getUserIdField()));
+                    QueryBuilder qb = new QueryBuilder();
+                    if (StringUtils.isNotBlank(searchString)) {
+                        String pattern = searchString.trim().toLowerCase() + '%';
+                        List<Predicate> predicates = userManager.getUserSearchFields()
+                                                             .stream()
+                                                             .map(f -> Predicates.ilike(f, pattern))
+                                                             .collect(Collectors.toList());
+                        qb.filter(new MultiExpression(Operator.OR, predicates));
+                    }
+                    qb.order(order).countTotal(true);
+                    if (pageSize > 0) {
+                        qb.limit(pageSize);
+                    }
+                    if (offset > 0) {
+                        qb.offset(offset);
+                    }
+                    DocumentModelList users = userManager.searchUsers(qb);
+                    setResultsCount(users.totalSize());
+                    pageUsers.addAll(users);
                 }
             } catch (SizeLimitExceededException slee) {
                 error = slee;
                 errorMessage = SEARCH_OVERFLOW_ERROR_MESSAGE;
                 log.warn(slee.getMessage(), slee);
-            }
-
-            if (!hasError()) {
-                long resultsCount = users.size();
-                setResultsCount(resultsCount);
-                // post-filter the results "by hand" to handle pagination
-                long pageSize = getMinMaxPageSize();
-                if (pageSize == 0) {
-                    pageUsers.addAll(users);
-                } else {
-                    // handle offset
-                    long offset = getCurrentPageOffset();
-                    if (offset <= resultsCount) {
-                        for (int i = (int) offset; i < resultsCount && i < offset + pageSize; i++) {
-                            pageUsers.add(users.get(i));
-                        }
-                    }
-                }
             }
         }
         return pageUsers;

--- a/modules/platform/nuxeo-platform-usermanager/src/test/java/org/nuxeo/ecm/platform/usermanager/TestUserManager.java
+++ b/modules/platform/nuxeo-platform-usermanager/src/test/java/org/nuxeo/ecm/platform/usermanager/TestUserManager.java
@@ -1471,7 +1471,7 @@ public class TestUserManager extends UserManagerTestCase {
     protected String getQueryForPattern(String pattern) {
         UserManagerImpl um = (UserManagerImpl) userManager;
         QueryBuilder queryBuilder = um.getQueryForPattern(pattern, um.getUserDirectoryName(), um.userSearchFields,
-                um.getUserOrderBy());
+                um.getUserOrderBy(), null, null);
         return queryBuilder.predicate().toString();
     }
 


### PR DESCRIPTION
**Issue:**

getQueryForPattern() in the UserManagerImpl class omits limit and offset, leading `/nuxeo/api/v1/user/search` and `/nuxeo/api/v1/group/search` to load all matching entries before paging them in memory. This can become inefficient with large datasets.

**Solution:**

- Added new limit and offset parameters to UserManagerImpl.getQueryForPattern so that paging can be pushed down to the directory query

- Reworked both AbstractUsersPageProvider and AbstractGroupsPageProvider to build a QueryBuilder with the requested page size and offset rather than fetching all entries then slicing in memory

- Updated tests to accommodate the new method signature when verifying the generated query for a pattern